### PR TITLE
Fix season page crash for anonymous public list viewers

### DIFF
--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -760,6 +760,11 @@ def season_details(
     if parent_media_type is None:
         parent_media_type = MediaTypes.TV.value
 
+    # AnonymousUser (public list viewers) has no watch_provider_region
+    watch_provider_region = (
+        request.user.watch_provider_region if request.user.is_authenticated else None
+    )
+
     context = {
         "user": request.user,
         "media": season_metadata,
@@ -779,9 +784,9 @@ def season_details(
         "item_id_for_polling": item_id_for_polling if not public_view else None,
         "trakt_score": trakt_score,
         "watch_providers": tmdb.filter_providers(
-            season_metadata.get("providers"), request.user.watch_provider_region
+            season_metadata.get("providers"), watch_provider_region
         ),
-        "watch_provider_region": request.user.watch_provider_region,
+        "watch_provider_region": watch_provider_region,
         "detail_link_sections": _build_detail_link_sections(
             season_metadata,
             MediaTypes.SEASON.value,

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -4789,6 +4789,53 @@ class MediaDetailsViewTests(TestCase):
 
     @patch("app.providers.services.get_media_metadata")
     @patch("app.providers.tmdb.process_episodes")
+    def test_season_details_public_view_anonymous_user(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+    ):
+        """Anonymous public viewers should not 500 on the season page.
+
+        Regression for #372: AnonymousUser has no watch_provider_region.
+        """
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Test TV Show",
+            "media_id": "1668",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Season 1",
+                "season_title": "Season 1",
+                "media_id": "1668",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TMDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [],
+            },
+        }
+        mock_process_episodes.return_value = []
+
+        self.client.logout()
+
+        response = self.client.get(
+            reverse(
+                "season_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "test-tv-show",
+                    "season_number": 1,
+                },
+            ),
+            {"public_view": "1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["watch_provider_region"])
+
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
     def test_season_details_secondary_fragment_renders_episodes(
         self,
         mock_process_episodes,


### PR DESCRIPTION
**Problem** — Opening a TV season on a public list without logging in throws a 500. `season_details` reads `request.user.watch_provider_region`, which `AnonymousUser` doesn't have. Fixes #372.

**Solution** — Guard it with `is_authenticated`, same as `media_details_views.py` already does for the same field.

**Validation** — Added a regression test (anonymous `?public_view=1` on a season). It fails without the fix (the exact AttributeError) and passes with it. Ran it with `manage.py test` and it's green. `ruff check` clean on the changed lines.

Backend-only, so no screenshots.

*(Wrote this with AI help, tested as above.)*