### PR TITLE
fix: show episode title and season/episode dropdowns at narrow widths

### DIFF
--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -5096,6 +5096,11 @@
       width: 173px;
     }
   }
+  .md\:w-auto {
+    @media (width >= 48rem) {
+      width: auto;
+    }
+  }
   .md\:max-w-\[250px\] {
     @media (width >= 48rem) {
       max-width: 250px;

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -61,7 +61,8 @@
             <div class="md:hidden text-sm font-medium text-gray-400 text-center">
               <a href="{{ season_url }}" class="hover:text-indigo-400 transition-colors">{{ season_title }}</a>
               <span class="mx-1 text-gray-600">•</span>
-              {% if episode and episode.display_episode_number|default:episode.episode_number %}Ep {{ episode.display_episode_number|default:episode.episode_number }}{% endif %}
+              {{ episode_title }}
+              {% if episode and episode.display_episode_number|default:episode.episode_number %}<span class="mx-1 text-gray-600">•</span>Ep {{ episode.display_episode_number|default:episode.episode_number }}{% endif %}
               {% if episode and episode.air_date %}<span class="mx-1 text-gray-600">•</span>{{ episode.air_date|user_date_format:user }}{% endif %}
               {% if not public_view and episode and episode.history %}{% with ep_watched=episode.history|watched_count %}{% if ep_watched %}<span class="mx-1 text-gray-600">•</span>Watched {% if ep_watched == 1 %}once{% else %}{{ ep_watched }} times{% endif %}{% endif %}{% endwith %}{% endif %}
             </div>

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -70,12 +70,12 @@
 
           {# Episode dropdown #}
           {% if episodes %}
-            <div class="relative hidden md:block"
+            <div class="relative w-full md:w-auto"
                  x-data="{ open: false }"
                  @click.away="open = false"
                  @keydown.escape.window="open = false">
               <button @click="open = !open"
-                      class="flex items-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer">
+                      class="flex w-full items-center justify-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer md:w-auto md:justify-start">
                 <span class="text-sm font-medium">{{ episode.display_episode_number|default:episode_number }}. {{ episode_title }}</span>
                 <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" %}</div>
               </button>

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -108,12 +108,12 @@
               </div>
 
               {# Season dropdown #}
-              <div class="relative hidden md:block"
+              <div class="relative w-full md:w-auto"
                    x-data="{ open: false }"
                    @click.away="open = false"
                    @keydown.escape.window="open = false">
                 <button @click="open = !open"
-                        class="flex items-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer">
+                        class="flex w-full items-center justify-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer md:w-auto md:justify-start">
                   <span class="text-sm font-medium">{{ media.season_header_title|default:media.title }}</span>
                   <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" %}</div>
                 </button>


### PR DESCRIPTION
## Summary
- The episode details page's mobile subtitle omitted the episode title entirely (only season, episode number, air date, and watch count showed), so it was invisible below the `md` breakpoint.
- The season page and episode page each have a switcher dropdown for jumping between seasons/episodes, but both were wrapped in `hidden md:block`, hiding them completely on narrow viewports with no mobile fallback.

## Changes
- `episode_details.html`: add the episode title to the mobile subtitle row.
- `episode_details.html` / `media_details.html`: make the season/episode dropdown trigger `w-full` and centered on mobile, `md:w-auto` and left-aligned on desktop (the dropdown panel itself was already styled for centered mobile display).
- `main.css`: add the corresponding compiled `md:w-auto` Tailwind utility rule.

## Test plan
- [x] Verified via headless Chromium screenshots (logged in as the demo account) on both the season page and an episode page at 1400px and 375px widths — dropdowns are reachable on mobile and unchanged in size on desktop, and the episode title shows in the mobile subtitle.