### PR TITLE
Fix Postgres pool exhaustion causing 504s under gthread concurrency

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -275,8 +275,13 @@ USING_SQLITE_DATABASE = not bool(DB_HOST)
 
 if DB_HOST:
     DB_POOL_ENABLED = config("DB_POOL_ENABLED", default=True, cast=bool)
-    DB_POOL_MIN = config("DB_POOL_MIN", default=1, cast=int)
-    DB_POOL_MAX = config("DB_POOL_MAX", default=2, cast=int)
+    DB_POOL_MIN = config("DB_POOL_MIN", default=2, cast=int)
+    # Default should be >= GUNICORN_THREADS (src/config/gunicorn.py) so a
+    # worker's pool never runs out of slots for its own concurrent request
+    # threads; +1 for headroom (e.g. the /health/ probe hitting the pool at
+    # the same time). A too-small pool causes psycopg_pool.PoolTimeout once
+    # concurrent requests in a worker exceed the pool size (issue #341).
+    DB_POOL_MAX = config("DB_POOL_MAX", default=5, cast=int)
     DB_POOL_TIMEOUT = config("DB_POOL_TIMEOUT", default=30, cast=int)
     db_options = {}
     if DB_POOL_ENABLED:


### PR DESCRIPTION
## Summary
- Raised `DB_POOL_MAX` default from 2 to 5 and `DB_POOL_MIN` default from 1 to 2 in `src/config/settings.py`.
- Gunicorn runs `gthread` workers with 4 threads each (`src/config/gunicorn.py`), but the Postgres connection pool per worker process defaulted to only 2 connections. Once 3+ concurrent requests in a worker needed a DB connection, extra threads queued for a pool slot and hit `psycopg_pool.PoolTimeout` after 30s, surfacing to users as nginx 504 Gateway Timeout.
- A prior fix (`279464b`, `CONN_HEALTH_CHECKS: True`) addressed stale pooled connections but not pool capacity, which is why the issue persisted after that change.

## Validation
- `python src/manage.py check` — passes, no issues.
- Verified via a settings import with `DB_HOST` set that the resulting pool options resolve to `{min_size: 2, max_size: 5, timeout: 30}`.

## Notes
- Refs #341


---
_Generated by [Claude Code](https://claude.ai/code/session_01NQsvzGRCSBpSXphYPm2b6P)_