### PR TITLE
Handle decrypt failures gracefully across import integrations (#356, #357)

### DIFF
--- a/src/app/providers/services.py
+++ b/src/app/providers/services.py
@@ -266,7 +266,7 @@ class ProviderAPIError(Exception):
                 provider_label,
                 exception_summary(error),
             )
-            message = f"Could not reach {provider_label}"
+            message = f"Could not reach {provider_label} ({exception_summary(error)})"
         else:
             if response_keys:
                 log_method(

--- a/src/integrations/imports/anilist.py
+++ b/src/integrations/imports/anilist.py
@@ -111,7 +111,7 @@ class AniListImporter:
         self.warnings = []
 
         if self.token is not None:
-            self.token = helpers.decrypt(self.token)
+            self.token = helpers.decrypt_or_raise(self.token)
 
         # Track existing media for "new" mode
         self.existing_media = helpers.get_existing_media(user)

--- a/src/integrations/imports/audiobookshelf.py
+++ b/src/integrations/imports/audiobookshelf.py
@@ -18,7 +18,7 @@ from app import helpers as app_helpers
 from app.log_safety import exception_summary
 from app.models import MediaTypes, Sources, Status
 from app.providers import services
-from integrations.imports.helpers import MediaImportError, decrypt
+from integrations.imports.helpers import MediaImportError, decrypt_or_raise
 from integrations.models import AudiobookshelfAccount
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,16 @@ class AudiobookshelfImporter:
             msg = "Connect Audiobookshelf before importing"
             raise MediaImportError(msg) from error
 
-        token = decrypt(self.account.api_token)
+        try:
+            token = decrypt_or_raise(self.account.api_token)
+        except MediaImportError as error:
+            self.account.connection_broken = True
+            self.account.last_error_message = str(error)
+            self.account.save(
+                update_fields=["connection_broken", "last_error_message", "updated_at"],
+            )
+            raise
+
         self.client = AudiobookshelfClient(self.account.base_url, token)
         self.warnings = []
         self.enable_provider_enrichment = not settings.TESTING

--- a/src/integrations/imports/gpodder.py
+++ b/src/integrations/imports/gpodder.py
@@ -24,7 +24,7 @@ from app.models import (
 )
 from integrations import gpodder_api, podcast_rss
 from integrations import models as integration_models
-from integrations.imports.helpers import MediaImportError, decrypt
+from integrations.imports.helpers import MediaImportError, decrypt_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +47,19 @@ class GPodderImporter:
         except integration_models.GPodderAccount.DoesNotExist as exc:
             raise MediaImportError("GPodder account not connected.") from exc
 
-        self.credentials = gpodder_api.GPodderCredentials(
-            server_url=decrypt(self.account.server_url),
-            username=decrypt(self.account.username),
-            password=decrypt(self.account.password),
-        )
+        try:
+            self.credentials = gpodder_api.GPodderCredentials(
+                server_url=decrypt_or_raise(self.account.server_url),
+                username=decrypt_or_raise(self.account.username),
+                password=decrypt_or_raise(self.account.password),
+            )
+        except MediaImportError as error:
+            self.account.connection_broken = True
+            self.account.last_error_message = str(error)
+            self.account.save(
+                update_fields=["connection_broken", "last_error_message", "updated_at"],
+            )
+            raise
         self._seen_fingerprints = set()
         self._episode_cache = {}
         self._show_cache = {}

--- a/src/integrations/imports/helpers.py
+++ b/src/integrations/imports/helpers.py
@@ -5,7 +5,7 @@ import json
 import logging
 from collections import defaultdict
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
@@ -329,3 +329,17 @@ def encrypt(value):
 def decrypt(token):
     """Decrypt value that was encrypted with `encrypt`."""
     return fernet().decrypt(token.encode()).decode()
+
+
+def decrypt_or_raise(token):
+    """Decrypt a stored credential, raising a friendly MediaImportError on failure."""
+    try:
+        return decrypt(token)
+    except InvalidToken as error:
+        logger.exception("Failed to decrypt stored credential")
+        msg = (
+            "Stored credentials could not be decrypted. This usually happens "
+            "after the app's encryption key changes. Please reconnect this "
+            "integration."
+        )
+        raise MediaImportError(msg) from error

--- a/src/integrations/imports/radarr.py
+++ b/src/integrations/imports/radarr.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from app.models import Item, MediaTypes, Sources
 from app.providers import services
-from integrations.imports.helpers import MediaImportError, decrypt
+from integrations.imports.helpers import MediaImportError, decrypt_or_raise
 from integrations.models import RadarrAccount
 from integrations.source_sync import upsert_collection_source_state
 
@@ -66,10 +66,17 @@ class RadarrImporter:
             msg = "Connect Radarr before importing"
             raise MediaImportError(msg) from error
 
-        self.client = RadarrClient(
-            self.account.base_url,
-            decrypt(self.account.api_key),
-        )
+        try:
+            api_key = decrypt_or_raise(self.account.api_key)
+        except MediaImportError as error:
+            self.account.connection_broken = True
+            self.account.last_error_message = str(error)
+            self.account.save(
+                update_fields=["connection_broken", "last_error_message", "updated_at"],
+            )
+            raise
+
+        self.client = RadarrClient(self.account.base_url, api_key)
         self.warnings = []
 
     def import_data(self):

--- a/src/integrations/imports/simkl.py
+++ b/src/integrations/imports/simkl.py
@@ -98,7 +98,7 @@ class SimklImporter:
             user: Django user object to import data for
             mode (str): Import mode ("new" or "overwrite")
         """
-        self.token = helpers.decrypt(token)
+        self.token = helpers.decrypt_or_raise(token)
         self.user = user
         self.mode = mode
         self.warnings = []

--- a/src/integrations/imports/sonarr.py
+++ b/src/integrations/imports/sonarr.py
@@ -9,7 +9,11 @@ from django.utils import timezone
 
 from app.models import CollectionEntry, Item, MediaTypes, Sources
 from app.providers import services
-from integrations.imports.helpers import MediaImportError, decrypt, retry_on_lock
+from integrations.imports.helpers import (
+    MediaImportError,
+    decrypt_or_raise,
+    retry_on_lock,
+)
 from integrations.models import SonarrAccount
 from integrations.source_sync import (
     remove_collection_source_state,
@@ -78,10 +82,17 @@ class SonarrImporter:
             msg = "Connect Sonarr before importing"
             raise MediaImportError(msg) from error
 
-        self.client = SonarrClient(
-            self.account.base_url,
-            decrypt(self.account.api_key),
-        )
+        try:
+            api_key = decrypt_or_raise(self.account.api_key)
+        except MediaImportError as error:
+            self.account.connection_broken = True
+            self.account.last_error_message = str(error)
+            self.account.save(
+                update_fields=["connection_broken", "last_error_message", "updated_at"],
+            )
+            raise
+
+        self.client = SonarrClient(self.account.base_url, api_key)
         self.warnings = []
 
     def import_data(self):

--- a/src/integrations/imports/storyteller.py
+++ b/src/integrations/imports/storyteller.py
@@ -30,7 +30,7 @@ from app import helpers as app_helpers
 from app.log_safety import exception_summary
 from app.models import MediaTypes, Sources, Status
 from app.providers import services
-from integrations.imports.helpers import MediaImportError, decrypt
+from integrations.imports.helpers import MediaImportError, decrypt_or_raise
 from integrations.models import StorytellerAccount
 
 logger = logging.getLogger(__name__)
@@ -149,7 +149,12 @@ class StorytellerImporter:
             msg = "Connect Storyteller before importing"
             raise MediaImportError(msg)
 
-        token = decrypt(self.account.auth_token)
+        try:
+            token = decrypt_or_raise(self.account.auth_token)
+        except MediaImportError as error:
+            self._mark_broken(str(error))
+            raise
+
         self.client = StorytellerClient(self.account.server_url, token)
         self.warnings = []
         self.enable_provider_enrichment = not settings.TESTING

--- a/src/integrations/imports/stremio.py
+++ b/src/integrations/imports/stremio.py
@@ -166,7 +166,16 @@ class StremioImporter:
             msg = "Connect Stremio before importing"
             raise MediaImportError(msg)
 
-        self.auth_key = helpers.decrypt(self.account.auth_key)
+        try:
+            self.auth_key = helpers.decrypt_or_raise(self.account.auth_key)
+        except MediaImportError as decrypt_error:
+            self.account.connection_broken = True
+            self.account.last_error_message = str(decrypt_error)
+            self.account.save(
+                update_fields=["connection_broken", "last_error_message", "updated_at"],
+            )
+            raise
+
         self.existing_media = helpers.get_existing_media(user)
         self.to_delete = defaultdict(lambda: defaultdict(set))
         self.bulk_media = defaultdict(list)

--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -115,7 +115,7 @@ def get_access_token(encrypted_refresh_token):
     """Get access token from encrypted refresh token."""
     url = "https://api.trakt.tv/oauth/token"
 
-    decrypted_token = helpers.decrypt(encrypted_refresh_token)
+    decrypted_token = helpers.decrypt_or_raise(encrypted_refresh_token)
 
     params = {
         "client_id": settings.TRAKT_API,

--- a/src/integrations/jellyfin_sync.py
+++ b/src/integrations/jellyfin_sync.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 
 from app.models import Episode, Movie, Sources, Status
-from integrations.imports.helpers import MediaImportError, decrypt
+from integrations.imports.helpers import MediaImportError, decrypt_or_raise
 from integrations.jellyfin_client import (
     JellyfinAuthError,
     JellyfinClient,
@@ -97,7 +97,7 @@ class JellyfinPushSyncService:
         return dict(self.counts), "\n".join(dict.fromkeys(self.warnings))
 
     def _build_client(self) -> JellyfinClient:
-        api_key = decrypt(self.account.api_key)
+        api_key = decrypt_or_raise(self.account.api_key)
         client = JellyfinClient(self.account.base_url, api_key, self.account.jellyfin_user_id or None)
 
         if not self.account.jellyfin_user_id:

--- a/src/integrations/tasks/_media_imports.py
+++ b/src/integrations/tasks/_media_imports.py
@@ -140,7 +140,7 @@ def import_mdblist(user_id, mode, username=None):  # noqa: ARG001
     if account is None:
         msg = "Connect your MDBList account before importing."
         raise helpers.MediaImportError(msg)
-    api_key = helpers.decrypt(account.api_key)
+    api_key = helpers.decrypt_or_raise(account.api_key)
     return import_media(mdblist.importer, api_key, user_id, mode)
 
 

--- a/src/lists/imports/mdblist.py
+++ b/src/lists/imports/mdblist.py
@@ -217,9 +217,8 @@ def import_mdblist_lists(user):
         logger.info("No MDBList account for user %s, skipping sync", user.username)
         return
 
-    api_key = helpers.decrypt(account.api_key)
-
     try:
+        api_key = helpers.decrypt_or_raise(account.api_key)
         own_lists = _request(api_key, "/lists/user")
         if not isinstance(own_lists, list):
             own_lists = []
@@ -280,7 +279,14 @@ def import_mdblist_list_by_reference(user, reference):
         msg = "Connect your MDBList account before importing lists."
         raise helpers.MediaImportError(msg)
 
-    api_key = helpers.decrypt(account.api_key)
+    try:
+        api_key = helpers.decrypt_or_raise(account.api_key)
+    except helpers.MediaImportError as error:
+        account.connection_broken = True
+        account.last_error_message = str(error)
+        account.save(update_fields=["connection_broken", "last_error_message"])
+        raise
+
     list_info = resolve_list_reference(api_key, reference)
     _sync_list(user, api_key, list_info)
     return list_info


### PR DESCRIPTION
Stored credential decryption (Radarr, Sonarr, Audiobookshelf, GPodder,
Stremio, AniList, Storyteller, Simkl, Trakt, Jellyfin, MDBList) previously
raised a raw cryptography.fernet.InvalidToken straight out of the importer
constructor whenever a credential could no longer be decrypted (e.g. after
the encryption key changes), crashing the Celery task instead of surfacing
an actionable error. Add helpers.decrypt_or_raise() to convert that into a
friendly MediaImportError, and mark the affected account connection_broken
with a clear message wherever an account record exists, matching the
pattern already used for HTTP failures and in pocketcasts.py. Fixes #356 and #357.

Also include the underlying exception reason in ProviderAPIError's
"Could not reach {provider}" message (app/providers/services.py) so
self-hosted users can diagnose connection failures without server log
access (#355).