### PR TITLE
Add StoryGraph CSV import

### DIFF
--- a/docs/superpowers/plans/2026-07-26-storygraph-import.md
+++ b/docs/superpowers/plans/2026-07-26-storygraph-import.md
@@ -1,0 +1,1887 @@
+# StoryGraph CSV Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Import a StoryGraph account export CSV into Yamtrack as book tracking entries, one entry per read, resolved against Hardcover with an Open Library fallback.
+
+**Architecture:** A single importer module, `src/integrations/imports/storygraph.py`, following the `goodreads.py` / `hardcover.py` shape: module-level pure parsers, a `StoryGraphImporter` class that resolves each row to a book, builds unsaved model instances, and hands them to `helpers.bulk_create_media`. Re-reads become separate `Book` rows because that is how Yamtrack models multiple reads — `history_cache_day_builder.py:176` builds the history calendar from live `Book.start_date`/`end_date`, never from `HistoricalBook`. The rest of the work is the standard import wiring: celery task, view, url, template card, source display, task-name map, API map.
+
+**Tech Stack:** Python 3, Django, django-simple-history (`bulk_create_with_history`), Celery, `pytest` via `pytest-django` (settings module `config.test_settings`).
+
+Design spec: `docs/superpowers/specs/2026-07-26-storygraph-import-design.md`.
+
+## Global Constraints
+
+- Run tests from the repo root: `pytest src/integrations/tests/imports/test_storygraph.py -v`. `pytest.ini` sets `DJANGO_SETTINGS_MODULE = config.test_settings`.
+- Never call a real provider API in a test. Patch `integrations.imports.storygraph.services.search` and `integrations.imports.storygraph.services.get_media_metadata`, as `src/integrations/tests/imports/test_hardcover.py` does.
+- Follow the repo's docstring style: every module, class, and public function has a one-line docstring. Ruff enforces it.
+- Media source values come from `app.models.Sources`; statuses from `app.models.Status`; media types from `app.models.MediaTypes`. Never hardcode their string values.
+- `Item` rows are shared by all users. Never overwrite a non-empty `Item.format`.
+- Commit after each task with the message given in the task's final step.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/integrations/imports/storygraph.py` (create) | Parsers, provider matching, importer class, `importer(file, user, mode)` entry point |
+| `src/integrations/tests/mock_data/import_storygraph.csv` (create) | Fixture export covering every row shape |
+| `src/integrations/tests/imports/test_storygraph.py` (create) | Importer tests |
+| `src/integrations/tasks/_media_imports.py` (modify) | Celery task `Import from StoryGraph` |
+| `src/integrations/tasks/__init__.py` (modify) | Re-export the task |
+| `src/integrations/views.py` (modify) | `import_storygraph` upload view |
+| `src/integrations/urls.py` (modify) | Route `import/storygraph` |
+| `src/users/templatetags/user_tags.py` (modify) | Source display entry |
+| `src/static/img/storygraph-logo.svg` (create) | Logo for the source display |
+| `src/templates/users/import_data.html` (modify) | Upload card |
+| `src/users/models.py` (modify) | Task-name map for import history |
+| `src/api/fork_views_integrations.py` (modify) | `POST /api/v1/imports/storygraph/` |
+
+---
+
+### Task 1: CSV field parsers
+
+Pure functions, no database, no network. Everything later tasks build on.
+
+**Files:**
+- Create: `src/integrations/imports/storygraph.py`
+- Create: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `Read` — `namedtuple("Read", ("start", "end"))`, both `datetime | None`
+  - `parse_reads(dates_read: str) -> list[Read]` — oldest first
+  - `determine_status(raw_status: str) -> str` — a `Status` value
+  - `parse_rating(raw_rating: str) -> float | None` — 0–10 scale
+  - `parse_tags(raw_tags: str) -> list[str]`
+  - `parse_authors(raw_authors: str) -> list[str]`
+  - `normalize_isbn(raw_isbn: str) -> str` — `""` when not an ISBN-10/13
+  - `map_format(raw_format: str) -> str`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+from datetime import datetime
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from app.models import Status
+from integrations.imports import storygraph
+
+
+class ParseReads(SimpleTestCase):
+    """Tests for parsing StoryGraph's Dates Read column."""
+
+    def test_range_gives_start_and_end(self):
+        """A dash-separated range is a start date and an end date."""
+        reads = storygraph.parse_reads("2022/03/16-2022/04/01")
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(reads[0].start.date(), datetime(2022, 3, 16).date())
+        self.assertEqual(reads[0].end.date(), datetime(2022, 4, 1).date())
+
+    def test_single_date_is_end_only(self):
+        """StoryGraph writes one date when only the finish date is known."""
+        reads = storygraph.parse_reads("2021/07/21")
+        self.assertEqual(len(reads), 1)
+        self.assertIsNone(reads[0].start)
+        self.assertEqual(reads[0].end.date(), datetime(2021, 7, 21).date())
+
+    def test_multiple_reads_sorted_oldest_first(self):
+        """Re-reads are comma separated and come back oldest first."""
+        reads = storygraph.parse_reads("2022/10/29-2022/11/28, 2021/09/14")
+        self.assertEqual(len(reads), 2)
+        self.assertEqual(reads[0].end.date(), datetime(2021, 9, 14).date())
+        self.assertEqual(reads[1].end.date(), datetime(2022, 11, 28).date())
+
+    def test_blank_and_garbage_ignored(self):
+        """Empty or unparseable values produce no reads."""
+        self.assertEqual(storygraph.parse_reads(""), [])
+        self.assertEqual(storygraph.parse_reads(None), [])
+        self.assertEqual(storygraph.parse_reads("not a date"), [])
+
+    def test_dates_are_timezone_aware(self):
+        """Parsed dates are aware so Django never warns on save."""
+        read = storygraph.parse_reads("2021/07/21")[0]
+        self.assertIsNotNone(timezone.is_aware(read.end) or None)
+        self.assertTrue(timezone.is_aware(read.end))
+
+
+class ParseFields(SimpleTestCase):
+    """Tests for the remaining column parsers."""
+
+    def test_status_mapping(self):
+        """Each StoryGraph read status maps to a Yamtrack status."""
+        self.assertEqual(storygraph.determine_status("read"), Status.COMPLETED.value)
+        self.assertEqual(
+            storygraph.determine_status("currently-reading"),
+            Status.IN_PROGRESS.value,
+        )
+        self.assertEqual(storygraph.determine_status("to-read"), Status.PLANNING.value)
+        self.assertEqual(
+            storygraph.determine_status("did-not-finish"),
+            Status.DROPPED.value,
+        )
+
+    def test_blank_status_defaults_to_planning(self):
+        """Rows with no read status are library entries, so plan them."""
+        self.assertEqual(storygraph.determine_status(""), Status.PLANNING.value)
+        self.assertEqual(storygraph.determine_status(None), Status.PLANNING.value)
+        self.assertEqual(storygraph.determine_status("nonsense"), Status.PLANNING.value)
+
+    def test_rating_doubled_to_ten_point_scale(self):
+        """StoryGraph rates 0-5 with halves; Yamtrack scores 0-10."""
+        self.assertEqual(storygraph.parse_rating("4.5"), 9.0)
+        self.assertEqual(storygraph.parse_rating("5.0"), 10.0)
+        self.assertIsNone(storygraph.parse_rating(""))
+        self.assertIsNone(storygraph.parse_rating("0"))
+        self.assertIsNone(storygraph.parse_rating("nonsense"))
+
+    def test_tags_split_and_deduplicated(self):
+        """Tags are comma separated free text."""
+        self.assertEqual(
+            storygraph.parse_tags("management, spanish , management"),
+            ["management", "spanish"],
+        )
+        self.assertEqual(storygraph.parse_tags(""), [])
+
+    def test_authors_split(self):
+        """Multiple authors are comma separated in one column."""
+        self.assertEqual(
+            storygraph.parse_authors("Brandon Sanderson, Robert Jordan"),
+            ["Brandon Sanderson", "Robert Jordan"],
+        )
+        self.assertEqual(storygraph.parse_authors(""), [])
+
+    def test_isbn_normalization(self):
+        """Only ISBN-10 and ISBN-13 values survive; ASINs do not."""
+        self.assertEqual(storygraph.normalize_isbn("978-0-575-07979-3"), "9780575079793")
+        self.assertEqual(storygraph.normalize_isbn("080442957X"), "080442957X")
+        self.assertEqual(storygraph.normalize_isbn("B0851JCZYV"), "")
+        self.assertEqual(storygraph.normalize_isbn(""), "")
+
+    def test_format_mapping(self):
+        """StoryGraph formats map onto the values Yamtrack already uses."""
+        self.assertEqual(storygraph.map_format("digital"), "ebook")
+        self.assertEqual(storygraph.map_format("audio"), "audiobook")
+        self.assertEqual(storygraph.map_format("paperback"), "paperback")
+        self.assertEqual(storygraph.map_format("hardcover"), "hardcover")
+        self.assertEqual(storygraph.map_format(""), "")
+        self.assertEqual(storygraph.map_format("something else"), "")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: collection error — `No module named 'integrations.imports.storygraph'`.
+
+- [ ] **Step 3: Write the parsers**
+
+Create `src/integrations/imports/storygraph.py`:
+
+```python
+"""Importer for The StoryGraph's account export CSV.
+
+StoryGraph has no public API, so the export CSV is the supported path. Each
+read in the ``Dates Read`` column becomes its own ``Book`` row, which is how
+Yamtrack models re-reads: the history calendar is built from live rows rather
+than from simple-history records.
+"""
+
+import logging
+import re
+from collections import namedtuple
+from datetime import datetime
+
+from django.utils import timezone
+
+from app.models import Status
+
+logger = logging.getLogger(__name__)
+
+STATUS_MAP = {
+    "read": Status.COMPLETED.value,
+    "currently-reading": Status.IN_PROGRESS.value,
+    "to-read": Status.PLANNING.value,
+    "did-not-finish": Status.DROPPED.value,
+}
+FORMAT_MAP = {
+    "digital": "ebook",
+    "audio": "audiobook",
+    "paperback": "paperback",
+    "hardcover": "hardcover",
+}
+ISBN_13_LENGTH = 13
+ISBN_10_LENGTH = 10
+MAX_STAR_RATING = 5
+
+Read = namedtuple("Read", ("start", "end"))
+
+
+def parse_date(value):
+    """Parse a StoryGraph ``YYYY/MM/DD`` date into an aware datetime."""
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.strptime(text, "%Y/%m/%d")  # noqa: DTZ007 - tz applied below
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.get_current_timezone())
+
+
+def parse_reads(dates_read):
+    """Parse ``Dates Read`` into ordered reads, oldest first.
+
+    A dash separated chunk is a start and an end date. A bare date is a finish
+    date with no known start, so ``start`` stays ``None``.
+    """
+    reads = []
+    for chunk in str(dates_read or "").split(","):
+        pieces = [piece.strip() for piece in chunk.split("-") if piece.strip()]
+        dates = [date for date in map(parse_date, pieces) if date]
+        if not dates:
+            continue
+        if len(dates) == 1:
+            reads.append(Read(start=None, end=dates[0]))
+        else:
+            reads.append(Read(start=dates[0], end=dates[-1]))
+
+    reads.sort(key=lambda read: read.end or read.start)
+    return reads
+
+
+def determine_status(raw_status):
+    """Map a StoryGraph read status onto a Yamtrack status."""
+    return STATUS_MAP.get(
+        str(raw_status or "").strip().lower(),
+        Status.PLANNING.value,
+    )
+
+
+def parse_rating(raw_rating):
+    """Convert a 0-5 star rating with halves into a 0-10 score."""
+    text = str(raw_rating or "").strip()
+    if not text:
+        return None
+    try:
+        rating = float(text)
+    except ValueError:
+        return None
+    if rating <= 0:
+        return None
+    return round(min(rating, MAX_STAR_RATING) * 2, 1)
+
+
+def parse_tags(raw_tags):
+    """Split the comma separated ``Tags`` column, preserving order."""
+    tags = [tag.strip() for tag in str(raw_tags or "").split(",") if tag.strip()]
+    return list(dict.fromkeys(tags))
+
+
+def parse_authors(raw_authors):
+    """Split the comma separated ``Authors`` column."""
+    return [name.strip() for name in str(raw_authors or "").split(",") if name.strip()]
+
+
+def normalize_isbn(raw_isbn):
+    """Return the value as an ISBN, or ``""`` when it is an ASIN or junk."""
+    candidate = str(raw_isbn or "").strip().replace("-", "").replace(" ", "").upper()
+    if len(candidate) == ISBN_13_LENGTH and candidate.isdigit():
+        return candidate
+    if len(candidate) == ISBN_10_LENGTH and candidate[:9].isdigit():
+        return candidate
+    return ""
+
+
+def map_format(raw_format):
+    """Map a StoryGraph format onto the format values Yamtrack stores."""
+    return FORMAT_MAP.get(str(raw_format or "").strip().lower(), "")
+
+
+def normalize_name(value):
+    """Lowercase a title or name down to alphanumerics for comparison."""
+    normalized = re.sub(r"[^a-z0-9]+", " ", str(value or "").lower())
+    return re.sub(r"\s+", " ", normalized).strip()
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/imports/storygraph.py src/integrations/tests/imports/test_storygraph.py
+git commit -m "Add StoryGraph CSV field parsers"
+```
+
+---
+
+### Task 2: Provider matching
+
+Resolve a CSV row to a book on Hardcover, falling back to Open Library, verifying title and author so an ASIN row does not silently match the wrong book.
+
+**Files:**
+- Modify: `src/integrations/imports/storygraph.py`
+- Modify: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: `normalize_name`, `normalize_isbn`, `parse_authors` from Task 1.
+- Produces:
+  - `titles_match(left: str, right: str) -> bool`
+  - `classify_authors(target: list[str], candidate: list[str]) -> str` — `"match"`, `"unknown"`, or `"conflict"`
+  - `extract_provider_authors(metadata: dict) -> list[str]`
+  - `BookResolver(cache: dict)` with `resolve(title: str, authors: list[str], isbn: str) -> tuple[str, str, dict] | None` returning `(source, media_id, metadata)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+from unittest.mock import patch
+
+from app.models import Sources
+
+
+class MatchingHelpers(SimpleTestCase):
+    """Tests for the title and author comparison helpers."""
+
+    def test_titles_match_tolerates_subtitles(self):
+        """A provider title with a subtitle still matches the CSV title."""
+        self.assertTrue(storygraph.titles_match("Mistborn", "Mistborn: The Final Empire"))
+        self.assertTrue(storygraph.titles_match("The Blade Itself", "the blade itself"))
+
+    def test_titles_do_not_match_across_books(self):
+        """Unrelated titles do not match."""
+        self.assertFalse(storygraph.titles_match("Mistborn", "The God Delusion"))
+        self.assertFalse(storygraph.titles_match("", "Mistborn"))
+
+    def test_author_classification(self):
+        """Authors classify as match, unknown, or conflict."""
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], ["Joe Abercrombie"]),
+            "match",
+        )
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], ["J. Abercrombie"]),
+            "match",
+        )
+        self.assertEqual(storygraph.classify_authors(["Joe Abercrombie"], []), "unknown")
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], ["Robin Hobb"]),
+            "conflict",
+        )
+        self.assertEqual(storygraph.classify_authors([], ["Robin Hobb"]), "match")
+
+    def test_extract_provider_authors_handles_shapes(self):
+        """Provider metadata carries authors as strings, lists, or dicts."""
+        self.assertEqual(
+            storygraph.extract_provider_authors(
+                {"details": {"author": ["Robin Hobb"]}},
+            ),
+            ["Robin Hobb"],
+        )
+        self.assertEqual(
+            storygraph.extract_provider_authors(
+                {"details": {"authors": [{"name": "Robin Hobb"}]}},
+            ),
+            ["Robin Hobb"],
+        )
+        self.assertEqual(
+            storygraph.extract_provider_authors({"details": {"author": "Robin Hobb"}}),
+            ["Robin Hobb"],
+        )
+        self.assertEqual(storygraph.extract_provider_authors({}), [])
+
+
+class BookResolverTests(SimpleTestCase):
+    """Tests for resolving CSV rows against metadata providers."""
+
+    def setUp(self):
+        """Build the provider fixtures shared by these tests."""
+        self.metadata = {
+            "1": {
+                "media_id": "1",
+                "title": "The Blade Itself",
+                "image": "https://example.com/blade.jpg",
+                "max_progress": 515,
+                "details": {"author": ["Joe Abercrombie"]},
+            },
+            "2": {
+                "media_id": "2",
+                "title": "A Completely Different Book",
+                "image": "https://example.com/other.jpg",
+                "max_progress": 100,
+                "details": {"author": ["Someone Else"]},
+            },
+        }
+
+    def _search(self, results_by_query):
+        def search(media_type, query, page, source):
+            return {"results": results_by_query.get((source, query), [])}
+
+        return search
+
+    def _metadata(self, media_type, media_id, source):
+        return self.metadata[str(media_id)]
+
+    def test_isbn_hit_on_hardcover_wins(self):
+        """An ISBN search on Hardcover short circuits the ladder."""
+        search = self._search(
+            {(Sources.HARDCOVER.value, "9780575079793"): [{"media_id": "1", "title": "The Blade Itself"}]},
+        )
+        with patch("integrations.imports.storygraph.services.search", side_effect=search), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself",
+                ["Joe Abercrombie"],
+                "9780575079793",
+            )
+
+        self.assertIsNotNone(resolved)
+        source, media_id, metadata = resolved
+        self.assertEqual(source, Sources.HARDCOVER.value)
+        self.assertEqual(media_id, "1")
+        self.assertEqual(metadata["max_progress"], 515)
+
+    def test_falls_back_to_openlibrary(self):
+        """A book Hardcover cannot find is looked up on Open Library."""
+        search = self._search(
+            {(Sources.OPENLIBRARY.value, "The Blade Itself Joe Abercrombie"): [
+                {"media_id": "1", "title": "The Blade Itself"},
+            ]},
+        )
+        with patch("integrations.imports.storygraph.services.search", side_effect=search), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself",
+                ["Joe Abercrombie"],
+                "",
+            )
+
+        self.assertIsNotNone(resolved)
+        self.assertEqual(resolved[0], Sources.OPENLIBRARY.value)
+
+    def test_wrong_title_is_rejected(self):
+        """A search result for a different book is not accepted."""
+        search = self._search(
+            {(Sources.HARDCOVER.value, "The Blade Itself Joe Abercrombie"): [
+                {"media_id": "2", "title": "A Completely Different Book"},
+            ]},
+        )
+        with patch("integrations.imports.storygraph.services.search", side_effect=search), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself",
+                ["Joe Abercrombie"],
+                "",
+            )
+
+        self.assertIsNone(resolved)
+
+    def test_provider_error_does_not_propagate(self):
+        """A provider blowing up leaves the book unresolved, not the import."""
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=Exception("provider down"),
+        ):
+            resolved = storygraph.BookResolver({}).resolve("Whatever", [], "")
+
+        self.assertIsNone(resolved)
+
+    def test_resolution_is_cached(self):
+        """Resolving the same book twice hits the provider once."""
+        calls = []
+
+        def search(media_type, query, page, source):
+            calls.append(query)
+            if (source, query) == (Sources.HARDCOVER.value, "9780575079793"):
+                return {"results": [{"media_id": "1", "title": "The Blade Itself"}]}
+            return {"results": []}
+
+        cache = {}
+        with patch("integrations.imports.storygraph.services.search", side_effect=search), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolver = storygraph.BookResolver(cache)
+            first = resolver.resolve("The Blade Itself", ["Joe Abercrombie"], "9780575079793")
+            second = resolver.resolve("The Blade Itself", ["Joe Abercrombie"], "9780575079793")
+
+        self.assertEqual(first, second)
+        self.assertEqual(calls.count("9780575079793"), 1)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v -k "MatchingHelpers or BookResolver"`
+Expected: FAIL — `module 'integrations.imports.storygraph' has no attribute 'titles_match'`.
+
+- [ ] **Step 3: Write the resolver**
+
+Add to the imports at the top of `src/integrations/imports/storygraph.py`:
+
+```python
+from difflib import SequenceMatcher
+
+from app.log_safety import exception_summary
+from app.models import MediaTypes, Sources, Status
+from app.providers import services
+```
+
+(The existing `from app.models import Status` line is replaced by the combined import above.)
+
+Add the constants next to the others:
+
+```python
+BOOK_METADATA_PROVIDER_ORDER = (Sources.HARDCOVER.value, Sources.OPENLIBRARY.value)
+TITLE_MATCH_THRESHOLD = 0.72
+MAX_SEARCH_RESULTS = 5
+MAX_TITLE_CANDIDATES = 3
+BEST_TIER = 3
+```
+
+Then append:
+
+```python
+def title_similarity(left, right):
+    """Return a 0-1 similarity ratio between two normalized titles."""
+    left_normalized = normalize_name(left)
+    right_normalized = normalize_name(right)
+    if not left_normalized or not right_normalized:
+        return 0.0
+    return SequenceMatcher(None, left_normalized, right_normalized).ratio()
+
+
+def titles_match(left, right):
+    """Match titles, tolerating subtitles ('Mistborn' vs 'Mistborn: ...')."""
+    left_normalized = normalize_name(left)
+    right_normalized = normalize_name(right)
+    if not left_normalized or not right_normalized:
+        return False
+    if left_normalized == right_normalized:
+        return True
+    if right_normalized.startswith(left_normalized) or left_normalized.startswith(
+        right_normalized,
+    ):
+        return True
+    return title_similarity(left, right) >= TITLE_MATCH_THRESHOLD
+
+
+def authors_overlap(target_authors, provider_authors):
+    """Return True when two author name sets plausibly mean the same person."""
+    target = {name for name in map(normalize_name, target_authors) if name}
+    provider = {name for name in map(normalize_name, provider_authors) if name}
+    if not target or not provider:
+        return False
+    if target & provider:
+        return True
+    for left in target:
+        for right in provider:
+            if left in right or right in left:
+                return True
+            if left.split()[-1] == right.split()[-1]:  # shared surname
+                return True
+    return False
+
+
+def classify_authors(target_authors, candidate_authors):
+    """Classify author agreement as 'match', 'unknown', or 'conflict'."""
+    if not target_authors:
+        return "match"
+    if not candidate_authors:
+        return "unknown"
+    if authors_overlap(target_authors, candidate_authors):
+        return "match"
+    return "conflict"
+
+
+def extract_provider_authors(metadata):
+    """Pull author names out of provider metadata, whatever shape they take."""
+    details = metadata.get("details", {}) if isinstance(metadata, dict) else {}
+    if not isinstance(details, dict):
+        details = {}
+
+    raw_authors = details.get("authors") or details.get("author") or []
+    if isinstance(raw_authors, str):
+        raw_authors = [part.strip() for part in raw_authors.split(",") if part.strip()]
+    elif not isinstance(raw_authors, list):
+        raw_authors = [raw_authors] if raw_authors else []
+
+    authors = []
+    for raw_author in raw_authors:
+        value = (
+            raw_author.get("name") or raw_author.get("person")
+            if isinstance(raw_author, dict)
+            else raw_author
+        )
+        name = str(value or "").strip()
+        if name:
+            authors.append(name)
+    return list(dict.fromkeys(authors))
+
+
+class BookResolver:
+    """Resolve StoryGraph rows to books on Hardcover, then Open Library."""
+
+    def __init__(self, cache):
+        """Initialize with a dict used to memoize resolutions across rows."""
+        self.cache = cache
+
+    def resolve(self, title, authors, isbn):
+        """Return ``(source, media_id, metadata)`` for a book, or None."""
+        cache_key = isbn or f"{normalize_name(title)}|{normalize_name(' '.join(authors))}"
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+
+        resolved = self._search_providers(title, authors, isbn)
+        self.cache[cache_key] = resolved
+        return resolved
+
+    def _queries(self, title, authors, isbn):
+        """Build the ordered search queries for one book."""
+        queries = [isbn] if isbn else []
+        if title and authors:
+            queries.append(f"{title} {authors[0]}")
+        if title:
+            queries.append(title)
+        return list(dict.fromkeys(query for query in queries if query))
+
+    def _search_providers(self, title, authors, isbn):
+        """Walk the provider and query ladder, keeping the best candidate."""
+        best_tier = 0
+        best_result = None
+
+        for source in BOOK_METADATA_PROVIDER_ORDER:
+            for query in self._queries(title, authors, isbn):
+                tier, result = self._match_query(source, query, title, authors)
+                if tier > best_tier:
+                    best_tier, best_result = tier, result
+                    if best_tier == BEST_TIER:
+                        return best_result
+
+        return best_result
+
+    def _match_query(self, source, query, title, authors):
+        """Search one provider with one query, returning ``(tier, result)``."""
+        try:
+            response = services.search(MediaTypes.BOOK.value, query, 1, source)
+        except Exception as error:  # noqa: BLE001 - a bad provider must not stop the import
+            logger.debug(
+                "StoryGraph search failed source=%s error=%s",
+                source,
+                exception_summary(error),
+            )
+            return 0, None
+
+        results = response.get("results", []) if isinstance(response, dict) else []
+        best_tier = 0
+        best_result = None
+
+        for candidate in self._title_candidates(results, title):
+            media_id = candidate.get("media_id")
+            if not media_id:
+                continue
+
+            try:
+                metadata = services.get_media_metadata(
+                    MediaTypes.BOOK.value,
+                    str(media_id),
+                    source,
+                )
+            except Exception as error:  # noqa: BLE001 - same reasoning as above
+                logger.debug(
+                    "StoryGraph metadata fetch failed source=%s error=%s",
+                    source,
+                    exception_summary(error),
+                )
+                continue
+
+            if not titles_match(title, str(metadata.get("title") or "")):
+                continue
+
+            verdict = classify_authors(authors, extract_provider_authors(metadata))
+            if verdict == "conflict":
+                continue
+
+            tier = BEST_TIER if verdict == "match" else 2
+            if tier > best_tier:
+                best_tier = tier
+                best_result = (source, str(media_id), metadata)
+                if best_tier == BEST_TIER:
+                    break
+
+        return best_tier, best_result
+
+    def _title_candidates(self, results, title):
+        """Return the best title-matching search results, best first."""
+        scored = []
+        for result in results[:MAX_SEARCH_RESULTS]:
+            candidate_title = str(result.get("title") or "")
+            if not titles_match(title, candidate_title):
+                continue
+            scored.append((title_similarity(title, candidate_title), result))
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [result for _score, result in scored[:MAX_TITLE_CANDIDATES]]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: PASS, all Task 1 and Task 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/imports/storygraph.py src/integrations/tests/imports/test_storygraph.py
+git commit -m "Add StoryGraph provider matching with Open Library fallback"
+```
+
+---
+
+### Task 3: Importer — entries, items, formats
+
+The importer itself: read the CSV, resolve each row, build one `Book` row per read, create items, and bulk create. Deduplication, tags, and the date report arrive in Tasks 4–6.
+
+**Files:**
+- Modify: `src/integrations/imports/storygraph.py`
+- Create: `src/integrations/tests/mock_data/import_storygraph.csv`
+- Modify: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 and 2.
+- Produces:
+  - `importer(file, user, mode) -> tuple[dict[str, int], str]`
+  - `StoryGraphImporter(file, user, mode)` with `import_data()`
+
+- [ ] **Step 1: Write the fixture CSV**
+
+Create `src/integrations/tests/mock_data/import_storygraph.csv` (header identical to a real export):
+
+```csv
+Title,Authors,Contributors,ISBN/UID,Format,Read Status,Date Added,Last Date Read,Dates Read,Read Count,Moods,Pace,Character- or Plot-Driven?,Strong Character Development?,Loveable Characters?,Diverse Characters?,Flawed Characters?,Star Rating,Review,Content Warnings,Content Warning Description,Tags,Owned?
+The Blade Itself,Joe Abercrombie,"",9780575079793,digital,read,2021/01/01,2021/02/09,2021/01/20-2021/02/09,1,"",,,,,,,4.5,Grim and funny.,"",,"fantasy",No
+Kindle Only,Some Author,"",B0851JCZYV,digital,read,2025/07/01,2025/07/16,2025/07/16,1,"",,,,,,,,,"",,"",No
+No Isbn Book,Another Author,"","",paperback,read,2013/06/04,"","",1,"",,,,,,,5.0,,"",,"",No
+Re-read Book,Third Author,"",9781111111111,digital,read,2021/09/01,2022/11/28,"2022/10/29-2022/11/28, 2021/09/14",2,"",,,,,,,5.0,,"",,"",No
+Current Book,Fourth Author,"",9782222222222,digital,currently-reading,2026/07/15,"","",0,"",,,,,,,,,"",,"",No
+Planned Book,Fifth Author,"",9783333333333,hardcover,to-read,2026/02/04,"","",0,"",,,,,,,,,"",,"",No
+Dnf Book,Sixth Author,"",9784444444444,digital,did-not-finish,2024/05/05,"","",0,"",,,,,,,,,"",,"",No
+Tagged Only Book,Seventh Author,"","",,,"","","",,"",,,,,,,,,"",,"management, spanish",No
+Audio Book,Eighth Author,"",9785555555555,audio,read,2024/01/01,2024/01/05,2024/01/02-2024/01/05,1,"",,,,,,,,,"",,"",No
+Missing Book,Unknown Author,"","",digital,read,2020/01/01,2020/01/05,2020/01/05,1,"",,,,,,,,,"",,"",No
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Book, Item
+
+mock_path = Path(__file__).resolve().parent.parent / "mock_data"
+
+PROVIDER_BOOKS = {
+    "The Blade Itself": {"media_id": "1", "pages": 515, "author": "Joe Abercrombie"},
+    "Kindle Only": {"media_id": "2", "pages": 300, "author": "Some Author"},
+    "No Isbn Book": {"media_id": "3", "pages": 200, "author": "Another Author"},
+    "Re-read Book": {"media_id": "4", "pages": 400, "author": "Third Author"},
+    "Current Book": {"media_id": "5", "pages": 350, "author": "Fourth Author"},
+    "Planned Book": {"media_id": "6", "pages": 1007, "author": "Fifth Author"},
+    "Dnf Book": {"media_id": "7", "pages": 250, "author": "Sixth Author"},
+    "Tagged Only Book": {"media_id": "8", "pages": 150, "author": "Seventh Author"},
+    "Audio Book": {"media_id": "9", "pages": 320, "author": "Eighth Author"},
+}
+PROVIDER_BY_ID = {book["media_id"]: (title, book) for title, book in PROVIDER_BOOKS.items()}
+
+
+def fake_search(media_type, query, page, source):
+    """Return a hit when the query names or identifies a fixture book."""
+    if source != Sources.HARDCOVER.value:
+        return {"results": []}
+    for title, book in PROVIDER_BOOKS.items():
+        if title.lower() in query.lower():
+            return {"results": [{"media_id": book["media_id"], "title": title}]}
+    return {"results": []}
+
+
+def fake_metadata(media_type, media_id, source):
+    """Return provider metadata for a fixture book."""
+    title, book = PROVIDER_BY_ID[str(media_id)]
+    return {
+        "media_id": book["media_id"],
+        "title": title,
+        "image": f"https://example.com/{book['media_id']}.jpg",
+        "max_progress": book["pages"],
+        "details": {"author": [book["author"]]},
+    }
+
+
+class ImportStoryGraph(TestCase):
+    """Tests for importing a StoryGraph export."""
+
+    def setUp(self):
+        """Import the fixture export with the providers mocked out."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            self.counts, self.messages = storygraph.importer(file, self.user, "new")
+
+    def _books(self, title):
+        return Book.objects.filter(user=self.user, item__title=title).order_by("end_date")
+
+    def test_entry_count(self):
+        """Nine resolvable rows produce ten entries, the re-read counting twice."""
+        self.assertEqual(Book.objects.filter(user=self.user).count(), 10)
+        self.assertEqual(self.counts["book"], 10)
+
+    def test_completed_read_dates(self):
+        """A dash separated read keeps its start and end date."""
+        book = self._books("The Blade Itself").get()
+        self.assertEqual(book.status, Status.COMPLETED.value)
+        self.assertEqual(book.start_date.date(), datetime(2021, 1, 20).date())
+        self.assertEqual(book.end_date.date(), datetime(2021, 2, 9).date())
+
+    def test_finish_date_only_leaves_start_null(self):
+        """A bare date is a finish date, not a one day read."""
+        book = self._books("Kindle Only").get()
+        self.assertIsNone(book.start_date)
+        self.assertEqual(book.end_date.date(), datetime(2025, 7, 16).date())
+
+    def test_reread_creates_two_entries(self):
+        """Each read in Dates Read becomes its own entry."""
+        books = list(self._books("Re-read Book"))
+        self.assertEqual(len(books), 2)
+        self.assertEqual(books[0].end_date.date(), datetime(2021, 9, 14).date())
+        self.assertEqual(books[1].end_date.date(), datetime(2022, 11, 28).date())
+
+    def test_rating_only_on_newest_read(self):
+        """One StoryGraph rating must not be counted once per re-read."""
+        books = list(self._books("Re-read Book"))
+        self.assertIsNone(books[0].score)
+        self.assertEqual(float(books[1].score), 10.0)
+
+    def test_review_becomes_notes(self):
+        """The Review column lands in notes."""
+        book = self._books("The Blade Itself").get()
+        self.assertEqual(book.notes, "Grim and funny.")
+        self.assertEqual(float(book.score), 9.0)
+
+    def test_progress_from_provider_page_count(self):
+        """Completed books take their page count from provider metadata."""
+        self.assertEqual(self._books("The Blade Itself").get().progress, 515)
+        self.assertEqual(self._books("Planned Book").get().progress, 0)
+
+    def test_audiobook_keeps_zero_progress(self):
+        """Audiobook progress is minutes, so a page count would render wrong."""
+        book = self._books("Audio Book").get()
+        self.assertEqual(book.status, Status.COMPLETED.value)
+        self.assertEqual(book.progress, 0)
+        self.assertEqual(book.item.format, "audiobook")
+
+    def test_status_mapping_across_rows(self):
+        """Every read status maps through to the tracked entry."""
+        self.assertEqual(self._books("Current Book").get().status, Status.IN_PROGRESS.value)
+        self.assertEqual(self._books("Planned Book").get().status, Status.PLANNING.value)
+        self.assertEqual(self._books("Dnf Book").get().status, Status.DROPPED.value)
+        self.assertEqual(self._books("Tagged Only Book").get().status, Status.PLANNING.value)
+
+    def test_date_added_is_never_a_start_date(self):
+        """Date Added is when a book was shelved, not when reading began."""
+        self.assertIsNone(self._books("Current Book").get().start_date)
+        self.assertIsNone(self._books("Current Book").get().end_date)
+
+    def test_read_without_dates_has_no_dates(self):
+        """A read with no dates is completed but contributes no calendar day."""
+        book = self._books("No Isbn Book").get()
+        self.assertEqual(book.status, Status.COMPLETED.value)
+        self.assertIsNone(book.start_date)
+        self.assertIsNone(book.end_date)
+
+    def test_format_written_only_when_empty(self):
+        """Item.format is shared between users, so an existing value stands."""
+        item = Item.objects.get(title="The Blade Itself")
+        self.assertEqual(item.format, "ebook")
+
+        item.format = "hardcover"
+        item.save(update_fields=["format"])
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            storygraph.importer(file, self.user, "new")
+
+        item.refresh_from_db()
+        self.assertEqual(item.format, "hardcover")
+
+    def test_unresolvable_book_warns(self):
+        """A book no provider knows is reported, not imported."""
+        self.assertIn("Missing Book", self.messages)
+        self.assertFalse(Book.objects.filter(item__title="Missing Book").exists())
+
+    def test_history_record_dated_from_the_read(self):
+        """The history record is stamped with the read's end date."""
+        book = self._books("The Blade Itself").get()
+        record = book.history.first()
+        self.assertEqual(record.history_date.date(), datetime(2021, 2, 9).date())
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py::ImportStoryGraph -v`
+Expected: FAIL — `module 'integrations.imports.storygraph' has no attribute 'importer'`.
+
+- [ ] **Step 4: Write the importer**
+
+Add to the imports at the top of `src/integrations/imports/storygraph.py`:
+
+```python
+from collections import defaultdict, namedtuple
+from csv import DictReader
+
+from django.apps import apps
+from django.conf import settings
+
+import app
+from integrations.imports import helpers
+from integrations.imports.helpers import MediaImportError, MediaImportUnexpectedError
+```
+
+(The existing `from collections import namedtuple` line is replaced by the combined import above.)
+
+Append to the module:
+
+```python
+def importer(file, user, mode):
+    """Import books from a StoryGraph export CSV."""
+    return StoryGraphImporter(file, user, mode).import_data()
+
+
+class StoryGraphImporter:
+    """Import a StoryGraph export, one tracked entry per read."""
+
+    def __init__(self, file, user, mode):
+        """Initialize the importer with the upload, user, and import mode."""
+        self.file = file
+        self.user = user
+        self.mode = mode
+        self.warnings = []
+
+        self.existing_media = helpers.get_existing_media(user)
+        self.to_delete = defaultdict(lambda: defaultdict(set))
+        self.bulk_media = defaultdict(list)
+        self.resolver = BookResolver({})
+
+        logger.info(
+            "Initialized StoryGraph CSV importer for user %s with mode %s",
+            user.username,
+            mode,
+        )
+
+    def import_data(self):
+        """Import every row of the CSV and return counts plus messages."""
+        try:
+            raw_file = self.file.read()
+            try:
+                decoded_file = raw_file.decode("utf-8-sig").splitlines()
+            except UnicodeDecodeError:
+                decoded_file = raw_file.decode("latin-1").splitlines()
+        except (UnicodeDecodeError, AttributeError) as error:
+            msg = "Invalid file format. Please upload a CSV file."
+            raise MediaImportError(msg) from error
+
+        for row in DictReader(decoded_file):
+            try:
+                self._process_row(row)
+            except services.ProviderAPIError as error:
+                title = (row.get("Title") or "").strip() or str(row)
+                self.warnings.append(f"Error processing entry: {title} - {error}")
+                continue
+            except Exception as error:
+                error_msg = f"Error processing entry: {row}"
+                raise MediaImportUnexpectedError(error_msg) from error
+
+        helpers.cleanup_existing_media(self.to_delete, self.user)
+        helpers.bulk_create_media(self.bulk_media, self.user)
+
+        imported_counts = {
+            media_type: len(media_list)
+            for media_type, media_list in self.bulk_media.items()
+        }
+        return imported_counts, "\n".join(dict.fromkeys(self.warnings))
+
+    def _process_row(self, row):
+        """Resolve one CSV row and queue its tracked entries."""
+        title = (row.get("Title") or "").strip()
+        if not title:
+            return
+
+        resolved = self.resolver.resolve(
+            title,
+            parse_authors(row.get("Authors")),
+            normalize_isbn(row.get("ISBN/UID")),
+        )
+        if not resolved:
+            self.warnings.append(
+                f"{title}: couldn't find this book on Hardcover or Open Library",
+            )
+            return
+
+        source, media_id, metadata = resolved
+        item = self._create_or_update_item(source, media_id, metadata, row)
+        for instance in self._build_entries(item, row, metadata):
+            self.bulk_media[MediaTypes.BOOK.value].append(instance)
+
+    def _create_or_update_item(self, source, media_id, metadata, row):
+        """Create or update the item, filling in an empty format only."""
+        item, _ = app.models.Item.objects.update_or_create(
+            media_id=media_id,
+            source=source,
+            media_type=MediaTypes.BOOK.value,
+            defaults={
+                **app.models.Item.title_fields_from_metadata(
+                    metadata,
+                    fallback_title=(row.get("Title") or "").strip(),
+                ),
+                "image": metadata.get("image") or settings.IMG_NONE,
+            },
+        )
+
+        book_format = map_format(row.get("Format"))
+        if book_format and not item.format:
+            item.format = book_format
+            item.save(update_fields=["format"])
+
+        return item
+
+    def _page_count(self, item, metadata, status):
+        """Return the progress to store, in pages, for a tracked entry."""
+        if status != Status.COMPLETED.value or item.format == "audiobook":
+            return 0
+        max_progress = metadata.get("max_progress")
+        return int(max_progress) if max_progress else 0
+
+    def _build_entries(self, item, row, metadata):
+        """Build one unsaved Book per read, newest last."""
+        status = determine_status(row.get("Read Status"))
+        progress = self._page_count(item, metadata, status)
+        reads = (
+            parse_reads(row.get("Dates Read"))
+            if status == Status.COMPLETED.value
+            else []
+        )
+        fallback_date = parse_date(row.get("Date Added"))
+
+        instances = [
+            self._build_instance(item, status, read.start, read.end, progress, fallback_date)
+            for read in reads
+        ]
+        if not instances:
+            instances.append(
+                self._build_instance(item, status, None, None, progress, fallback_date),
+            )
+
+        newest = instances[-1]
+        newest.score = parse_rating(row.get("Star Rating"))
+        newest.notes = (row.get("Review") or "").strip()
+        return instances
+
+    def _build_instance(self, item, status, start_date, end_date, progress, fallback_date):
+        """Build a single unsaved Book instance for one read."""
+        model = apps.get_model(app_label="app", model_name=MediaTypes.BOOK.value)
+        instance = model(
+            item=item,
+            user=self.user,
+            status=status,
+            progress=progress,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        instance._history_date = (  # noqa: SLF001 - simple_history reads this
+            end_date or start_date or fallback_date or timezone.now()
+        )
+        return instance
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: PASS, all tests including `ImportStoryGraph`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/integrations/imports/storygraph.py src/integrations/tests/imports/test_storygraph.py src/integrations/tests/mock_data/import_storygraph.csv
+git commit -m "Add StoryGraph importer creating one entry per read"
+```
+
+---
+
+### Task 4: Deduplication and import modes
+
+Re-importing must not duplicate reads. Matching is on the read's end date.
+
+**Files:**
+- Modify: `src/integrations/imports/storygraph.py`
+- Modify: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: `StoryGraphImporter` from Task 3.
+- Produces: `StoryGraphImporter.tracked_reads` — `dict[tuple[str, str], set[date | None]]` keyed by `(source, media_id)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+class ImportStoryGraphDeduplication(TestCase):
+    """Tests that re-importing does not duplicate reads."""
+
+    def setUp(self):
+        """Create the user and import the fixture once."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self._import()
+
+    def _import(self, mode="new", rows=None):
+        """Import the fixture, or a custom CSV body, with providers mocked."""
+        if rows is None:
+            source_file = Path(mock_path / "import_storygraph.csv").open("rb")
+        else:
+            source_file = BytesIO(rows.encode("utf-8"))
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), source_file as file:
+            return storygraph.importer(file, self.user, mode)
+
+    def test_reimport_creates_nothing(self):
+        """Importing the same export twice leaves the entry count unchanged."""
+        before = Book.objects.filter(user=self.user).count()
+        counts, _ = self._import()
+        self.assertEqual(Book.objects.filter(user=self.user).count(), before)
+        self.assertEqual(counts.get("book", 0), 0)
+
+    def test_new_read_creates_one_entry(self):
+        """A read added in StoryGraph after the first import arrives."""
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            "The Blade Itself,Joe Abercrombie,\"\",9780575079793,digital,read,"
+            "2021/01/01,2026/05/10,\"2021/01/20-2021/02/09, 2026/05/01-2026/05/10\",2,"
+            "\"\",,,,,,,4.5,Grim and funny.,\"\",,\"fantasy\",No"
+        )
+        counts, _ = self._import(rows=f"{header}\n{row}\n")
+
+        self.assertEqual(counts.get("book", 0), 1)
+        books = Book.objects.filter(user=self.user, item__title="The Blade Itself")
+        self.assertEqual(books.count(), 2)
+
+    def test_dateless_read_not_duplicated(self):
+        """A read with no dates is added once and never again."""
+        counts, _ = self._import()
+        self.assertEqual(counts.get("book", 0), 0)
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="No Isbn Book").count(),
+            1,
+        )
+
+    def test_overwrite_rebuilds_entries(self):
+        """Overwrite mode replaces the book's entries rather than adding to them."""
+        self._import(mode="overwrite")
+        self.assertEqual(Book.objects.filter(user=self.user).count(), 10)
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="Re-read Book").count(),
+            2,
+        )
+```
+
+Add `from io import BytesIO` to the test module's imports.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py::ImportStoryGraphDeduplication -v`
+Expected: FAIL — `test_reimport_creates_nothing` finds 20 books instead of 10.
+
+- [ ] **Step 3: Add deduplication to the importer**
+
+In `StoryGraphImporter.__init__`, after `self.bulk_media = defaultdict(list)`:
+
+```python
+        self.tracked_reads = self._load_tracked_reads()
+```
+
+Add the two methods:
+
+```python
+    def _load_tracked_reads(self):
+        """Map each already-tracked book to the read dates it has."""
+        tracked = defaultdict(set)
+        model = apps.get_model(app_label="app", model_name=MediaTypes.BOOK.value)
+        for book in model.objects.filter(user=self.user).select_related("item"):
+            key = (book.item.source, book.item.media_id)
+            tracked[key].add(book.end_date.date() if book.end_date else None)
+        return tracked
+
+    def _tracked_dates(self, source, media_id):
+        """Return the read dates to skip, queueing a wipe in overwrite mode."""
+        if self.mode == "overwrite":
+            if media_id in self.existing_media[MediaTypes.BOOK.value][source]:
+                self.to_delete[MediaTypes.BOOK.value][source].add(media_id)
+            self.tracked_reads[(source, media_id)] = set()
+        return self.tracked_reads[(source, media_id)]
+```
+
+Change `_process_row` to pass the tracked dates through:
+
+```python
+        source, media_id, metadata = resolved
+        item = self._create_or_update_item(source, media_id, metadata, row)
+        tracked_dates = self._tracked_dates(source, media_id)
+        for instance in self._build_entries(item, row, metadata, tracked_dates):
+            self.bulk_media[MediaTypes.BOOK.value].append(instance)
+```
+
+Replace `_build_entries` with the deduplicating version:
+
+```python
+    def _build_entries(self, item, row, metadata, tracked_dates):
+        """Build one unsaved Book per untracked read, newest last."""
+        status = determine_status(row.get("Read Status"))
+        progress = self._page_count(item, metadata, status)
+        reads = (
+            parse_reads(row.get("Dates Read"))
+            if status == Status.COMPLETED.value
+            else []
+        )
+        fallback_date = parse_date(row.get("Date Added"))
+        had_entries = bool(tracked_dates)
+
+        instances = []
+        for read in reads:
+            read_day = read.end.date() if read.end else None
+            if read_day in tracked_dates:
+                continue
+            tracked_dates.add(read_day)
+            instances.append(
+                self._build_instance(
+                    item,
+                    status,
+                    read.start,
+                    read.end,
+                    progress,
+                    fallback_date,
+                ),
+            )
+
+        if not reads and not had_entries:
+            tracked_dates.add(None)
+            instances.append(
+                self._build_instance(item, status, None, None, progress, fallback_date),
+            )
+
+        if instances and not had_entries:
+            # One StoryGraph rating covers the book, so it goes on the newest
+            # entry only - repeating it per re-read would double count it in
+            # statistics. A book that already has entries carries its rating
+            # there, so a newly added re-read is left unrated.
+            newest = instances[-1]
+            newest.score = parse_rating(row.get("Star Rating"))
+            newest.notes = (row.get("Review") or "").strip()
+
+        return instances
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: PASS, every class.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/imports/storygraph.py src/integrations/tests/imports/test_storygraph.py
+git commit -m "Deduplicate StoryGraph reads by end date across imports"
+```
+
+---
+
+### Task 5: Tags become custom lists
+
+**Files:**
+- Modify: `src/integrations/imports/storygraph.py`
+- Modify: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: `parse_tags` from Task 1, `StoryGraphImporter` from Task 4.
+- Produces: `StoryGraphImporter._sync_tags(item, row) -> None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+from lists.models import CustomList, CustomListItem
+
+
+class ImportStoryGraphTags(TestCase):
+    """Tests for mapping StoryGraph tags onto custom lists."""
+
+    def setUp(self):
+        """Create the user and import the fixture."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self._import()
+
+    def _import(self):
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            return storygraph.importer(file, self.user, "new")
+
+    def test_lists_created_from_tags(self):
+        """Each tag becomes a local custom list owned by the user."""
+        names = set(
+            CustomList.objects.filter(owner=self.user).values_list("name", flat=True),
+        )
+        self.assertEqual(names, {"fantasy", "management", "spanish"})
+
+    def test_items_added_to_their_lists(self):
+        """A tagged book joins every list its tags name."""
+        tagged = Item.objects.get(title="Tagged Only Book")
+        list_names = set(
+            CustomListItem.objects.filter(item=tagged).values_list(
+                "custom_list__name",
+                flat=True,
+            ),
+        )
+        self.assertEqual(list_names, {"management", "spanish"})
+
+    def test_membership_is_idempotent(self):
+        """Re-importing does not duplicate lists or memberships."""
+        self._import()
+        self.assertEqual(CustomList.objects.filter(owner=self.user).count(), 3)
+        self.assertEqual(
+            CustomListItem.objects.filter(custom_list__owner=self.user).count(),
+            3,
+        )
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py::ImportStoryGraphTags -v`
+Expected: FAIL — no `CustomList` rows exist.
+
+- [ ] **Step 3: Add tag syncing**
+
+Add the import at the top of `src/integrations/imports/storygraph.py`:
+
+```python
+from lists.models import CustomList, CustomListItem
+```
+
+In `StoryGraphImporter.__init__`, after `self.tracked_reads = self._load_tracked_reads()`:
+
+```python
+        self.list_cache = {}
+```
+
+Add the method:
+
+```python
+    def _sync_tags(self, item, row):
+        """Mirror the row's tags as custom lists holding this item."""
+        for tag in parse_tags(row.get("Tags")):
+            custom_list = self.list_cache.get(tag)
+            if custom_list is None:
+                custom_list = CustomList.objects.filter(
+                    owner=self.user,
+                    name=tag,
+                ).first() or CustomList.objects.create(
+                    owner=self.user,
+                    name=tag,
+                    source="local",
+                )
+                self.list_cache[tag] = custom_list
+
+            CustomListItem.objects.get_or_create(
+                item=item,
+                custom_list=custom_list,
+                defaults={"added_by": self.user},
+            )
+```
+
+Call it from `_process_row`, right after the item is created:
+
+```python
+        item = self._create_or_update_item(source, media_id, metadata, row)
+        self._sync_tags(item, row)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: PASS, every class.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/imports/storygraph.py src/integrations/tests/imports/test_storygraph.py
+git commit -m "Mirror StoryGraph tags as custom lists"
+```
+
+---
+
+### Task 6: Incomplete-date report
+
+StoryGraph exports commonly lack read dates. The import summary names the affected books so they can be fixed at the source and re-imported.
+
+**Files:**
+- Modify: `src/integrations/imports/storygraph.py`
+- Modify: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: `StoryGraphImporter` from Task 5.
+- Produces: `StoryGraphImporter._report_lines() -> list[str]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+class ImportStoryGraphDateReport(TestCase):
+    """Tests for the incomplete-date report in the import summary."""
+
+    def setUp(self):
+        """Create the user and import the fixture."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            self.counts, self.messages = storygraph.importer(file, self.user, "new")
+
+    def test_books_read_without_dates_listed(self):
+        """A read with no dates at all is named in the summary."""
+        self.assertIn("No Isbn Book", self.messages)
+        self.assertIn("no read date", self.messages)
+
+    def test_reads_without_start_date_listed(self):
+        """A read with a finish date but no start date is named."""
+        self.assertIn("Kindle Only", self.messages)
+        self.assertIn("no start date", self.messages)
+
+    def test_complete_reads_not_listed(self):
+        """A read with both dates is not reported."""
+        report = [line for line in self.messages.splitlines() if "date" in line]
+        self.assertNotIn("The Blade Itself", "\n".join(report))
+
+    def test_report_absent_when_dates_complete(self):
+        """An export with complete dates produces no report lines."""
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            "The Blade Itself,Joe Abercrombie,\"\",9780575079793,digital,read,"
+            "2021/01/01,2021/02/09,2021/01/20-2021/02/09,1,"
+            "\"\",,,,,,,4.5,Grim and funny.,\"\",,\"fantasy\",No"
+        )
+        user = get_user_model().objects.create_user(
+            username="other",
+            password="12345",  # noqa: S106 - test credential
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), BytesIO(f"{header}\n{row}\n".encode()) as file:
+            _counts, messages = storygraph.importer(file, user, "new")
+
+        self.assertEqual(messages, "")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py::ImportStoryGraphDateReport -v`
+Expected: FAIL — `"no read date"` is not in the messages.
+
+- [ ] **Step 3: Add the report**
+
+In `StoryGraphImporter.__init__`, after `self.list_cache = {}`:
+
+```python
+        self.missing_read_dates = []
+        self.missing_start_dates = []
+```
+
+In `_build_entries`, record the gaps as each completed instance is built. Replace the loop body and the dateless branch:
+
+```python
+        for read in reads:
+            read_day = read.end.date() if read.end else None
+            if read_day in tracked_dates:
+                continue
+            tracked_dates.add(read_day)
+            if not read.start:
+                self.missing_start_dates.append(item.title)
+            instances.append(
+                self._build_instance(
+                    item,
+                    status,
+                    read.start,
+                    read.end,
+                    progress,
+                    fallback_date,
+                ),
+            )
+
+        if not reads and not had_entries:
+            tracked_dates.add(None)
+            if status == Status.COMPLETED.value:
+                self.missing_read_dates.append(item.title)
+            instances.append(
+                self._build_instance(item, status, None, None, progress, fallback_date),
+            )
+```
+
+Add the report builder:
+
+```python
+    def _report_lines(self):
+        """Describe the date gaps worth fixing in StoryGraph and re-importing."""
+        lines = []
+        if self.missing_read_dates:
+            titles = ", ".join(dict.fromkeys(self.missing_read_dates))
+            lines.append(f"Imported as read with no read date: {titles}")
+        if self.missing_start_dates:
+            titles = ", ".join(dict.fromkeys(self.missing_start_dates))
+            lines.append(f"Imported with a finish date but no start date: {titles}")
+        return lines
+```
+
+Change the return of `import_data`:
+
+```python
+        messages = list(dict.fromkeys(self.warnings)) + self._report_lines()
+        return imported_counts, "\n".join(messages)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py -v`
+Expected: PASS, every class.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/imports/storygraph.py src/integrations/tests/imports/test_storygraph.py
+git commit -m "Report StoryGraph reads with missing dates in the import summary"
+```
+
+---
+
+### Task 7: Wiring — task, view, url, UI, API
+
+Hook the importer into the app the way every other CSV importer is hooked in.
+
+**Files:**
+- Modify: `src/integrations/tasks/_media_imports.py:235-238` (after `import_hardcover`)
+- Modify: `src/integrations/tasks/__init__.py:37` (import list) and its `__all__`-style re-export block
+- Modify: `src/integrations/views.py:2134-2152` (after `import_hardcover`)
+- Modify: `src/integrations/urls.py:63`
+- Modify: `src/users/templatetags/user_tags.py:96-99`
+- Create: `src/static/img/storygraph-logo.svg`
+- Modify: `src/templates/users/import_data.html:1675-1700` (after the Hardcover card)
+- Modify: `src/users/models.py:1497`
+- Modify: `src/api/fork_views_integrations.py:36` and the docstring at line 54
+- Modify: `src/integrations/tests/imports/test_storygraph.py`
+
+**Interfaces:**
+- Consumes: `storygraph.importer` from Task 6.
+- Produces: celery task `import_storygraph` registered as `"Import from StoryGraph"`; url name `import_storygraph`; API service key `storygraph`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/integrations/tests/imports/test_storygraph.py`:
+
+```python
+from django.urls import reverse
+
+from config.celery import app as celery_app
+from integrations import tasks
+
+
+class StoryGraphWiring(TestCase):
+    """Tests that the importer is reachable from the app."""
+
+    def setUp(self):
+        """Create and sign in a user."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self.client.force_login(self.user)
+
+    def test_task_registered(self):
+        """The celery task is registered under its display name."""
+        self.assertEqual(tasks.import_storygraph.name, "Import from StoryGraph")
+        self.assertIn("Import from StoryGraph", celery_app.tasks)
+
+    def test_view_requires_a_file(self):
+        """Posting without a file reports an error instead of queueing."""
+        response = self.client.post(reverse("import_storygraph"), {"mode": "new"})
+        self.assertEqual(response.status_code, 302)
+
+    def test_view_queues_the_task(self):
+        """Posting a CSV queues the import task."""
+        with Path(mock_path / "import_storygraph.csv").open("rb") as file, patch(
+            "integrations.tasks.import_storygraph.delay",
+        ) as delay:
+            response = self.client.post(
+                reverse("import_storygraph"),
+                {"mode": "new", "storygraph_csv": file},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        delay.assert_called_once()
+```
+
+`from config.celery import app as celery_app` is the same import `src/integrations/tests/test_task_registration.py` uses.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py::StoryGraphWiring -v`
+Expected: FAIL — `module 'integrations.tasks' has no attribute 'import_storygraph'`.
+
+- [ ] **Step 3: Add the celery task**
+
+In `src/integrations/tasks/_media_imports.py`, add `storygraph` to the `from integrations.imports import (...)` block (alphabetically, after `steam`), then add after `import_hardcover`:
+
+```python
+@shared_task(name="Import from StoryGraph")
+def import_storygraph(file, user_id, mode):
+    """Celery task for importing media data from StoryGraph."""
+    return import_media(storygraph.importer, _coerce_uploaded_file(file), user_id, mode)
+```
+
+In `src/integrations/tasks/__init__.py`, add `import_storygraph` to the `from integrations.tasks._media_imports import (...)` list, keeping alphabetical order (after `import_steam`). If the module ends with an explicit re-export list, add it there too.
+
+- [ ] **Step 4: Add the view and url**
+
+In `src/integrations/views.py`, after `import_hardcover`:
+
+```python
+@require_POST
+def import_storygraph(request):
+    """View for importing books data from StoryGraph CSV."""
+    file = request.FILES.get("storygraph_csv")
+
+    if not file:
+        messages.error(request, "StoryGraph CSV file is required.")
+        return redirect("import_data")
+
+    mode = request.POST["mode"]
+    tasks.import_storygraph.delay(
+        user_id=request.user.id,
+        file=_read_uploaded_file(file),
+        mode=mode,
+    )
+    messages.info(
+        request,
+        "The task to import media from StoryGraph CSV file has been queued.",
+    )
+    return redirect("import_data")
+```
+
+In `src/integrations/urls.py`, after the `import/hardcover` line:
+
+```python
+    path("import/storygraph", views.import_storygraph, name="import_storygraph"),
+```
+
+- [ ] **Step 5: Run the wiring tests**
+
+Run: `pytest src/integrations/tests/imports/test_storygraph.py::StoryGraphWiring -v`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 6: Add the logo**
+
+Create `src/static/img/storygraph-logo.svg` — a simple three-bar mark in StoryGraph's palette, no trademarked wordmark:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="StoryGraph">
+  <rect width="32" height="32" rx="6" fill="#0f1c2e"/>
+  <rect x="7" y="18" width="5" height="8" rx="1.5" fill="#f4b942"/>
+  <rect x="13.5" y="12" width="5" height="14" rx="1.5" fill="#e8734a"/>
+  <rect x="20" y="6" width="5" height="20" rx="1.5" fill="#5bc0be"/>
+</svg>
+```
+
+- [ ] **Step 7: Add the source display, UI card, task-name map, and API entry**
+
+In `src/users/templatetags/user_tags.py`, after the `"hardcover"` entry:
+
+```python
+    "storygraph": {
+        "name": "StoryGraph",
+        "logo": static("img/storygraph-logo.svg"),
+    },
+```
+
+In `src/templates/users/import_data.html`, after the Hardcover card's closing `</div>`:
+
+```html
+        {# StoryGraph #}
+        <div class="bg-[#39404b] p-4 rounded-lg"
+             x-show="sourceSupports(['reading'])"
+             x-transition.opacity.duration.150ms>
+          <div class="flex items-center mb-3">{% source_display "storygraph" %}</div>
+          <p class="text-sm text-gray-400 mb-3"
+             x-text="importFrequency === 'once' ? 'Import from StoryGraph export (Profile -> Manage Account -> Export StoryGraph Library)' : 'File uploads are not available for periodic imports'">
+          </p>
+          <form method="post"
+                action="{% url 'import_storygraph' %}"
+                enctype="multipart/form-data">
+            {% csrf_token %}
+            <input type="hidden" name="frequency" x-model="importFrequency">
+            <input type="hidden" name="time" x-model="importTime">
+            <input type="hidden" name="mode" x-model="importMode">
+            <label class="flex items-center justify-center w-full px-4 py-2 text-sm rounded-md transition-colors"
+                   :class="importFrequency === 'once' && !standardImportsDisabled() ? 'bg-indigo-600 text-white hover:bg-indigo-700 cursor-pointer' : 'bg-gray-600 text-gray-400 cursor-not-allowed'"
+                   :disabled="importFrequency !== 'once' || standardImportsDisabled()">
+              <input name="storygraph_csv"
+                     accept=".csv"
+                     class="hidden"
+                     type="file"
+                     :disabled="importFrequency !== 'once' || standardImportsDisabled()"
+                     @change="importFrequency === 'once' && !standardImportsDisabled() && $el.form.submit()">
+              Select CSV File
+            </label>
+          </form>
+        </div>
+```
+
+In `src/users/models.py`, after the `"hardcover"` entry in `result_task_names`:
+
+```python
+            "storygraph": ["Import from StoryGraph"],
+```
+
+In `src/api/fork_views_integrations.py`, after the `"hardcover"` entry in `_FILE_IMPORTS`:
+
+```python
+    "storygraph": (tasks.import_storygraph, "StoryGraph CSV"),
+```
+
+and extend the `ImportDispatchView` docstring's service list to read `goodreads, hardcover, storygraph)`.
+
+- [ ] **Step 8: Run the full import and users test suites**
+
+Run: `pytest src/integrations/tests -q && pytest src/users/tests -q`
+Expected: PASS. Investigate any failure before continuing — `src/users/tests/views/test_import_data.py` renders the page that the new card lives on.
+
+- [ ] **Step 9: Lint**
+
+Run: `ruff check src/integrations/imports/storygraph.py src/integrations/views.py src/integrations/tests/imports/test_storygraph.py`
+Expected: no findings. Fix anything reported.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/integrations/tasks src/integrations/views.py src/integrations/urls.py src/users/templatetags/user_tags.py src/static/img/storygraph-logo.svg src/templates/users/import_data.html src/users/models.py src/api/fork_views_integrations.py src/integrations/tests/imports/test_storygraph.py
+git commit -m "Wire up StoryGraph CSV import"
+```
+
+---
+
+### Task 8: Verify against the real export
+
+The fixture is synthetic. This checks the importer against the 280-row export in the repo root, without touching a database or a provider.
+
+**Files:**
+- No production changes expected. Fix `src/integrations/imports/storygraph.py` if this surfaces a bug.
+
+- [ ] **Step 1: Parse every row of the real export**
+
+Run:
+
+```bash
+cd src && python -c "
+import csv, django, os
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.test_settings')
+django.setup()
+from integrations.imports import storygraph
+rows = list(csv.DictReader(open('../ea51fe84545edfba6d019e36d854f71015e870866ab83ddc54da3bd7afc274d1.csv', encoding='utf-8-sig')))
+reads = statuses = 0
+for row in rows:
+    parsed = storygraph.parse_reads(row['Dates Read'])
+    reads += len(parsed)
+    storygraph.determine_status(row['Read Status'])
+    storygraph.parse_rating(row['Star Rating'])
+    storygraph.parse_tags(row['Tags'])
+    storygraph.normalize_isbn(row['ISBN/UID'])
+    statuses += 1
+print('rows', len(rows), 'reads', reads, 'parsed', statuses)
+"
+```
+
+Expected: `rows 280 reads 210 parsed 280` — 209 dated reads plus the second read of the one re-read book. No exception. If the read count differs, print the rows whose `Dates Read` is non-empty but parses to nothing and fix the parser.
+
+- [ ] **Step 2: Commit any fix**
+
+Only if Step 1 required a change:
+
+```bash
+git add src/integrations/imports/storygraph.py
+git commit -m "Fix StoryGraph date parsing found against a real export"
+```
+
+---
+
+## Notes for the implementer
+
+- `wiki/` is an empty submodule in this checkout, so there is no wiki page to update. The card's help text in `import_data.html` is the user-facing documentation.
+- `helpers.bulk_create_media` calls `bulk_create_with_history`, which bypasses `Model.save()`. That is why progress is computed in the importer instead of relying on `process_progress`, and why `_history_date` must be set on each instance.
+- The `Read Count` column is intentionally unused: `Dates Read` is the authoritative record of individual reads, and the two disagree in real exports.

--- a/docs/superpowers/plans/2026-07-26-storygraph-import.md
+++ b/docs/superpowers/plans/2026-07-26-storygraph-import.md
@@ -105,7 +105,6 @@ class ParseReads(SimpleTestCase):
     def test_dates_are_timezone_aware(self):
         """Parsed dates are aware so Django never warns on save."""
         read = storygraph.parse_reads("2021/07/21")[0]
-        self.assertIsNotNone(timezone.is_aware(read.end) or None)
         self.assertTrue(timezone.is_aware(read.end))
 
 

--- a/docs/superpowers/specs/2026-07-26-storygraph-import-design.md
+++ b/docs/superpowers/specs/2026-07-26-storygraph-import-design.md
@@ -1,0 +1,200 @@
+# StoryGraph CSV Import — Design
+
+Issue: [#957](https://github.com/FuzzyGrim/Yamtrack/issues/957) (StoryGraph half only; Ryot is out of scope).
+
+## Context
+
+StoryGraph has no public API ([roadmap post](https://roadmap.thestorygraph.com/features/posts/an-api));
+third-party packages scrape HTML. The account export CSV is the supported path, so the
+importer is a file upload like `goodreads.py` and `hardcover.py`.
+
+### Export format
+
+Columns, in order:
+
+```
+Title, Authors, Contributors, ISBN/UID, Format, Read Status, Date Added, Last Date Read,
+Dates Read, Read Count, Moods, Pace, Character- or Plot-Driven?, Strong Character Development?,
+Loveable Characters?, Diverse Characters?, Flawed Characters?, Star Rating, Review,
+Content Warnings, Content Warning Description, Tags, Owned?
+```
+
+Observed in a real 280-row export:
+
+| Field | Reality |
+| --- | --- |
+| `Read Status` | `read` (247), blank (26), `currently-reading` (5), `to-read` (2). StoryGraph also emits `did-not-finish`. |
+| `ISBN/UID` | 164 ISBN-13, 5 ISBN-10, 56 Amazon ASINs (`B0851JCZYV`), 55 blank. ~40% unusable for ISBN lookup. |
+| `Dates Read` | `2021/07/21` (one day), `2022/03/16-2022/04/01` (range), or comma-separated ranges for re-reads. 38 `read` rows have no dates. |
+| `Star Rating` | 0–5 with halves (`4.5`). Yamtrack scores 0–10, so ×2. |
+| `Tags` | Comma-separated free text (`management`, `spanish`). |
+| Pages | **Absent** — unlike the Goodreads and Hardcover exports. |
+| Book ID | **Absent** — no stable StoryGraph identifier to key on. |
+
+Rows with a blank `Read Status` also have a blank `Date Added`; they carry only tags.
+
+## Key finding: re-reads are extra `Book` rows
+
+Yamtrack tracks multiple entries per item. `BasicMedia.filter_media` returns a queryset,
+`total_medias` and `instance_id` thread through the track modal and history modal, and
+`Media` has no unique constraint on `(user, item)`.
+
+The history calendar is built from live rows, not from simple-history:
+`history_cache_day_builder.py:176` reads `Book.start_date`/`Book.end_date` directly and never
+touches `HistoricalBook`. Hand-written `HistoricalBook` rows would therefore appear nowhere in
+the calendar or in statistics. A second `Book` row surfaces a re-read in the calendar, the
+statistics, and the item timeline with no new mechanics.
+
+**Decision:** one `Book` row per read.
+
+## Components
+
+### `src/integrations/imports/storygraph.py`
+
+`importer(file, user, mode)` delegating to `StoryGraphImporter`, mirroring `goodreads.py`:
+decode UTF-8 with a latin-1 fallback, `DictReader`, per-row try/except that converts
+`services.ProviderAPIError` into a warning and any other exception into
+`MediaImportUnexpectedError`, then `helpers.cleanup_existing_media` +
+`helpers.bulk_create_media`, returning `(imported_counts, deduplicated_messages)`.
+
+### Book resolution
+
+Resolutions are cached within a run, keyed by the normalized ISBN or `title|authors`.
+
+1. `ISBN/UID` counts as an ISBN only when it is 10 or 13 digits after stripping dashes.
+   ASINs and blanks skip straight to text search.
+2. Query ladder — for each provider in `(hardcover, openlibrary)`, try `isbn`, then
+   `"{title} {first author}"`, then `title`.
+3. A candidate is accepted only when its title fuzzy-matches the CSV title and its authors do
+   not conflict with the CSV authors, the tiering `storyteller.py` uses. Reimplemented
+   compactly inside this module: `storyteller.py` works today and its matcher is entangled
+   with its own thresholds, so it is not refactored for reuse.
+4. `services.get_media_metadata` on the winner supplies `max_progress` (page count).
+5. No match produces a warning naming the title and the row is skipped.
+
+OpenLibrary as the second provider also means self-hosters without `HARDCOVER_API`
+configured still get results.
+
+### Row to entries
+
+`Dates Read` splits on commas; each part is either `A-B` (start = A, end = B) or a bare
+`YYYY/MM/DD`, which StoryGraph writes when only the finish date is known — that becomes
+`end_date` with `start_date` left null rather than inventing a same-day start. Reads are
+sorted oldest to newest and created in that order, so the newest read ends up first under
+`Media.Meta.ordering` (`-created_at`).
+
+| CSV state | Result |
+| --- | --- |
+| `read`, N date ranges | N rows, each `Completed`, with that read's start/end, `_history_date` = its end date |
+| `read`, no dates | 1 row, `Completed`, no dates, `_history_date` = `Date Added` or now |
+| `currently-reading` | 1 row, `In progress`, **no dates** |
+| `to-read` or blank | 1 row, `Planning`, no dates |
+| `did-not-finish` | 1 row, `Dropped`, no dates |
+
+`Date Added` is when a book was shelved, not when reading began — the export has
+`currently-reading` rows added years earlier — so it never becomes a `start_date`. It is used
+only as the simple-history timestamp for dateless rows, which feeds neither the calendar nor
+statistics.
+
+`Star Rating` ×2 and `Review` land on the newest entry only; earlier reads get `score=None`
+and empty notes. `statistics_cache.py:458` aggregates every `Book` row with a non-null score,
+so repeating one StoryGraph rating across re-read rows would count it twice.
+
+Progress is the resolved provider's `max_progress` on `Completed` entries, 0 otherwise.
+
+### Deduplication and modes
+
+Existing `Book` rows for the user are preloaded, keyed by `(source, media_id)` to the set of
+end dates (date granularity, not datetime) already tracked, plus a flag for dateless entries.
+
+- **`new` mode:** create only reads whose end date is not already tracked for that item. A
+  dateless read is created only when the item has no entries at all. This deliberately
+  departs from `helpers.should_process_media`, which skips a known item wholesale — under
+  that rule a read added in StoryGraph after the first import could never arrive.
+- **`overwrite` mode:** matched items go through `cleanup_existing_media` as usual and every
+  entry is rebuilt from the CSV.
+
+Duplicate end dates within a single file are collapsed the same way.
+
+### Tags to custom lists
+
+`Tags` splits on commas. Per tag:
+`CustomList.objects.get_or_create(owner=user, name=tag, source="local")` then
+`CustomListItem.objects.get_or_create(item=item, custom_list=..., added_by=user)`, following
+`lists/imports/trakt.py`. Membership is idempotent by the model's unique constraint.
+
+### Format
+
+`digital → ebook`, `audio → audiobook`, `paperback → paperback`, `hardcover → hardcover`,
+written to `Item.format` **only when it is empty**, the `services/tracking_hydration.py:405`
+pattern. `Item` rows are shared across users, so a provider value or another user's value is
+never overwritten.
+
+`Book.formatted_progress` renders progress as HH:MM when the format is `audiobook`, so
+`audio` rows keep progress 0 rather than storing a page count that would display as a runtime.
+
+### Wiring
+
+- Celery task `Import from StoryGraph` in `integrations/tasks/_media_imports.py`, exported
+  from `integrations/tasks/__init__.py`.
+- `import_storygraph` view in `integrations/views.py` reading the `storygraph_csv` upload,
+  plus the route in `integrations/urls.py`.
+- `users/templatetags/user_tags.py` source entry and a `static/img/storygraph-logo.svg` mark.
+- Upload card in `templates/users/import_data.html`, alongside Goodreads and Hardcover.
+- Task-name entry in `users/models.py` so import history resolves the label.
+- `api/fork_views_integrations.py` map entry, exposing `POST /api/integrations/import/storygraph`.
+- Wiki import documentation.
+
+### Incomplete-date report
+
+StoryGraph exports are commonly missing read dates, and those gaps are fixable at the source.
+The import summary therefore ends with two informational lines listing affected titles, so the
+user can correct them in StoryGraph and re-import (the deduplication rules above make a
+re-import safe):
+
+- books imported as `read` with no read dates at all
+- reads imported with a finish date but no start date
+
+They are appended to the same warnings string the other CSV importers return, after any real
+warnings, and prefixed so they read as informational rather than as failures.
+
+## Error handling
+
+- Unreadable upload → `MediaImportError("Invalid file format. Please upload a CSV file.")`.
+- Provider failure on a row → warning, row skipped, import continues.
+- Unresolvable book → warning naming the title, row skipped.
+- Anything else → `MediaImportUnexpectedError` carrying the row, aborting the task.
+- Warnings are deduplicated before being returned, as in the other CSV importers.
+
+## Testing
+
+`src/integrations/tests/mock_data/import_storygraph.csv`, hand-written, covering: ISBN-13 hit,
+ASIN falling back to title search, missing ISBN, a two-range re-read, `currently-reading`,
+`to-read`, `did-not-finish`, blank status with tags, `audio` format, a review, and a half-star
+rating.
+
+`src/integrations/tests/imports/test_storygraph.py` with `services.search` and
+`services.get_media_metadata` mocked:
+
+- Read counts and per-entry start/end dates, including two rows for the re-read.
+- Rating and review on the newest entry only; earlier read has no score.
+- Re-importing the same file creates nothing new.
+- Re-importing a file with one extra read date creates exactly one row.
+- `overwrite` mode rebuilds entries.
+- Tags create lists and idempotent membership.
+- Format written only when `Item.format` is empty; audio rows keep progress 0.
+- Completed rows take page count from provider metadata.
+- Unmatched book produces a warning and no entry.
+- The incomplete-date report lists the dateless read and the finish-date-only read, and stays
+  empty when every read has both dates.
+- Status mapping for every `Read Status` value, blank included.
+
+Task registration is covered by the existing `test_task_registration.py` pattern.
+
+## Out of scope
+
+- Ryot import (separate export format, separate issue scope).
+- `Moods`, `Pace`, the five content-question columns, `Content Warnings`, and `Owned?` —
+  Yamtrack has no field for them and cramming them into notes helps nobody.
+- Scraping StoryGraph for periodic sync; this is a one-off file upload, and the import UI
+  already blocks file uploads for scheduled imports.

--- a/docs/superpowers/specs/2026-07-26-storygraph-incomplete-dates.md
+++ b/docs/superpowers/specs/2026-07-26-storygraph-incomplete-dates.md
@@ -1,0 +1,144 @@
+# StoryGraph rows with incomplete read dates
+
+Source: ea51fe84...csv (280 rows)
+
+## Read, but no read dates at all (38)
+
+| Title | Authors | Format | Date Added |
+| --- | --- | --- | --- |
+| A Clash of Kings | George R.R. Martin | paperback | 2013/06/04 |
+| A Dance with Dragons: After the Feast | George R.R. Martin | digital | 2013/06/04 |
+| A Dance with Dragons: Dreams and Dust | George R.R. Martin | paperback | 2013/06/04 |
+| A Feast for Crows | George R.R. Martin | paperback | 2013/06/04 |
+| A Game of Thrones | George R.R. Martin | paperback | 2013/06/04 |
+| A Storm of Swords: Steel and Snow | George R.R. Martin | paperback | 2013/06/04 |
+| Búrka mečov 2: Krv a zlato | George R.R. Martin | hardcover | 2013/06/04 |
+| Daemon | Daniel Suarez | hardcover | 2013/06/13 |
+| Drupal 7 Module Development | Larry Garfield, John Wilkins, Matt Butcher | paperback | 2014/02/06 |
+| Drupal 7 Multilingual Sites | Kristen Pol | paperback | 2014/02/06 |
+| Dutch for Dummies | Margreet Kwakernaak | paperback | 2021/01/09 |
+| Freedom™ | Daniel Suarez | hardcover | 2013/06/13 |
+| Harry Potter and the Chamber of Secrets | J.K. Rowling | audio | 2013/06/16 |
+| Harry Potter and the Deathly Hallows | J.K. Rowling | audio | 2013/06/16 |
+| Harry Potter and the Goblet of Fire | J.K. Rowling | hardcover | 2013/06/16 |
+| Harry Potter and the Half-Blood Prince | J.K. Rowling | paperback | 2013/06/16 |
+| Harry Potter and the Order of the Phoenix | J.K. Rowling | paperback | 2013/06/16 |
+| Harry Potter and the Prisoner of Azkaban | J.K. Rowling | paperback | 2013/06/16 |
+| Harry Potter and the Sorcerer's Stone | J.K. Rowling | paperback | 2013/06/16 |
+| I Am The Secret Footballer: Lifting the Lid on the Beautiful Game | The Secret Footballer | paperback | 2013/11/18 |
+| King of Thorns | Mark Lawrence | hardcover | 2013/06/04 |
+| Modern VIM: Craft Your Development Environment with VIM 8 and Neovim | Drew Neil | paperback | 2022/01/16 |
+| Practical VIM: Edit Text at the Speed of Thought | Drew Neil | paperback | 2022/01/16 |
+| Prince of Fools | Mark Lawrence | hardcover | 2015/08/09 |
+| Prince of Thorns | Mark Lawrence | hardcover | 2013/06/06 |
+| Pro Drupal 7 Development | Todd Tomlinson, John Vandyk | paperback | 2014/02/06 |
+| Red Sister | Mark Lawrence | paperback | 2019/12/02 |
+| The Blood that Burns the Winter Snow | Ryan Cahill | digital | 2025/05/09 |
+| The Fellowship of the Ring  | J.R.R. Tolkien | paperback | 2013/06/16 |
+| The God Delusion | Richard Dawkins | hardcover | 2013/06/16 |
+| The Hedge Knight | George R.R. Martin | digital | 2014/12/06 |
+| The Hedge Knight II: Sworn Sword | Ben Avery | hardcover | 2014/12/06 |
+| The Hobbit | J.R.R. Tolkien | audio | 2013/06/16 |
+| The Liar's Key | Mark Lawrence | paperback | 2015/08/09 |
+| The Lord of the Rings | J.R.R. Tolkien | paperback | 2013/06/16 |
+| The Return of the King | J.R.R. Tolkien | paperback | 2013/06/16 |
+| The Two Towers | J.R.R. Tolkien | paperback | 2013/06/16 |
+| Ve(e)rkracht | Lore Baeten | paperback | 2020/11/01 |
+
+## Read, finish date only (no start date) (93)
+
+| Title | Authors | Dates Read |
+| --- | --- | --- |
+| A Little Hatred | Joe Abercrombie | 2021/03/30 |
+| A Time Of Dread | John Gwynne | 2021/04/28 |
+| A Time of Blood | John Gwynne | 2021/05/03 |
+| A Time of Courage | John Gwynne | 2021/05/07 |
+| Assassin's Apprentice - Illustrated Edition | Robin Hobb | 2021/10/20 |
+| Assassin's Quest | Robin Hobb | 2021/11/03 |
+| Baptism of Fire | Andrzej Sapkowski | 2020/12/22 |
+| Before They Are Hanged | Joe Abercrombie | 2021/02/09 |
+| Best Served Cold | Joe Abercrombie | 2021/03/01 |
+| Blood Song | Anthony Ryan | 2021/06/03 |
+| Blood of Dragons | Robin Hobb | 2022/01/11 |
+| Blood of Elves | Andrzej Sapkowski | 2020/12/06 |
+| Bound | Mark Lawrence | 2019/12/22 |
+| City of Dragons | Robin Hobb | 2022/01/06 |
+| Creating Flat Design Websites | Antonio Pratas | 2014/10/15 |
+| Critical Chain | Eliyahu M. Goldratt | 2020/04/03 |
+| De ongelovige Thomas heeft een punt | Maarten Boudry, Johan Braeckman | 2013/08/02 |
+| Dispel Illusion | Mark Lawrence | 2021/01/17 |
+| Dit is agile | Sander Hoogendoorn | 2014/10/26 |
+| Dragon Haven | Robin Hobb | 2022/01/02 |
+| Dragon Keeper | Robin Hobb | 2021/12/27 |
+| Drupal 7 Views Cookbook | J. A. Green | 2013/07/14 |
+| Drupal for Education and Elearning (2nd Edition) | James Gordon Robertson | 2013/09/10 |
+| Drush User's Guide | Juan Pablo Novillo Requena | 2013/11/20 |
+| During the Dance | Mark Lawrence | 2020/04/12 |
+| Emperor of Thorns | Mark Lawrence | 2013/08/14 |
+| Fear: Trump in the White House | Bob Woodward | 2019/12/15 |
+| Fool's Assassin | Robin Hobb | 2022/01/23 |
+| Fool's Errand | Robin Hobb | 2021/12/04 |
+| Fool's Fate | Robin Hobb | 2021/12/21 |
+| Fool's Quest | Robin Hobb | 2022/02/07 |
+| Freakonomics: A Rogue Economist Explores the Hidden Side of Everything | Steven D. Levitt, Stephen J. Dubner | 2013/12/28 |
+| Golden Fool | Robin Hobb | 2021/12/12 |
+| Grey Sister | Mark Lawrence | 2019/12/18 |
+| Half a King | Joe Abercrombie | 2021/10/03 |
+| Half a War | Joe Abercrombie | 2021/10/12 |
+| Half the World | Joe Abercrombie | 2021/10/08 |
+| Holy Sister | Mark Lawrence | 2019/12/25 |
+| How Not to Get Shot: And Other Advice From White People | D.L. Hughley, Doug Moe | 2021/01/09 |
+| Je hebt wél iets te verbergen | Maurits Martijn, Dimitri Tokmetzis | 2020/11/01 |
+| Lady of the Lake | Andrzej Sapkowski | 2021/01/03 |
+| Last Argument of Kings | Joe Abercrombie | 2021/02/14 |
+| Limited Wish | Mark Lawrence | 2021/01/16 |
+| Mad Ship | Robin Hobb | 2021/11/22 |
+| Malice | John Gwynne | 2021/05/12 |
+| One Word Kill | Mark Lawrence | 2021/01/13 |
+| Principles of Package Design: Preparing your code for reuse | Matthias Noback | 2019/12/12 |
+| Queen of Fire | Anthony Ryan | 2021/06/27 |
+| Red Country | Joe Abercrombie | 2021/03/20 |
+| Royal Assassin | Robin Hobb | 2021/10/27 |
+| Ruin | John Gwynne | 2021/05/20 |
+| Sandrunners | Anthony Ryan | 2021/07/26 |
+| Season of Storms | Andrzej Sapkowski | 2021/01/07 |
+| Sharp Ends | Joe Abercrombie | 2021/04/14 |
+| Ship of Destiny | Robin Hobb | 2021/11/26 |
+| Ship of Magic | Robin Hobb | 2021/11/13 |
+| Sleeping Beauty | Mark Lawrence | 2015/08/10 |
+| Spanish Essentials For Dummies | Gail Stein, Mary Kraynak | 2020/04/04 |
+| Standing on the Shoulders of Giants | Eliyahu M. Goldratt | 2020/03/31 |
+| Sunburn: The unofficial history of the Sun newspaper in 99 headlines | James Felton | 2021/09/03 |
+| Sword of Destiny | Andrzej Sapkowski | 2020/11/19 |
+| The Black Song | Anthony Ryan | 2021/07/11 |
+| The Blade Itself | Joe Abercrombie | 2021/02/02 |
+| The Empire of Ashes | Anthony Ryan | 2021/07/25 |
+| The Fates of Yoran | D.K. Holmberg | 2021/08/09 |
+| The Girl and the Mountain | Mark Lawrence | 2021/04/23 |
+| The Girl and the Stars | Mark Lawrence | 2021/04/18 |
+| The Goal: A Process of Ongoing Improvement | Eliyahu M. Goldratt | 2020/03/31 |
+| The Heroes | Joe Abercrombie | 2021/03/11 |
+| The Jade Egg | D.K. Holmberg | 2021/08/02 |
+| The Last Wish | Andrzej Sapkowski | 2020/01/12 |
+| The Legion of Flame | Anthony Ryan | 2021/07/21 |
+| The No Asshole Rule: Building a Civilised Workplace and Surviving One That Isn't | Robert I. Sutton | 2021/01/22 |
+| The Numbers Game: Why Everything You Know about Soccer Is Wrong | David Sally, Chris Anderson | 2014/12/03 |
+| The Order Returns | D.K. Holmberg | 2021/09/26 |
+| The Paper Dragon | D.K. Holmberg | 2021/08/22 |
+| The Phoenix Project: A Novel about IT, DevOps, and Helping Your Business Win | George Spafford, Gene Kim, Kevin Behr | 2020/03/28 |
+| The Risen Shard | D.K. Holmberg | 2021/07/29 |
+| The Shadow of the Gods | John Gwynne | 2022/10/29-2022/11/28, 2021/09/14 |
+| The Stone Wolf | D.K. Holmberg | 2021/08/11 |
+| The Tower Treasure | Franklin W. Dixon | 2020/04/07 |
+| The Tower of the Swallow | Andrzej Sapkowski | 2020/12/25 |
+| The Trouble with Peace | Joe Abercrombie | 2021/04/10 |
+| The Waking Fire | Anthony Ryan | 2021/07/17 |
+| The Wheel of Osheim | Mark Lawrence | 2016/06/24 |
+| The Wisdom of Crowds | Joe Abercrombie | 2021/09/23 |
+| The Wolf's Call | Anthony Ryan | 2021/07/05 |
+| Time of Contempt | Andrzej Sapkowski | 2020/12/15 |
+| Tower Lord | Anthony Ryan | 2021/06/14 |
+| Vagrant: Up and Running: Create and Manage Virtualized Development Environments | Mitchell Hashimoto | 2014/09/30 |
+| Valour | John Gwynne | 2021/05/15 |
+| Version Control with Git | Jon Loeliger | 2013/09/28 |
+| Wrath | John Gwynne | 2021/05/25 |

--- a/src/api/fork_views_integrations.py
+++ b/src/api/fork_views_integrations.py
@@ -34,6 +34,7 @@ _FILE_IMPORTS = {
     "imdb": (tasks.import_imdb, "IMDB CSV"),
     "goodreads": (tasks.import_goodreads, "Goodreads CSV"),
     "hardcover": (tasks.import_hardcover, "Hardcover CSV"),
+    "storygraph": (tasks.import_storygraph, "StoryGraph CSV"),
 }
 
 
@@ -51,8 +52,8 @@ class ImportDispatchView(drf_views.APIView):
 
     Username services (mal, anilist, kitsu, steam) take {"username", "mode"}.
     File services (yamtrack, trakt-collection, hltb, grouvee, imdb,
-    goodreads, hardcover) take a multipart upload in the "file" field plus
-    an optional "mode". Returns 202 with a task_id pollable at
+    goodreads, hardcover, storygraph) take a multipart upload in the "file"
+    field plus an optional "mode". Returns 202 with a task_id pollable at
     /api/v1/tasks/{task_id}. Recurring schedules stay web-only.
     """
 

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -411,9 +411,29 @@ class StoryGraphImporter:
         source, media_id, metadata = resolved
         item = self._create_or_update_item(source, media_id, metadata, row)
         self._sync_tags(item, row)
+        self._record_date_gaps(item, row)
         tracked_dates = self._tracked_dates(source, media_id)
         for instance in self._build_entries(item, row, metadata, tracked_dates):
             self.bulk_media[MediaTypes.BOOK.value].append(instance)
+
+    def _record_date_gaps(self, item, row):
+        """Note date gaps in the row itself, regardless of dedup or mode.
+
+        The report describes the quality of the export, not what a given run
+        happened to write, so it is derived straight from the row's own
+        ``Read Status`` and ``Dates Read`` values every time the row is
+        processed - including on a re-import where every read is already
+        tracked and no new instance gets built.
+        """
+        if determine_status(row.get("Read Status")) != Status.COMPLETED.value:
+            return
+        reads = parse_reads(row.get("Dates Read"))
+        if not reads:
+            self.missing_read_dates.append(item.title)
+            return
+        for read in reads:
+            if not read.start:
+                self.missing_start_dates.append(item.title)
 
     def _load_tracked_reads(self):
         """Map each already-tracked book to the read dates it has."""
@@ -485,14 +505,16 @@ class StoryGraphImporter:
         return int(max_progress) if max_progress else 0
 
     def _report_lines(self):
-        """Describe the date gaps worth fixing in StoryGraph and re-importing."""
+        """Describe the date gaps in the export worth fixing in StoryGraph."""
         lines = []
         if self.missing_read_dates:
             titles = ", ".join(dict.fromkeys(self.missing_read_dates))
-            lines.append(f"Imported as read with no read date: {titles}")
+            lines.append(f"Marked read in StoryGraph with no read date: {titles}")
         if self.missing_start_dates:
             titles = ", ".join(dict.fromkeys(self.missing_start_dates))
-            lines.append(f"Imported with a finish date but no start date: {titles}")
+            lines.append(
+                f"Has a finish date in StoryGraph but no start date: {titles}",
+            )
         return lines
 
     def _build_entries(self, item, row, metadata, tracked_dates):
@@ -513,8 +535,6 @@ class StoryGraphImporter:
             if read_day in tracked_dates:
                 continue
             tracked_dates.add(read_day)
-            if not read.start:
-                self.missing_start_dates.append(item.title)
             instances.append(
                 self._build_instance(
                     item,
@@ -528,8 +548,6 @@ class StoryGraphImporter:
 
         if not reads and not had_entries:
             tracked_dates.add(None)
-            if status == Status.COMPLETED.value:
-                self.missing_read_dates.append(item.title)
             instances.append(
                 self._build_instance(item, status, None, None, progress, fallback_date),
             )

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -9,11 +9,14 @@ than from simple-history records.
 import logging
 import re
 from datetime import datetime
+from difflib import SequenceMatcher
 from typing import NamedTuple
 
 from django.utils import timezone
 
-from app.models import Status
+from app.log_safety import exception_summary
+from app.models import MediaTypes, Sources, Status
+from app.providers import services
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +35,11 @@ FORMAT_MAP = {
 ISBN_13_LENGTH = 13
 ISBN_10_LENGTH = 10
 MAX_STAR_RATING = 5
+BOOK_METADATA_PROVIDER_ORDER = (Sources.HARDCOVER.value, Sources.OPENLIBRARY.value)
+TITLE_MATCH_THRESHOLD = 0.72
+MAX_SEARCH_RESULTS = 5
+MAX_TITLE_CANDIDATES = 3
+BEST_TIER = 3
 
 
 class Read(NamedTuple):
@@ -126,3 +134,186 @@ def normalize_name(value):
     """Lowercase a title or name down to alphanumerics for comparison."""
     normalized = re.sub(r"[^a-z0-9]+", " ", str(value or "").lower())
     return re.sub(r"\s+", " ", normalized).strip()
+
+
+def title_similarity(left, right):
+    """Return a 0-1 similarity ratio between two normalized titles."""
+    left_normalized = normalize_name(left)
+    right_normalized = normalize_name(right)
+    if not left_normalized or not right_normalized:
+        return 0.0
+    return SequenceMatcher(None, left_normalized, right_normalized).ratio()
+
+
+def titles_match(left, right):
+    """Match titles, tolerating subtitles ('Mistborn' vs 'Mistborn: ...')."""
+    left_normalized = normalize_name(left)
+    right_normalized = normalize_name(right)
+    if not left_normalized or not right_normalized:
+        return False
+    if left_normalized == right_normalized:
+        return True
+    if right_normalized.startswith(left_normalized) or left_normalized.startswith(
+        right_normalized,
+    ):
+        return True
+    return title_similarity(left, right) >= TITLE_MATCH_THRESHOLD
+
+
+def authors_overlap(target_authors, provider_authors):
+    """Return True when two author name sets plausibly mean the same person."""
+    target = {name for name in map(normalize_name, target_authors) if name}
+    provider = {name for name in map(normalize_name, provider_authors) if name}
+    if not target or not provider:
+        return False
+    if target & provider:
+        return True
+    for left in target:
+        for right in provider:
+            if left in right or right in left:
+                return True
+            if left.split()[-1] == right.split()[-1]:  # shared surname
+                return True
+    return False
+
+
+def classify_authors(target_authors, candidate_authors):
+    """Classify author agreement as 'match', 'unknown', or 'conflict'."""
+    if not target_authors:
+        return "match"
+    if not candidate_authors:
+        return "unknown"
+    if authors_overlap(target_authors, candidate_authors):
+        return "match"
+    return "conflict"
+
+
+def extract_provider_authors(metadata):
+    """Pull author names out of provider metadata, whatever shape they take."""
+    details = metadata.get("details", {}) if isinstance(metadata, dict) else {}
+    if not isinstance(details, dict):
+        details = {}
+
+    raw_authors = details.get("authors") or details.get("author") or []
+    if isinstance(raw_authors, str):
+        raw_authors = [part.strip() for part in raw_authors.split(",") if part.strip()]
+    elif not isinstance(raw_authors, list):
+        raw_authors = [raw_authors] if raw_authors else []
+
+    authors = []
+    for raw_author in raw_authors:
+        value = (
+            raw_author.get("name") or raw_author.get("person")
+            if isinstance(raw_author, dict)
+            else raw_author
+        )
+        name = str(value or "").strip()
+        if name:
+            authors.append(name)
+    return list(dict.fromkeys(authors))
+
+
+class BookResolver:
+    """Resolve StoryGraph rows to books on Hardcover, then Open Library."""
+
+    def __init__(self, cache):
+        """Initialize with a dict used to memoize resolutions across rows."""
+        self.cache = cache
+
+    def resolve(self, title, authors, isbn):
+        """Return ``(source, media_id, metadata)`` for a book, or None."""
+        cache_key = isbn or (
+            f"{normalize_name(title)}|{normalize_name(' '.join(authors))}"
+        )
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+
+        resolved = self._search_providers(title, authors, isbn)
+        self.cache[cache_key] = resolved
+        return resolved
+
+    def _queries(self, title, authors, isbn):
+        """Build the ordered search queries for one book."""
+        queries = [isbn] if isbn else []
+        if title and authors:
+            queries.append(f"{title} {authors[0]}")
+        if title:
+            queries.append(title)
+        return list(dict.fromkeys(query for query in queries if query))
+
+    def _search_providers(self, title, authors, isbn):
+        """Walk the provider and query ladder, keeping the best candidate."""
+        best_tier = 0
+        best_result = None
+
+        for source in BOOK_METADATA_PROVIDER_ORDER:
+            for query in self._queries(title, authors, isbn):
+                tier, result = self._match_query(source, query, title, authors)
+                if tier > best_tier:
+                    best_tier, best_result = tier, result
+                    if best_tier == BEST_TIER:
+                        return best_result
+
+        return best_result
+
+    def _match_query(self, source, query, title, authors):
+        """Search one provider with one query, returning ``(tier, result)``."""
+        try:
+            response = services.search(MediaTypes.BOOK.value, query, 1, source)
+        except Exception as error:  # noqa: BLE001 - a bad provider must not stop the import
+            logger.debug(
+                "StoryGraph search failed source=%s error=%s",
+                source,
+                exception_summary(error),
+            )
+            return 0, None
+
+        results = response.get("results", []) if isinstance(response, dict) else []
+        best_tier = 0
+        best_result = None
+
+        for candidate in self._title_candidates(results, title):
+            media_id = candidate.get("media_id")
+            if not media_id:
+                continue
+
+            try:
+                metadata = services.get_media_metadata(
+                    MediaTypes.BOOK.value,
+                    str(media_id),
+                    source,
+                )
+            except Exception as error:  # noqa: BLE001 - same reasoning as above
+                logger.debug(
+                    "StoryGraph metadata fetch failed source=%s error=%s",
+                    source,
+                    exception_summary(error),
+                )
+                continue
+
+            if not titles_match(title, str(metadata.get("title") or "")):
+                continue
+
+            verdict = classify_authors(authors, extract_provider_authors(metadata))
+            if verdict == "conflict":
+                continue
+
+            tier = BEST_TIER if verdict == "match" else 2
+            if tier > best_tier:
+                best_tier = tier
+                best_result = (source, str(media_id), metadata)
+                if best_tier == BEST_TIER:
+                    break
+
+        return best_tier, best_result
+
+    def _title_candidates(self, results, title):
+        """Return the best title-matching search results, best first."""
+        scored = []
+        for result in results[:MAX_SEARCH_RESULTS]:
+            candidate_title = str(result.get("title") or "")
+            if not titles_match(title, candidate_title):
+                continue
+            scored.append((title_similarity(title, candidate_title), result))
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [result for _score, result in scored[:MAX_TITLE_CANDIDATES]]

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -8,15 +8,22 @@ than from simple-history records.
 
 import logging
 import re
+from collections import defaultdict
+from csv import DictReader
 from datetime import datetime
 from difflib import SequenceMatcher
 from typing import NamedTuple
 
+from django.apps import apps
+from django.conf import settings
 from django.utils import timezone
 
+import app
 from app.log_safety import exception_summary
 from app.models import MediaTypes, Sources, Status
 from app.providers import services
+from integrations.imports import helpers
+from integrations.imports.helpers import MediaImportError, MediaImportUnexpectedError
 
 logger = logging.getLogger(__name__)
 
@@ -317,3 +324,158 @@ class BookResolver:
             scored.append((title_similarity(title, candidate_title), result))
         scored.sort(key=lambda pair: pair[0], reverse=True)
         return [result for _score, result in scored[:MAX_TITLE_CANDIDATES]]
+
+
+def importer(file, user, mode):
+    """Import books from a StoryGraph export CSV."""
+    return StoryGraphImporter(file, user, mode).import_data()
+
+
+class StoryGraphImporter:
+    """Import a StoryGraph export, one tracked entry per read."""
+
+    def __init__(self, file, user, mode):
+        """Initialize the importer with the upload, user, and import mode."""
+        self.file = file
+        self.user = user
+        self.mode = mode
+        self.warnings = []
+
+        self.existing_media = helpers.get_existing_media(user)
+        self.to_delete = defaultdict(lambda: defaultdict(set))
+        self.bulk_media = defaultdict(list)
+        self.resolver = BookResolver({})
+
+        logger.info(
+            "Initialized StoryGraph CSV importer for user %s with mode %s",
+            user.username,
+            mode,
+        )
+
+    def import_data(self):
+        """Import every row of the CSV and return counts plus messages."""
+        try:
+            raw_file = self.file.read()
+            try:
+                decoded_file = raw_file.decode("utf-8-sig").splitlines()
+            except UnicodeDecodeError:
+                decoded_file = raw_file.decode("latin-1").splitlines()
+        except (UnicodeDecodeError, AttributeError) as error:
+            msg = "Invalid file format. Please upload a CSV file."
+            raise MediaImportError(msg) from error
+
+        for row in DictReader(decoded_file):
+            try:
+                self._process_row(row)
+            except services.ProviderAPIError as error:
+                title = (row.get("Title") or "").strip() or str(row)
+                self.warnings.append(f"Error processing entry: {title} - {error}")
+                continue
+            except Exception as error:
+                error_msg = f"Error processing entry: {row}"
+                raise MediaImportUnexpectedError(error_msg) from error
+
+        helpers.cleanup_existing_media(self.to_delete, self.user)
+        helpers.bulk_create_media(self.bulk_media, self.user)
+
+        imported_counts = {
+            media_type: len(media_list)
+            for media_type, media_list in self.bulk_media.items()
+        }
+        return imported_counts, "\n".join(dict.fromkeys(self.warnings))
+
+    def _process_row(self, row):
+        """Resolve one CSV row and queue its tracked entries."""
+        title = (row.get("Title") or "").strip()
+        if not title:
+            return
+
+        resolved = self.resolver.resolve(
+            title,
+            parse_authors(row.get("Authors")),
+            normalize_isbn(row.get("ISBN/UID")),
+        )
+        if not resolved:
+            self.warnings.append(
+                f"{title}: couldn't find this book on Hardcover or Open Library",
+            )
+            return
+
+        source, media_id, metadata = resolved
+        item = self._create_or_update_item(source, media_id, metadata, row)
+        for instance in self._build_entries(item, row, metadata):
+            self.bulk_media[MediaTypes.BOOK.value].append(instance)
+
+    def _create_or_update_item(self, source, media_id, metadata, row):
+        """Create or update the item, filling in an empty format only."""
+        item, _ = app.models.Item.objects.update_or_create(
+            media_id=media_id,
+            source=source,
+            media_type=MediaTypes.BOOK.value,
+            defaults={
+                **app.models.Item.title_fields_from_metadata(
+                    metadata,
+                    fallback_title=(row.get("Title") or "").strip(),
+                ),
+                "image": metadata.get("image") or settings.IMG_NONE,
+            },
+        )
+
+        book_format = map_format(row.get("Format"))
+        if book_format and not item.format:
+            item.format = book_format
+            item.save(update_fields=["format"])
+
+        return item
+
+    def _page_count(self, item, metadata, status):
+        """Return the progress to store, in pages, for a tracked entry."""
+        if status != Status.COMPLETED.value or item.format == "audiobook":
+            return 0
+        max_progress = metadata.get("max_progress")
+        return int(max_progress) if max_progress else 0
+
+    def _build_entries(self, item, row, metadata):
+        """Build one unsaved Book per read, newest last."""
+        status = determine_status(row.get("Read Status"))
+        progress = self._page_count(item, metadata, status)
+        reads = (
+            parse_reads(row.get("Dates Read"))
+            if status == Status.COMPLETED.value
+            else []
+        )
+        fallback_date = parse_date(row.get("Date Added"))
+
+        instances = [
+            self._build_instance(
+                item, status, read.start, read.end, progress, fallback_date,
+            )
+            for read in reads
+        ]
+        if not instances:
+            instances.append(
+                self._build_instance(item, status, None, None, progress, fallback_date),
+            )
+
+        newest = instances[-1]
+        newest.score = parse_rating(row.get("Star Rating"))
+        newest.notes = (row.get("Review") or "").strip()
+        return instances
+
+    def _build_instance(
+        self, item, status, start_date, end_date, progress, fallback_date,
+    ):
+        """Build a single unsaved Book instance for one read."""
+        model = apps.get_model(app_label="app", model_name=MediaTypes.BOOK.value)
+        instance = model(
+            item=item,
+            user=self.user,
+            status=status,
+            progress=progress,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        instance._history_date = (
+            end_date or start_date or fallback_date or timezone.now()
+        )
+        return instance

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -1,0 +1,128 @@
+"""Importer for The StoryGraph's account export CSV.
+
+StoryGraph has no public API, so the export CSV is the supported path. Each
+read in the ``Dates Read`` column becomes its own ``Book`` row, which is how
+Yamtrack models re-reads: the history calendar is built from live rows rather
+than from simple-history records.
+"""
+
+import logging
+import re
+from datetime import datetime
+from typing import NamedTuple
+
+from django.utils import timezone
+
+from app.models import Status
+
+logger = logging.getLogger(__name__)
+
+STATUS_MAP = {
+    "read": Status.COMPLETED.value,
+    "currently-reading": Status.IN_PROGRESS.value,
+    "to-read": Status.PLANNING.value,
+    "did-not-finish": Status.DROPPED.value,
+}
+FORMAT_MAP = {
+    "digital": "ebook",
+    "audio": "audiobook",
+    "paperback": "paperback",
+    "hardcover": "hardcover",
+}
+ISBN_13_LENGTH = 13
+ISBN_10_LENGTH = 10
+MAX_STAR_RATING = 5
+
+
+class Read(NamedTuple):
+    """A single read interval with optional start date."""
+
+    start: datetime | None
+    end: datetime | None
+
+
+def parse_date(value):
+    """Parse a StoryGraph ``YYYY/MM/DD`` date into an aware datetime."""
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.strptime(text, "%Y/%m/%d")  # noqa: DTZ007 - tz applied below
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.get_current_timezone())
+
+
+def parse_reads(dates_read):
+    """Parse ``Dates Read`` into ordered reads, oldest first.
+
+    A dash separated chunk is a start and an end date. A bare date is a finish
+    date with no known start, so ``start`` stays ``None``.
+    """
+    reads = []
+    for chunk in str(dates_read or "").split(","):
+        pieces = [piece.strip() for piece in chunk.split("-") if piece.strip()]
+        dates = [date for date in map(parse_date, pieces) if date]
+        if not dates:
+            continue
+        if len(dates) == 1:
+            reads.append(Read(start=None, end=dates[0]))
+        else:
+            reads.append(Read(start=dates[0], end=dates[-1]))
+
+    reads.sort(key=lambda read: read.end or read.start)
+    return reads
+
+
+def determine_status(raw_status):
+    """Map a StoryGraph read status onto a Yamtrack status."""
+    return STATUS_MAP.get(
+        str(raw_status or "").strip().lower(),
+        Status.PLANNING.value,
+    )
+
+
+def parse_rating(raw_rating):
+    """Convert a 0-5 star rating with halves into a 0-10 score."""
+    text = str(raw_rating or "").strip()
+    if not text:
+        return None
+    try:
+        rating = float(text)
+    except ValueError:
+        return None
+    if rating <= 0:
+        return None
+    return round(min(rating, MAX_STAR_RATING) * 2, 1)
+
+
+def parse_tags(raw_tags):
+    """Split the comma separated ``Tags`` column, preserving order."""
+    tags = [tag.strip() for tag in str(raw_tags or "").split(",") if tag.strip()]
+    return list(dict.fromkeys(tags))
+
+
+def parse_authors(raw_authors):
+    """Split the comma separated ``Authors`` column."""
+    return [name.strip() for name in str(raw_authors or "").split(",") if name.strip()]
+
+
+def normalize_isbn(raw_isbn):
+    """Return the value as an ISBN, or ``""`` when it is an ASIN or junk."""
+    candidate = str(raw_isbn or "").strip().replace("-", "").replace(" ", "").upper()
+    if len(candidate) == ISBN_13_LENGTH and candidate.isdigit():
+        return candidate
+    if len(candidate) == ISBN_10_LENGTH and candidate[:9].isdigit():
+        return candidate
+    return ""
+
+
+def map_format(raw_format):
+    """Map a StoryGraph format onto the format values Yamtrack stores."""
+    return FORMAT_MAP.get(str(raw_format or "").strip().lower(), "")
+
+
+def normalize_name(value):
+    """Lowercase a title or name down to alphanumerics for comparison."""
+    normalized = re.sub(r"[^a-z0-9]+", " ", str(value or "").lower())
+    return re.sub(r"\s+", " ", normalized).strip()

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -19,7 +19,6 @@ from django.conf import settings
 from django.utils import timezone
 
 import app
-from app.log_safety import exception_summary
 from app.models import MediaTypes, Sources, Status
 from app.providers import services
 from integrations.imports import helpers
@@ -250,31 +249,52 @@ class BookResolver:
         return list(dict.fromkeys(query for query in queries if query))
 
     def _search_providers(self, title, authors, isbn):
-        """Walk the provider and query ladder, keeping the best candidate."""
+        """Walk the provider and query ladder, keeping the best candidate.
+
+        A ``ProviderAPIError`` on one query does not stop the ladder - Open
+        Library exists as a coverage fallback specifically for when
+        Hardcover is unavailable, so the next query or provider still gets
+        tried. Only when every query on every provider fails outright, with
+        no successful response from any of them, does the last failure
+        propagate - the caller must not be told the book was "not found"
+        when the truth is that nothing was ever actually checked. Any other
+        exception is genuinely unexpected and is not caught here at all, so
+        it can abort the import as the design spec requires.
+        """
         best_tier = 0
         best_result = None
+        last_error = None
+        any_success = False
 
         for source in BOOK_METADATA_PROVIDER_ORDER:
             for query in self._queries(title, authors, isbn):
-                tier, result = self._match_query(source, query, title, authors)
+                try:
+                    tier, result = self._match_query(source, query, title, authors)
+                except services.ProviderAPIError as error:
+                    last_error = error
+                    continue
+                any_success = True
                 if tier > best_tier:
                     best_tier, best_result = tier, result
                     if best_tier == BEST_TIER:
                         return best_result
 
+        if best_result is None and not any_success and last_error is not None:
+            raise last_error
+
         return best_result
 
     def _match_query(self, source, query, title, authors):
-        """Search one provider with one query, returning ``(tier, result)``."""
-        try:
-            response = services.search(MediaTypes.BOOK.value, query, 1, source)
-        except Exception as error:  # noqa: BLE001 - a bad provider must not stop the import
-            logger.debug(
-                "StoryGraph search failed source=%s error=%s",
-                source,
-                exception_summary(error),
-            )
-            return 0, None
+        """Search one provider with one query, returning ``(tier, result)``.
+
+        Provider failures are not caught here: ``services.search`` and
+        ``services.get_media_metadata`` only raise ``ProviderAPIError`` once
+        their own retries are exhausted, so it always represents a real
+        failure, and ``_search_providers`` is what decides whether to fall
+        back to the next provider or let it propagate. Any other exception
+        is unexpected and must propagate too.
+        """
+        response = services.search(MediaTypes.BOOK.value, query, 1, source)
 
         results = response.get("results", []) if isinstance(response, dict) else []
         best_tier = 0
@@ -285,19 +305,11 @@ class BookResolver:
             if not media_id:
                 continue
 
-            try:
-                metadata = services.get_media_metadata(
-                    MediaTypes.BOOK.value,
-                    str(media_id),
-                    source,
-                )
-            except Exception as error:  # noqa: BLE001 - same reasoning as above
-                logger.debug(
-                    "StoryGraph metadata fetch failed source=%s error=%s",
-                    source,
-                    exception_summary(error),
-                )
-                continue
+            metadata = services.get_media_metadata(
+                MediaTypes.BOOK.value,
+                str(media_id),
+                source,
+            )
 
             if not titles_match(title, str(metadata.get("title") or "")):
                 continue
@@ -346,7 +358,7 @@ class StoryGraphImporter:
         self.to_delete = defaultdict(lambda: defaultdict(set))
         self.bulk_media = defaultdict(list)
         self.resolver = BookResolver({})
-        self.tracked_reads = self._load_tracked_reads()
+        self.tracked_reads, self.tracked_statuses = self._load_tracked_reads()
         self._overwritten = set()
         self.list_cache = {}
         self.missing_read_dates = []
@@ -412,8 +424,10 @@ class StoryGraphImporter:
         item = self._create_or_update_item(source, media_id, metadata, row)
         self._sync_tags(item, row)
         self._record_date_gaps(item, row)
-        tracked_dates = self._tracked_dates(source, media_id)
-        for instance in self._build_entries(item, row, metadata, tracked_dates):
+        tracked_dates, tracked_statuses = self._tracked_state(source, media_id)
+        for instance in self._build_entries(
+            item, row, metadata, tracked_dates, tracked_statuses,
+        ):
             self.bulk_media[MediaTypes.BOOK.value].append(instance)
 
     def _record_date_gaps(self, item, row):
@@ -436,23 +450,44 @@ class StoryGraphImporter:
                 self.missing_start_dates.append(item.title)
 
     def _load_tracked_reads(self):
-        """Map each already-tracked book to the read dates it has."""
-        tracked = defaultdict(set)
+        """Map each already-tracked book to its completed dates and statuses.
+
+        ``tracked_dates`` is seeded only from existing ``Completed`` rows -
+        real end dates plus a ``None`` sentinel for a completed read that
+        was recorded with no date at all. ``tracked_statuses`` is seeded
+        from every other existing row, keyed to the status itself rather
+        than to a shared ``None`` sentinel.
+
+        Keeping these separate matters: every non-completed status
+        (Planning, In progress, Dropped) is created dateless by
+        construction, so a shared sentinel would make an existing Planning
+        row look identical to an existing dateless Completed row. That was
+        the bug - a Planning row left a ``None`` sentinel behind, so a later
+        export marking the same book finished with no recorded date (the
+        most common gap in real StoryGraph exports) was silently dropped
+        because the sentinel was already "used".
+        """
+        tracked_dates = defaultdict(set)
+        tracked_statuses = defaultdict(set)
         model = apps.get_model(app_label="app", model_name=MediaTypes.BOOK.value)
         for book in model.objects.filter(user=self.user).select_related("item"):
             key = (book.item.source, book.item.media_id)
-            tracked[key].add(book.end_date.date() if book.end_date else None)
-        return tracked
+            if book.status == Status.COMPLETED.value:
+                tracked_dates[key].add(book.end_date.date() if book.end_date else None)
+            else:
+                tracked_statuses[key].add(book.status)
+        return tracked_dates, tracked_statuses
 
-    def _tracked_dates(self, source, media_id):
-        """Return the read dates to skip, queueing a wipe in overwrite mode."""
+    def _tracked_state(self, source, media_id):
+        """Return the (dates, statuses) sets to skip, wiping both in overwrite mode."""
         key = (source, media_id)
         if self.mode == "overwrite" and key not in self._overwritten:
             self._overwritten.add(key)
             if media_id in self.existing_media[MediaTypes.BOOK.value][source]:
                 self.to_delete[MediaTypes.BOOK.value][source].add(media_id)
             self.tracked_reads[key] = set()
-        return self.tracked_reads[key]
+            self.tracked_statuses[key] = set()
+        return self.tracked_reads[key], self.tracked_statuses[key]
 
     def _create_or_update_item(self, source, media_id, metadata, row):
         """Create or update the item, filling in an empty format only."""
@@ -517,8 +552,17 @@ class StoryGraphImporter:
             )
         return lines
 
-    def _build_entries(self, item, row, metadata, tracked_dates):
-        """Build one unsaved Book per untracked read, newest last."""
+    def _build_entries(self, item, row, metadata, tracked_dates, tracked_statuses):
+        """Build one unsaved Book per untracked read, newest last.
+
+        A dateless entry is gated differently depending on whether the row
+        is Completed: a dateless Completed read is created once per item
+        (``tracked_dates`` carries the ``None`` sentinel for that), while a
+        dateless non-completed row is created once per status
+        (``tracked_statuses``) - so a Planning row followed by another
+        Planning row still does not duplicate, but a Planning row followed
+        by a dateless Completed row is not blocked by it.
+        """
         status = determine_status(row.get("Read Status"))
         progress = self._page_count(item, metadata, status)
         reads = (
@@ -546,11 +590,22 @@ class StoryGraphImporter:
                 ),
             )
 
-        if not reads and not had_entries:
-            tracked_dates.add(None)
-            instances.append(
-                self._build_instance(item, status, None, None, progress, fallback_date),
-            )
+        if not reads:
+            if status == Status.COMPLETED.value:
+                if not had_entries:
+                    tracked_dates.add(None)
+                    instances.append(
+                        self._build_instance(
+                            item, status, None, None, progress, fallback_date,
+                        ),
+                    )
+            elif status not in tracked_statuses:
+                tracked_statuses.add(status)
+                instances.append(
+                    self._build_instance(
+                        item, status, None, None, progress, fallback_date,
+                    ),
+                )
 
         if instances and not had_entries:
             # One StoryGraph rating covers the book, so it goes on the newest

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -349,6 +349,8 @@ class StoryGraphImporter:
         self.tracked_reads = self._load_tracked_reads()
         self._overwritten = set()
         self.list_cache = {}
+        self.missing_read_dates = []
+        self.missing_start_dates = []
 
         logger.info(
             "Initialized StoryGraph CSV importer for user %s with mode %s",
@@ -386,7 +388,8 @@ class StoryGraphImporter:
             media_type: len(media_list)
             for media_type, media_list in self.bulk_media.items()
         }
-        return imported_counts, "\n".join(dict.fromkeys(self.warnings))
+        messages = list(dict.fromkeys(self.warnings)) + self._report_lines()
+        return imported_counts, "\n".join(messages)
 
     def _process_row(self, row):
         """Resolve one CSV row and queue its tracked entries."""
@@ -481,6 +484,17 @@ class StoryGraphImporter:
         max_progress = metadata.get("max_progress")
         return int(max_progress) if max_progress else 0
 
+    def _report_lines(self):
+        """Describe the date gaps worth fixing in StoryGraph and re-importing."""
+        lines = []
+        if self.missing_read_dates:
+            titles = ", ".join(dict.fromkeys(self.missing_read_dates))
+            lines.append(f"Imported as read with no read date: {titles}")
+        if self.missing_start_dates:
+            titles = ", ".join(dict.fromkeys(self.missing_start_dates))
+            lines.append(f"Imported with a finish date but no start date: {titles}")
+        return lines
+
     def _build_entries(self, item, row, metadata, tracked_dates):
         """Build one unsaved Book per untracked read, newest last."""
         status = determine_status(row.get("Read Status"))
@@ -499,6 +513,8 @@ class StoryGraphImporter:
             if read_day in tracked_dates:
                 continue
             tracked_dates.add(read_day)
+            if not read.start:
+                self.missing_start_dates.append(item.title)
             instances.append(
                 self._build_instance(
                     item,
@@ -512,6 +528,8 @@ class StoryGraphImporter:
 
         if not reads and not had_entries:
             tracked_dates.add(None)
+            if status == Status.COMPLETED.value:
+                self.missing_read_dates.append(item.title)
             instances.append(
                 self._build_instance(item, status, None, None, progress, fallback_date),
             )

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -24,6 +24,7 @@ from app.models import MediaTypes, Sources, Status
 from app.providers import services
 from integrations.imports import helpers
 from integrations.imports.helpers import MediaImportError, MediaImportUnexpectedError
+from lists.models import CustomList, CustomListItem
 
 logger = logging.getLogger(__name__)
 
@@ -347,6 +348,7 @@ class StoryGraphImporter:
         self.resolver = BookResolver({})
         self.tracked_reads = self._load_tracked_reads()
         self._overwritten = set()
+        self.list_cache = {}
 
         logger.info(
             "Initialized StoryGraph CSV importer for user %s with mode %s",
@@ -405,6 +407,7 @@ class StoryGraphImporter:
 
         source, media_id, metadata = resolved
         item = self._create_or_update_item(source, media_id, metadata, row)
+        self._sync_tags(item, row)
         tracked_dates = self._tracked_dates(source, media_id)
         for instance in self._build_entries(item, row, metadata, tracked_dates):
             self.bulk_media[MediaTypes.BOOK.value].append(instance)
@@ -449,6 +452,27 @@ class StoryGraphImporter:
             item.save(update_fields=["format"])
 
         return item
+
+    def _sync_tags(self, item, row):
+        """Mirror the row's tags as custom lists holding this item."""
+        for tag in parse_tags(row.get("Tags")):
+            custom_list = self.list_cache.get(tag)
+            if custom_list is None:
+                custom_list = CustomList.objects.filter(
+                    owner=self.user,
+                    name=tag,
+                ).first() or CustomList.objects.create(
+                    owner=self.user,
+                    name=tag,
+                    source="local",
+                )
+                self.list_cache[tag] = custom_list
+
+            CustomListItem.objects.get_or_create(
+                item=item,
+                custom_list=custom_list,
+                defaults={"added_by": self.user},
+            )
 
     def _page_count(self, item, metadata, status):
         """Return the progress to store, in pages, for a tracked entry."""

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -346,6 +346,7 @@ class StoryGraphImporter:
         self.bulk_media = defaultdict(list)
         self.resolver = BookResolver({})
         self.tracked_reads = self._load_tracked_reads()
+        self._overwritten = set()
 
         logger.info(
             "Initialized StoryGraph CSV importer for user %s with mode %s",
@@ -419,11 +420,13 @@ class StoryGraphImporter:
 
     def _tracked_dates(self, source, media_id):
         """Return the read dates to skip, queueing a wipe in overwrite mode."""
-        if self.mode == "overwrite":
+        key = (source, media_id)
+        if self.mode == "overwrite" and key not in self._overwritten:
+            self._overwritten.add(key)
             if media_id in self.existing_media[MediaTypes.BOOK.value][source]:
                 self.to_delete[MediaTypes.BOOK.value][source].add(media_id)
-            self.tracked_reads[(source, media_id)] = set()
-        return self.tracked_reads[(source, media_id)]
+            self.tracked_reads[key] = set()
+        return self.tracked_reads[key]
 
     def _create_or_update_item(self, source, media_id, metadata, row):
         """Create or update the item, filling in an empty format only."""

--- a/src/integrations/imports/storygraph.py
+++ b/src/integrations/imports/storygraph.py
@@ -345,6 +345,7 @@ class StoryGraphImporter:
         self.to_delete = defaultdict(lambda: defaultdict(set))
         self.bulk_media = defaultdict(list)
         self.resolver = BookResolver({})
+        self.tracked_reads = self._load_tracked_reads()
 
         logger.info(
             "Initialized StoryGraph CSV importer for user %s with mode %s",
@@ -403,8 +404,26 @@ class StoryGraphImporter:
 
         source, media_id, metadata = resolved
         item = self._create_or_update_item(source, media_id, metadata, row)
-        for instance in self._build_entries(item, row, metadata):
+        tracked_dates = self._tracked_dates(source, media_id)
+        for instance in self._build_entries(item, row, metadata, tracked_dates):
             self.bulk_media[MediaTypes.BOOK.value].append(instance)
+
+    def _load_tracked_reads(self):
+        """Map each already-tracked book to the read dates it has."""
+        tracked = defaultdict(set)
+        model = apps.get_model(app_label="app", model_name=MediaTypes.BOOK.value)
+        for book in model.objects.filter(user=self.user).select_related("item"):
+            key = (book.item.source, book.item.media_id)
+            tracked[key].add(book.end_date.date() if book.end_date else None)
+        return tracked
+
+    def _tracked_dates(self, source, media_id):
+        """Return the read dates to skip, queueing a wipe in overwrite mode."""
+        if self.mode == "overwrite":
+            if media_id in self.existing_media[MediaTypes.BOOK.value][source]:
+                self.to_delete[MediaTypes.BOOK.value][source].add(media_id)
+            self.tracked_reads[(source, media_id)] = set()
+        return self.tracked_reads[(source, media_id)]
 
     def _create_or_update_item(self, source, media_id, metadata, row):
         """Create or update the item, filling in an empty format only."""
@@ -435,8 +454,8 @@ class StoryGraphImporter:
         max_progress = metadata.get("max_progress")
         return int(max_progress) if max_progress else 0
 
-    def _build_entries(self, item, row, metadata):
-        """Build one unsaved Book per read, newest last."""
+    def _build_entries(self, item, row, metadata, tracked_dates):
+        """Build one unsaved Book per untracked read, newest last."""
         status = determine_status(row.get("Read Status"))
         progress = self._page_count(item, metadata, status)
         reads = (
@@ -445,21 +464,40 @@ class StoryGraphImporter:
             else []
         )
         fallback_date = parse_date(row.get("Date Added"))
+        had_entries = bool(tracked_dates)
 
-        instances = [
-            self._build_instance(
-                item, status, read.start, read.end, progress, fallback_date,
+        instances = []
+        for read in reads:
+            read_day = read.end.date() if read.end else None
+            if read_day in tracked_dates:
+                continue
+            tracked_dates.add(read_day)
+            instances.append(
+                self._build_instance(
+                    item,
+                    status,
+                    read.start,
+                    read.end,
+                    progress,
+                    fallback_date,
+                ),
             )
-            for read in reads
-        ]
-        if not instances:
+
+        if not reads and not had_entries:
+            tracked_dates.add(None)
             instances.append(
                 self._build_instance(item, status, None, None, progress, fallback_date),
             )
 
-        newest = instances[-1]
-        newest.score = parse_rating(row.get("Star Rating"))
-        newest.notes = (row.get("Review") or "").strip()
+        if instances and not had_entries:
+            # One StoryGraph rating covers the book, so it goes on the newest
+            # entry only - repeating it per re-read would double count it in
+            # statistics. A book that already has entries carries its rating
+            # there, so a newly added re-read is left unrated.
+            newest = instances[-1]
+            newest.score = parse_rating(row.get("Star Rating"))
+            newest.notes = (row.get("Review") or "").strip()
+
         return instances
 
     def _build_instance(

--- a/src/integrations/tasks/__init__.py
+++ b/src/integrations/tasks/__init__.py
@@ -50,6 +50,7 @@ from integrations.tasks._media_imports import (
     import_sonarr,
     import_sonarr_recurring,
     import_steam,
+    import_storygraph,
     import_storyteller,
     import_storyteller_recurring,
     import_stremio,

--- a/src/integrations/tasks/__init__.py
+++ b/src/integrations/tasks/__init__.py
@@ -50,7 +50,7 @@ from integrations.tasks._media_imports import (
     import_sonarr,
     import_sonarr_recurring,
     import_steam,
-    import_storygraph,
+    import_storygraph,  # noqa: F401 - re-exported for tasks.import_storygraph
     import_storyteller,
     import_storyteller_recurring,
     import_stremio,

--- a/src/integrations/tasks/_media_imports.py
+++ b/src/integrations/tasks/_media_imports.py
@@ -27,6 +27,7 @@ from integrations.imports import (
     simkl,
     sonarr,
     steam,
+    storygraph,
     storyteller,
     stremio,
     trakt,
@@ -236,6 +237,12 @@ def import_goodreads_dotted(file, user_id, mode):
 def import_hardcover(file, user_id, mode):
     """Celery task for importing media data from Hardcover."""
     return import_media(hardcover.importer, _coerce_uploaded_file(file), user_id, mode)
+
+
+@shared_task(name="Import from StoryGraph")
+def import_storygraph(file, user_id, mode):
+    """Celery task for importing media data from StoryGraph."""
+    return import_media(storygraph.importer, _coerce_uploaded_file(file), user_id, mode)
 
 
 @shared_task(name="Import from Plex")

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -621,3 +621,60 @@ class ImportStoryGraphDeduplication(TestCase):
         books = Book.objects.filter(user=self.user, item__title="The Blade Itself")
         self.assertEqual(books.count(), 1)
         self.assertEqual(float(books.get().score), 9.0)
+
+
+class ImportStoryGraphDateReport(TestCase):
+    """Tests for the incomplete-date report in the import summary."""
+
+    def setUp(self):
+        """Create the user and import the fixture."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            self.counts, self.messages = storygraph.importer(file, self.user, "new")
+
+    def test_books_read_without_dates_listed(self):
+        """A read with no dates at all is named in the summary."""
+        self.assertIn("No Isbn Book", self.messages)
+        self.assertIn("no read date", self.messages)
+
+    def test_reads_without_start_date_listed(self):
+        """A read with a finish date but no start date is named."""
+        self.assertIn("Kindle Only", self.messages)
+        self.assertIn("no start date", self.messages)
+
+    def test_complete_reads_not_listed(self):
+        """A read with both dates is not reported."""
+        report = [line for line in self.messages.splitlines() if "date" in line]
+        self.assertNotIn("The Blade Itself", "\n".join(report))
+
+    def test_report_absent_when_dates_complete(self):
+        """An export with complete dates produces no report lines."""
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            'The Blade Itself,Joe Abercrombie,"",9780575079793,digital,read,'
+            "2021/01/01,2021/02/09,2021/01/20-2021/02/09,1,"
+            '"",,,,,,,4.5,Grim and funny.,"",,"fantasy",No'
+        )
+        user = get_user_model().objects.create_user(
+            username="other",
+            password="12345",  # noqa: S106 - test credential
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), BytesIO(f"{header}\n{row}\n".encode()) as file:
+            _counts, messages = storygraph.importer(file, user, "new")
+
+        self.assertEqual(messages, "")

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from app.models import Book, Item, Sources, Status
 from integrations.imports import storygraph
+from lists.models import CustomList, CustomListItem
 
 
 class ParseReads(SimpleTestCase):
@@ -481,6 +482,55 @@ class ImportStoryGraph(TestCase):
         book = self._books("The Blade Itself").get()
         record = book.history.first()
         self.assertEqual(record.history_date.date(), datetime(2021, 2, 9).date())  # noqa: DTZ001
+
+
+class ImportStoryGraphTags(TestCase):
+    """Tests for mapping StoryGraph tags onto custom lists."""
+
+    def setUp(self):
+        """Create the user and import the fixture."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self._import()
+
+    def _import(self):
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            return storygraph.importer(file, self.user, "new")
+
+    def test_lists_created_from_tags(self):
+        """Each tag becomes a local custom list owned by the user."""
+        names = set(
+            CustomList.objects.filter(owner=self.user).values_list("name", flat=True),
+        )
+        self.assertEqual(names, {"fantasy", "management", "spanish"})
+
+    def test_items_added_to_their_lists(self):
+        """A tagged book joins every list its tags name."""
+        tagged = Item.objects.get(title="Tagged Only Book")
+        list_names = set(
+            CustomListItem.objects.filter(item=tagged).values_list(
+                "custom_list__name",
+                flat=True,
+            ),
+        )
+        self.assertEqual(list_names, {"management", "spanish"})
+
+    def test_membership_is_idempotent(self):
+        """Re-importing does not duplicate lists or memberships."""
+        self._import()
+        self.assertEqual(CustomList.objects.filter(owner=self.user).count(), 3)
+        self.assertEqual(
+            CustomListItem.objects.filter(custom_list__owner=self.user).count(),
+            3,
+        )
 
 
 class ImportStoryGraphDeduplication(TestCase):

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -9,9 +9,11 @@ from django.urls import reverse
 from django.utils import timezone
 
 from app.models import Book, Item, Sources, Status
+from app.providers import services
 from config.celery import app as celery_app
 from integrations import tasks
 from integrations.imports import storygraph
+from integrations.imports.helpers import MediaImportUnexpectedError
 from lists.models import CustomList, CustomListItem
 
 
@@ -281,15 +283,68 @@ class BookResolverTests(SimpleTestCase):
 
         self.assertIsNone(resolved)
 
-    def test_provider_error_does_not_propagate(self):
-        """A provider blowing up leaves the book unresolved, not the import."""
+    def test_provider_error_on_one_provider_falls_back_to_next(self):
+        """A Hardcover outage does not stop Open Library from being tried.
+
+        Open Library exists as a coverage fallback specifically for when
+        Hardcover is unavailable, so a ``ProviderAPIError`` on the first
+        provider must not stop the ladder - it is exactly when the fallback
+        matters most.
+        """
+
+        def search(_media_type, query, _page, source):
+            if source == Sources.HARDCOVER.value:
+                raise services.ProviderAPIError(
+                    Sources.HARDCOVER.value, Exception("boom"),
+                )
+            if (source, query) == (
+                Sources.OPENLIBRARY.value,
+                "The Blade Itself Joe Abercrombie",
+            ):
+                return {"results": [{"media_id": "1", "title": "The Blade Itself"}]}
+            return {"results": []}
+
         with patch(
             "integrations.imports.storygraph.services.search",
-            side_effect=Exception("provider down"),
+            side_effect=search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
         ):
-            resolved = storygraph.BookResolver({}).resolve("Whatever", [], "")
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself", ["Joe Abercrombie"], "",
+            )
 
-        self.assertIsNone(resolved)
+        self.assertIsNotNone(resolved)
+        self.assertEqual(resolved[0], Sources.OPENLIBRARY.value)
+
+    def test_provider_error_on_every_provider_propagates(self):
+        """A failure on every provider reaches the caller, not a silent None.
+
+        Swallowing this here would make ``_process_row`` treat a persistent
+        provider outage as "book not found", which is indistinguishable from
+        a book that genuinely does not exist.
+        """
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=services.ProviderAPIError(
+                Sources.HARDCOVER.value, Exception("boom"),
+            ),
+        ), self.assertRaises(services.ProviderAPIError):
+            storygraph.BookResolver({}).resolve("Whatever", [], "")
+
+    def test_unexpected_error_is_not_swallowed_by_the_resolver(self):
+        """A genuinely unexpected exception is not caught in the resolver.
+
+        The design spec requires anything other than a provider failure or
+        an unresolvable book to raise ``MediaImportUnexpectedError`` and
+        abort the task; that can only happen if the resolver lets it through.
+        """
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=ValueError("bug, not a provider failure"),
+        ), self.assertRaises(ValueError):
+            storygraph.BookResolver({}).resolve("Whatever", [], "")
 
     def test_resolution_is_cached(self):
         """Resolving the same book twice hits the provider once."""
@@ -600,6 +655,70 @@ class ImportStoryGraphDeduplication(TestCase):
             1,
         )
 
+    def test_planning_status_not_duplicated_on_reimport(self):
+        """A Planning row followed by the same Planning row creates nothing."""
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="Planned Book").count(),
+            1,
+        )
+        counts, _ = self._import()
+        self.assertEqual(counts.get("book", 0), 0)
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="Planned Book").count(),
+            1,
+        )
+
+    def test_dateless_status_transition_to_completed_is_not_dropped(self):
+        """A book finished with no recorded date must not get stuck at Planning.
+
+        The fixture imports "Planned Book" as ``to-read``. StoryGraph's most
+        common export gap is a ``read`` row with a blank ``Dates Read``, so a
+        later export marking the same book finished - with no date - must
+        still produce a Completed entry rather than being silently dropped
+        because a dateless Planning row already occupied the same sentinel.
+        """
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="Planned Book").count(),
+            1,
+        )
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            'Planned Book,Fifth Author,"",9783333333333,hardcover,read,'
+            '2026/02/04,"","",1,"",,,,,,,,,"",,"",No'
+        )
+        counts, _ = self._import(rows=f"{header}\n{row}\n")
+
+        self.assertEqual(counts.get("book", 0), 1)
+        books = Book.objects.filter(user=self.user, item__title="Planned Book")
+        self.assertEqual(books.count(), 2)
+        self.assertEqual(
+            books.filter(status=Status.PLANNING.value).count(), 1,
+        )
+        completed = books.get(status=Status.COMPLETED.value)
+        self.assertIsNone(completed.start_date)
+        self.assertIsNone(completed.end_date)
+
+    def test_dateless_completed_transition_not_duplicated_again(self):
+        """Once the dateless Completed entry exists, re-importing gains none."""
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            'Planned Book,Fifth Author,"",9783333333333,hardcover,read,'
+            '2026/02/04,"","",1,"",,,,,,,,,"",,"",No'
+        )
+        self._import(rows=f"{header}\n{row}\n")
+
+        counts, _ = self._import(rows=f"{header}\n{row}\n")
+
+        self.assertEqual(counts.get("book", 0), 0)
+        self.assertEqual(
+            Book.objects.filter(
+                user=self.user,
+                item__title="Planned Book",
+                status=Status.COMPLETED.value,
+            ).count(),
+            1,
+        )
+
     def test_overwrite_rebuilds_entries(self):
         """Overwrite mode replaces the book's entries rather than adding to them."""
         counts, _ = self._import(mode="overwrite")
@@ -624,6 +743,57 @@ class ImportStoryGraphDeduplication(TestCase):
         books = Book.objects.filter(user=self.user, item__title="The Blade Itself")
         self.assertEqual(books.count(), 1)
         self.assertEqual(float(books.get().score), 9.0)
+
+
+class ImportStoryGraphProviderErrors(TestCase):
+    """Tests that provider failures are reported distinctly from not-found."""
+
+    def setUp(self):
+        """Create the user importing a single-row CSV each test builds."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self.header = Path(
+            mock_path / "import_storygraph.csv",
+        ).read_text().splitlines()[0]
+        self.row = (
+            'The Blade Itself,Joe Abercrombie,"",9780575079793,digital,read,'
+            "2021/01/01,2021/02/09,2021/01/20-2021/02/09,1,"
+            '"",,,,,,,4.5,Grim and funny.,"",,"fantasy",No'
+        )
+
+    def _import(self, **patches):
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            **patches,
+        ), BytesIO(f"{self.header}\n{self.row}\n".encode()) as file:
+            return storygraph.importer(file, self.user, "new")
+
+    def test_provider_failure_warns_distinctly_from_not_found(self):
+        """A persistent provider outage names the provider, not 'not found'.
+
+        ``services.search`` only raises ``ProviderAPIError`` once its own
+        429/backoff retries are exhausted, so this always represents a real,
+        persistent failure - it must not be collapsed into the generic
+        "couldn't find this book" warning used for a book that genuinely
+        does not exist on either provider.
+        """
+        counts, messages = self._import(
+            side_effect=services.ProviderAPIError(
+                Sources.HARDCOVER.value, Exception("boom"),
+            ),
+        )
+
+        self.assertEqual(counts, {})
+        self.assertNotIn("couldn't find this book", messages)
+        self.assertIn("Hardcover", messages)
+        self.assertFalse(Book.objects.filter(user=self.user).exists())
+
+    def test_unexpected_error_aborts_import(self):
+        """A genuinely unexpected exception aborts the task, per the design spec."""
+        with self.assertRaises(MediaImportUnexpectedError):
+            self._import(side_effect=ValueError("bug, not a provider failure"))
 
 
 class ImportStoryGraphDateReport(TestCase):

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -1,9 +1,10 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 from django.utils import timezone
 
-from app.models import Status
+from app.models import Sources, Status
 from integrations.imports import storygraph
 
 
@@ -106,3 +107,208 @@ class ParseFields(SimpleTestCase):
         self.assertEqual(storygraph.map_format("hardcover"), "hardcover")
         self.assertEqual(storygraph.map_format(""), "")
         self.assertEqual(storygraph.map_format("something else"), "")
+
+
+class MatchingHelpers(SimpleTestCase):
+    """Tests for the title and author comparison helpers."""
+
+    def test_titles_match_tolerates_subtitles(self):
+        """A provider title with a subtitle still matches the CSV title."""
+        self.assertTrue(
+            storygraph.titles_match("Mistborn", "Mistborn: The Final Empire")
+        )
+        self.assertTrue(
+            storygraph.titles_match("The Blade Itself", "the blade itself")
+        )
+
+    def test_titles_do_not_match_across_books(self):
+        """Unrelated titles do not match."""
+        self.assertFalse(storygraph.titles_match("Mistborn", "The God Delusion"))
+        self.assertFalse(storygraph.titles_match("", "Mistborn"))
+
+    def test_author_classification(self):
+        """Authors classify as match, unknown, or conflict."""
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], ["Joe Abercrombie"]),
+            "match",
+        )
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], ["J. Abercrombie"]),
+            "match",
+        )
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], []), "unknown"
+        )
+        self.assertEqual(
+            storygraph.classify_authors(["Joe Abercrombie"], ["Robin Hobb"]),
+            "conflict",
+        )
+        self.assertEqual(storygraph.classify_authors([], ["Robin Hobb"]), "match")
+
+    def test_extract_provider_authors_handles_shapes(self):
+        """Provider metadata carries authors as strings, lists, or dicts."""
+        self.assertEqual(
+            storygraph.extract_provider_authors(
+                {"details": {"author": ["Robin Hobb"]}},
+            ),
+            ["Robin Hobb"],
+        )
+        self.assertEqual(
+            storygraph.extract_provider_authors(
+                {"details": {"authors": [{"name": "Robin Hobb"}]}},
+            ),
+            ["Robin Hobb"],
+        )
+        self.assertEqual(
+            storygraph.extract_provider_authors({"details": {"author": "Robin Hobb"}}),
+            ["Robin Hobb"],
+        )
+        self.assertEqual(storygraph.extract_provider_authors({}), [])
+
+
+class BookResolverTests(SimpleTestCase):
+    """Tests for resolving CSV rows against metadata providers."""
+
+    def setUp(self):
+        """Build the provider fixtures shared by these tests."""
+        self.metadata = {
+            "1": {
+                "media_id": "1",
+                "title": "The Blade Itself",
+                "image": "https://example.com/blade.jpg",
+                "max_progress": 515,
+                "details": {"author": ["Joe Abercrombie"]},
+            },
+            "2": {
+                "media_id": "2",
+                "title": "A Completely Different Book",
+                "image": "https://example.com/other.jpg",
+                "max_progress": 100,
+                "details": {"author": ["Someone Else"]},
+            },
+        }
+
+    def _search(self, results_by_query):
+        def search(_media_type, query, _page, source):
+            return {"results": results_by_query.get((source, query), [])}
+
+        return search
+
+    def _metadata(self, _media_type, media_id, _source):
+        return self.metadata[str(media_id)]
+
+    def test_isbn_hit_on_hardcover_wins(self):
+        """An ISBN search on Hardcover short circuits the ladder."""
+        search = self._search(
+            {
+                (Sources.HARDCOVER.value, "9780575079793"): [
+                    {"media_id": "1", "title": "The Blade Itself"}
+                ]
+            },
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself",
+                ["Joe Abercrombie"],
+                "9780575079793",
+            )
+
+        self.assertIsNotNone(resolved)
+        source, media_id, metadata = resolved
+        self.assertEqual(source, Sources.HARDCOVER.value)
+        self.assertEqual(media_id, "1")
+        self.assertEqual(metadata["max_progress"], 515)
+
+    def test_falls_back_to_openlibrary(self):
+        """A book Hardcover cannot find is looked up on Open Library."""
+        search = self._search(
+            {
+                (Sources.OPENLIBRARY.value, "The Blade Itself Joe Abercrombie"): [
+                    {"media_id": "1", "title": "The Blade Itself"},
+                ]
+            },
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself",
+                ["Joe Abercrombie"],
+                "",
+            )
+
+        self.assertIsNotNone(resolved)
+        self.assertEqual(resolved[0], Sources.OPENLIBRARY.value)
+
+    def test_wrong_title_is_rejected(self):
+        """A search result for a different book is not accepted."""
+        search = self._search(
+            {
+                (Sources.HARDCOVER.value, "The Blade Itself Joe Abercrombie"): [
+                    {"media_id": "2", "title": "A Completely Different Book"},
+                ]
+            },
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolved = storygraph.BookResolver({}).resolve(
+                "The Blade Itself",
+                ["Joe Abercrombie"],
+                "",
+            )
+
+        self.assertIsNone(resolved)
+
+    def test_provider_error_does_not_propagate(self):
+        """A provider blowing up leaves the book unresolved, not the import."""
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=Exception("provider down"),
+        ):
+            resolved = storygraph.BookResolver({}).resolve("Whatever", [], "")
+
+        self.assertIsNone(resolved)
+
+    def test_resolution_is_cached(self):
+        """Resolving the same book twice hits the provider once."""
+        calls = []
+
+        def search(_media_type, query, _page, source):
+            calls.append(query)
+            if (source, query) == (Sources.HARDCOVER.value, "9780575079793"):
+                return {"results": [{"media_id": "1", "title": "The Blade Itself"}]}
+            return {"results": []}
+
+        cache = {}
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=self._metadata,
+        ):
+            resolver = storygraph.BookResolver(cache)
+            first = resolver.resolve(
+                "The Blade Itself", ["Joe Abercrombie"], "9780575079793"
+            )
+            second = resolver.resolve(
+                "The Blade Itself", ["Joe Abercrombie"], "9780575079793"
+            )
+
+        self.assertEqual(first, second)
+        self.assertEqual(calls.count("9780575079793"), 1)

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -1,10 +1,12 @@
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import patch
 
-from django.test import SimpleTestCase
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
-from app.models import Sources, Status
+from app.models import Book, Item, Sources, Status
 from integrations.imports import storygraph
 
 
@@ -312,3 +314,169 @@ class BookResolverTests(SimpleTestCase):
 
         self.assertEqual(first, second)
         self.assertEqual(calls.count("9780575079793"), 1)
+
+
+mock_path = Path(__file__).resolve().parent.parent / "mock_data"
+
+PROVIDER_BOOKS = {
+    "The Blade Itself": {"media_id": "1", "pages": 515, "author": "Joe Abercrombie"},
+    "Kindle Only": {"media_id": "2", "pages": 300, "author": "Some Author"},
+    "No Isbn Book": {"media_id": "3", "pages": 200, "author": "Another Author"},
+    "Re-read Book": {"media_id": "4", "pages": 400, "author": "Third Author"},
+    "Current Book": {"media_id": "5", "pages": 350, "author": "Fourth Author"},
+    "Planned Book": {"media_id": "6", "pages": 1007, "author": "Fifth Author"},
+    "Dnf Book": {"media_id": "7", "pages": 250, "author": "Sixth Author"},
+    "Tagged Only Book": {"media_id": "8", "pages": 150, "author": "Seventh Author"},
+    "Audio Book": {"media_id": "9", "pages": 320, "author": "Eighth Author"},
+}
+PROVIDER_BY_ID = {
+    book["media_id"]: (title, book) for title, book in PROVIDER_BOOKS.items()
+}
+
+
+def fake_search(_media_type, query, _page, source):
+    """Return a hit when the query names or identifies a fixture book."""
+    if source != Sources.HARDCOVER.value:
+        return {"results": []}
+    for title, book in PROVIDER_BOOKS.items():
+        if title.lower() in query.lower():
+            return {"results": [{"media_id": book["media_id"], "title": title}]}
+    return {"results": []}
+
+
+def fake_metadata(_media_type, media_id, _source):
+    """Return provider metadata for a fixture book."""
+    title, book = PROVIDER_BY_ID[str(media_id)]
+    return {
+        "media_id": book["media_id"],
+        "title": title,
+        "image": f"https://example.com/{book['media_id']}.jpg",
+        "max_progress": book["pages"],
+        "details": {"author": [book["author"]]},
+    }
+
+
+class ImportStoryGraph(TestCase):
+    """Tests for importing a StoryGraph export."""
+
+    def setUp(self):
+        """Import the fixture export with the providers mocked out."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            self.counts, self.messages = storygraph.importer(file, self.user, "new")
+
+    def _books(self, title):
+        return Book.objects.filter(
+            user=self.user, item__title=title,
+        ).order_by("end_date")
+
+    def test_entry_count(self):
+        """Nine resolvable rows produce ten entries, the re-read counting twice."""
+        self.assertEqual(Book.objects.filter(user=self.user).count(), 10)
+        self.assertEqual(self.counts["book"], 10)
+
+    def test_completed_read_dates(self):
+        """A dash separated read keeps its start and end date."""
+        book = self._books("The Blade Itself").get()
+        self.assertEqual(book.status, Status.COMPLETED.value)
+        self.assertEqual(book.start_date.date(), datetime(2021, 1, 20).date())  # noqa: DTZ001
+        self.assertEqual(book.end_date.date(), datetime(2021, 2, 9).date())  # noqa: DTZ001
+
+    def test_finish_date_only_leaves_start_null(self):
+        """A bare date is a finish date, not a one day read."""
+        book = self._books("Kindle Only").get()
+        self.assertIsNone(book.start_date)
+        self.assertEqual(book.end_date.date(), datetime(2025, 7, 16).date())  # noqa: DTZ001
+
+    def test_reread_creates_two_entries(self):
+        """Each read in Dates Read becomes its own entry."""
+        books = list(self._books("Re-read Book"))
+        self.assertEqual(len(books), 2)
+        self.assertEqual(books[0].end_date.date(), datetime(2021, 9, 14).date())  # noqa: DTZ001
+        self.assertEqual(books[1].end_date.date(), datetime(2022, 11, 28).date())  # noqa: DTZ001
+
+    def test_rating_only_on_newest_read(self):
+        """One StoryGraph rating must not be counted once per re-read."""
+        books = list(self._books("Re-read Book"))
+        self.assertIsNone(books[0].score)
+        self.assertEqual(float(books[1].score), 10.0)
+
+    def test_review_becomes_notes(self):
+        """The Review column lands in notes."""
+        book = self._books("The Blade Itself").get()
+        self.assertEqual(book.notes, "Grim and funny.")
+        self.assertEqual(float(book.score), 9.0)
+
+    def test_progress_from_provider_page_count(self):
+        """Completed books take their page count from provider metadata."""
+        self.assertEqual(self._books("The Blade Itself").get().progress, 515)
+        self.assertEqual(self._books("Planned Book").get().progress, 0)
+
+    def test_audiobook_keeps_zero_progress(self):
+        """Audiobook progress is minutes, so a page count would render wrong."""
+        book = self._books("Audio Book").get()
+        self.assertEqual(book.status, Status.COMPLETED.value)
+        self.assertEqual(book.progress, 0)
+        self.assertEqual(book.item.format, "audiobook")
+
+    def test_status_mapping_across_rows(self):
+        """Every read status maps through to the tracked entry."""
+        current_status = self._books("Current Book").get().status
+        self.assertEqual(current_status, Status.IN_PROGRESS.value)
+        planned_status = self._books("Planned Book").get().status
+        self.assertEqual(planned_status, Status.PLANNING.value)
+        dnf_status = self._books("Dnf Book").get().status
+        self.assertEqual(dnf_status, Status.DROPPED.value)
+        tagged_status = self._books("Tagged Only Book").get().status
+        self.assertEqual(tagged_status, Status.PLANNING.value)
+
+    def test_date_added_is_never_a_start_date(self):
+        """Date Added is when a book was shelved, not when reading began."""
+        self.assertIsNone(self._books("Current Book").get().start_date)
+        self.assertIsNone(self._books("Current Book").get().end_date)
+
+    def test_read_without_dates_has_no_dates(self):
+        """A read with no dates is completed but contributes no calendar day."""
+        book = self._books("No Isbn Book").get()
+        self.assertEqual(book.status, Status.COMPLETED.value)
+        self.assertIsNone(book.start_date)
+        self.assertIsNone(book.end_date)
+
+    def test_format_written_only_when_empty(self):
+        """Item.format is shared between users, so an existing value stands."""
+        item = Item.objects.get(title="The Blade Itself")
+        self.assertEqual(item.format, "ebook")
+
+        item.format = "hardcover"
+        item.save(update_fields=["format"])
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            storygraph.importer(file, self.user, "new")
+
+        item.refresh_from_db()
+        self.assertEqual(item.format, "hardcover")
+
+    def test_unresolvable_book_warns(self):
+        """A book no provider knows is reported, not imported."""
+        self.assertIn("Missing Book", self.messages)
+        self.assertFalse(Book.objects.filter(item__title="Missing Book").exists())
+
+    def test_history_record_dated_from_the_read(self):
+        """The history record is stamped with the read's end date."""
+        book = self._books("The Blade Itself").get()
+        record = book.history.first()
+        self.assertEqual(record.history_date.date(), datetime(2021, 2, 9).date())  # noqa: DTZ001

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -480,3 +481,71 @@ class ImportStoryGraph(TestCase):
         book = self._books("The Blade Itself").get()
         record = book.history.first()
         self.assertEqual(record.history_date.date(), datetime(2021, 2, 9).date())  # noqa: DTZ001
+
+
+class ImportStoryGraphDeduplication(TestCase):
+    """Tests that re-importing does not duplicate reads."""
+
+    def setUp(self):
+        """Create the user and import the fixture once."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self._import()
+
+    def _import(self, mode="new", rows=None):
+        """Import the fixture, or a custom CSV body, with providers mocked."""
+        if rows is None:
+            source_file = Path(  # noqa: SIM115 - closed by the with-block below
+                mock_path / "import_storygraph.csv",
+            ).open("rb")
+        else:
+            source_file = BytesIO(rows.encode("utf-8"))
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), source_file as file:
+            return storygraph.importer(file, self.user, mode)
+
+    def test_reimport_creates_nothing(self):
+        """Importing the same export twice leaves the entry count unchanged."""
+        before = Book.objects.filter(user=self.user).count()
+        counts, _ = self._import()
+        self.assertEqual(Book.objects.filter(user=self.user).count(), before)
+        self.assertEqual(counts.get("book", 0), 0)
+
+    def test_new_read_creates_one_entry(self):
+        """A read added in StoryGraph after the first import arrives."""
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            'The Blade Itself,Joe Abercrombie,"",9780575079793,digital,read,'
+            '2021/01/01,2026/05/10,"2021/01/20-2021/02/09, 2026/05/01-2026/05/10",2,'
+            '"",,,,,,,4.5,Grim and funny.,"",,"fantasy",No'
+        )
+        counts, _ = self._import(rows=f"{header}\n{row}\n")
+
+        self.assertEqual(counts.get("book", 0), 1)
+        books = Book.objects.filter(user=self.user, item__title="The Blade Itself")
+        self.assertEqual(books.count(), 2)
+
+    def test_dateless_read_not_duplicated(self):
+        """A read with no dates is added once and never again."""
+        counts, _ = self._import()
+        self.assertEqual(counts.get("book", 0), 0)
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="No Isbn Book").count(),
+            1,
+        )
+
+    def test_overwrite_rebuilds_entries(self):
+        """Overwrite mode replaces the book's entries rather than adding to them."""
+        self._import(mode="overwrite")
+        self.assertEqual(Book.objects.filter(user=self.user).count(), 10)
+        self.assertEqual(
+            Book.objects.filter(user=self.user, item__title="Re-read Book").count(),
+            2,
+        )

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -529,8 +529,14 @@ class ImportStoryGraphDeduplication(TestCase):
         counts, _ = self._import(rows=f"{header}\n{row}\n")
 
         self.assertEqual(counts.get("book", 0), 1)
-        books = Book.objects.filter(user=self.user, item__title="The Blade Itself")
+        books = Book.objects.filter(
+            user=self.user, item__title="The Blade Itself",
+        ).order_by("end_date")
         self.assertEqual(books.count(), 2)
+        preexisting, new_read = books
+        self.assertEqual(float(preexisting.score), 9.0)
+        self.assertIsNone(new_read.score)
+        self.assertEqual(new_read.notes, "")
 
     def test_dateless_read_not_duplicated(self):
         """A read with no dates is added once and never again."""
@@ -543,9 +549,25 @@ class ImportStoryGraphDeduplication(TestCase):
 
     def test_overwrite_rebuilds_entries(self):
         """Overwrite mode replaces the book's entries rather than adding to them."""
-        self._import(mode="overwrite")
+        counts, _ = self._import(mode="overwrite")
+        self.assertEqual(counts.get("book", 0), 10)
         self.assertEqual(Book.objects.filter(user=self.user).count(), 10)
         self.assertEqual(
             Book.objects.filter(user=self.user, item__title="Re-read Book").count(),
             2,
         )
+
+    def test_overwrite_does_not_wipe_twice_for_duplicate_rows(self):
+        """Two CSV rows for one book in overwrite mode do not duplicate reads."""
+        header = Path(mock_path / "import_storygraph.csv").read_text().splitlines()[0]
+        row = (
+            'The Blade Itself,Joe Abercrombie,"",9780575079793,digital,read,'
+            "2021/01/01,2021/02/09,2021/01/20-2021/02/09,1,"
+            '"",,,,,,,4.5,Grim and funny.,"",,"fantasy",No'
+        )
+        counts, _ = self._import(mode="overwrite", rows=f"{header}\n{row}\n{row}\n")
+
+        self.assertEqual(counts.get("book", 0), 1)
+        books = Book.objects.filter(user=self.user, item__title="The Blade Itself")
+        self.assertEqual(books.count(), 1)
+        self.assertEqual(float(books.get().score), 9.0)

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from app.models import Status
+from integrations.imports import storygraph
+
+
+class ParseReads(SimpleTestCase):
+    """Tests for parsing StoryGraph's Dates Read column."""
+
+    def test_range_gives_start_and_end(self):
+        """A dash-separated range is a start date and an end date."""
+        reads = storygraph.parse_reads("2022/03/16-2022/04/01")
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(reads[0].start.date(), datetime(2022, 3, 16).date())  # noqa: DTZ001
+        self.assertEqual(reads[0].end.date(), datetime(2022, 4, 1).date())  # noqa: DTZ001
+
+    def test_single_date_is_end_only(self):
+        """StoryGraph writes one date when only the finish date is known."""
+        reads = storygraph.parse_reads("2021/07/21")
+        self.assertEqual(len(reads), 1)
+        self.assertIsNone(reads[0].start)
+        self.assertEqual(reads[0].end.date(), datetime(2021, 7, 21).date())  # noqa: DTZ001
+
+    def test_multiple_reads_sorted_oldest_first(self):
+        """Re-reads are comma separated and come back oldest first."""
+        reads = storygraph.parse_reads("2022/10/29-2022/11/28, 2021/09/14")
+        self.assertEqual(len(reads), 2)
+        self.assertEqual(reads[0].end.date(), datetime(2021, 9, 14).date())  # noqa: DTZ001
+        self.assertEqual(reads[1].end.date(), datetime(2022, 11, 28).date())  # noqa: DTZ001
+
+    def test_blank_and_garbage_ignored(self):
+        """Empty or unparseable values produce no reads."""
+        self.assertEqual(storygraph.parse_reads(""), [])
+        self.assertEqual(storygraph.parse_reads(None), [])
+        self.assertEqual(storygraph.parse_reads("not a date"), [])
+
+    def test_dates_are_timezone_aware(self):
+        """Parsed dates are aware so Django never warns on save."""
+        read = storygraph.parse_reads("2021/07/21")[0]
+        self.assertTrue(timezone.is_aware(read.end))
+
+
+class ParseFields(SimpleTestCase):
+    """Tests for the remaining column parsers."""
+
+    def test_status_mapping(self):
+        """Each StoryGraph read status maps to a Yamtrack status."""
+        self.assertEqual(storygraph.determine_status("read"), Status.COMPLETED.value)
+        self.assertEqual(
+            storygraph.determine_status("currently-reading"),
+            Status.IN_PROGRESS.value,
+        )
+        self.assertEqual(storygraph.determine_status("to-read"), Status.PLANNING.value)
+        self.assertEqual(
+            storygraph.determine_status("did-not-finish"),
+            Status.DROPPED.value,
+        )
+
+    def test_blank_status_defaults_to_planning(self):
+        """Rows with no read status are library entries, so plan them."""
+        self.assertEqual(storygraph.determine_status(""), Status.PLANNING.value)
+        self.assertEqual(storygraph.determine_status(None), Status.PLANNING.value)
+        self.assertEqual(storygraph.determine_status("nonsense"), Status.PLANNING.value)
+
+    def test_rating_doubled_to_ten_point_scale(self):
+        """StoryGraph rates 0-5 with halves; Yamtrack scores 0-10."""
+        self.assertEqual(storygraph.parse_rating("4.5"), 9.0)
+        self.assertEqual(storygraph.parse_rating("5.0"), 10.0)
+        self.assertIsNone(storygraph.parse_rating(""))
+        self.assertIsNone(storygraph.parse_rating("0"))
+        self.assertIsNone(storygraph.parse_rating("nonsense"))
+
+    def test_tags_split_and_deduplicated(self):
+        """Tags are comma separated free text."""
+        self.assertEqual(
+            storygraph.parse_tags("management, spanish , management"),
+            ["management", "spanish"],
+        )
+        self.assertEqual(storygraph.parse_tags(""), [])
+
+    def test_authors_split(self):
+        """Multiple authors are comma separated in one column."""
+        self.assertEqual(
+            storygraph.parse_authors("Brandon Sanderson, Robert Jordan"),
+            ["Brandon Sanderson", "Robert Jordan"],
+        )
+        self.assertEqual(storygraph.parse_authors(""), [])
+
+    def test_isbn_normalization(self):
+        """Only ISBN-10 and ISBN-13 values survive; ASINs do not."""
+        self.assertEqual(
+            storygraph.normalize_isbn("978-0-575-07979-3"), "9780575079793"
+        )
+        self.assertEqual(storygraph.normalize_isbn("080442957X"), "080442957X")
+        self.assertEqual(storygraph.normalize_isbn("B0851JCZYV"), "")
+        self.assertEqual(storygraph.normalize_isbn(""), "")
+
+    def test_format_mapping(self):
+        """StoryGraph formats map onto the values Yamtrack already uses."""
+        self.assertEqual(storygraph.map_format("digital"), "ebook")
+        self.assertEqual(storygraph.map_format("audio"), "audiobook")
+        self.assertEqual(storygraph.map_format("paperback"), "paperback")
+        self.assertEqual(storygraph.map_format("hardcover"), "hardcover")
+        self.assertEqual(storygraph.map_format(""), "")
+        self.assertEqual(storygraph.map_format("something else"), "")

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -678,3 +678,19 @@ class ImportStoryGraphDateReport(TestCase):
             _counts, messages = storygraph.importer(file, user, "new")
 
         self.assertEqual(messages, "")
+
+    def test_gaps_still_reported_on_unfixed_reimport(self):
+        """Re-importing the same unfixed export in new mode still names the gaps."""
+        with patch(
+            "integrations.imports.storygraph.services.search",
+            side_effect=fake_search,
+        ), patch(
+            "integrations.imports.storygraph.services.get_media_metadata",
+            side_effect=fake_metadata,
+        ), Path(mock_path / "import_storygraph.csv").open("rb") as file:
+            _counts, messages = storygraph.importer(file, self.user, "new")
+
+        self.assertIn("No Isbn Book", messages)
+        self.assertIn("no read date", messages)
+        self.assertIn("Kindle Only", messages)
+        self.assertIn("no start date", messages)

--- a/src/integrations/tests/imports/test_storygraph.py
+++ b/src/integrations/tests/imports/test_storygraph.py
@@ -5,9 +5,12 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from app.models import Book, Item, Sources, Status
+from config.celery import app as celery_app
+from integrations import tasks
 from integrations.imports import storygraph
 from lists.models import CustomList, CustomListItem
 
@@ -694,3 +697,38 @@ class ImportStoryGraphDateReport(TestCase):
         self.assertIn("no read date", messages)
         self.assertIn("Kindle Only", messages)
         self.assertIn("no start date", messages)
+
+
+class StoryGraphWiring(TestCase):
+    """Tests that the importer is reachable from the app."""
+
+    def setUp(self):
+        """Create and sign in a user."""
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",  # noqa: S106 - test credential
+        )
+        self.client.force_login(self.user)
+
+    def test_task_registered(self):
+        """The celery task is registered under its display name."""
+        self.assertEqual(tasks.import_storygraph.name, "Import from StoryGraph")
+        self.assertIn("Import from StoryGraph", celery_app.tasks)
+
+    def test_view_requires_a_file(self):
+        """Posting without a file reports an error instead of queueing."""
+        response = self.client.post(reverse("import_storygraph"), {"mode": "new"})
+        self.assertEqual(response.status_code, 302)
+
+    def test_view_queues_the_task(self):
+        """Posting a CSV queues the import task."""
+        with Path(mock_path / "import_storygraph.csv").open("rb") as file, patch(
+            "integrations.tasks.import_storygraph.delay",
+        ) as delay:
+            response = self.client.post(
+                reverse("import_storygraph"),
+                {"mode": "new", "storygraph_csv": file},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        delay.assert_called_once()

--- a/src/integrations/tests/mock_data/import_storygraph.csv
+++ b/src/integrations/tests/mock_data/import_storygraph.csv
@@ -1,0 +1,11 @@
+Title,Authors,Contributors,ISBN/UID,Format,Read Status,Date Added,Last Date Read,Dates Read,Read Count,Moods,Pace,Character- or Plot-Driven?,Strong Character Development?,Loveable Characters?,Diverse Characters?,Flawed Characters?,Star Rating,Review,Content Warnings,Content Warning Description,Tags,Owned?
+The Blade Itself,Joe Abercrombie,"",9780575079793,digital,read,2021/01/01,2021/02/09,2021/01/20-2021/02/09,1,"",,,,,,,4.5,Grim and funny.,"",,"fantasy",No
+Kindle Only,Some Author,"",B0851JCZYV,digital,read,2025/07/01,2025/07/16,2025/07/16,1,"",,,,,,,,,"",,"",No
+No Isbn Book,Another Author,"","",paperback,read,2013/06/04,"","",1,"",,,,,,,5.0,,"",,"",No
+Re-read Book,Third Author,"",9781111111111,digital,read,2021/09/01,2022/11/28,"2022/10/29-2022/11/28, 2021/09/14",2,"",,,,,,,5.0,,"",,"",No
+Current Book,Fourth Author,"",9782222222222,digital,currently-reading,2026/07/15,"","",0,"",,,,,,,,,"",,"",No
+Planned Book,Fifth Author,"",9783333333333,hardcover,to-read,2026/02/04,"","",0,"",,,,,,,,,"",,"",No
+Dnf Book,Sixth Author,"",9784444444444,digital,did-not-finish,2024/05/05,"","",0,"",,,,,,,,,"",,"",No
+Tagged Only Book,Seventh Author,"","",,,"","","",,"",,,,,,,,,"",,"management, spanish",No
+Audio Book,Eighth Author,"",9785555555555,audio,read,2024/01/01,2024/01/05,2024/01/02-2024/01/05,1,"",,,,,,,,,"",,"",No
+Missing Book,Unknown Author,"","",digital,read,2020/01/01,2020/01/05,2020/01/05,1,"",,,,,,,,,"",,"",No

--- a/src/integrations/urls.py
+++ b/src/integrations/urls.py
@@ -61,6 +61,7 @@ urlpatterns = [
     path("import/imdb", views.import_imdb, name="import_imdb"),
     path("import/goodreads", views.import_goodreads, name="import_goodreads"),
     path("import/hardcover", views.import_hardcover, name="import_hardcover"),
+    path("import/storygraph", views.import_storygraph, name="import_storygraph"),
     path("import/audiobookshelf/connect", views.audiobookshelf_connect, name="audiobookshelf_connect"),
     path("import/audiobookshelf/disconnect", views.audiobookshelf_disconnect, name="audiobookshelf_disconnect"),
     path("import/audiobookshelf", views.import_audiobookshelf, name="import_audiobookshelf"),

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -2152,6 +2152,28 @@ def import_hardcover(request):
     return redirect("import_data")
 
 
+@require_POST
+def import_storygraph(request):
+    """View for importing books data from StoryGraph CSV."""
+    file = request.FILES.get("storygraph_csv")
+
+    if not file:
+        messages.error(request, "StoryGraph CSV file is required.")
+        return redirect("import_data")
+
+    mode = request.POST["mode"]
+    tasks.import_storygraph.delay(
+        user_id=request.user.id,
+        file=_read_uploaded_file(file),
+        mode=mode,
+    )
+    messages.info(
+        request,
+        "The task to import media from StoryGraph CSV file has been queued.",
+    )
+    return redirect("import_data")
+
+
 @require_GET
 def import_template_csv(request):
     """View for downloading a sample CSV demonstrating the import format."""

--- a/src/static/img/storygraph-logo.svg
+++ b/src/static/img/storygraph-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="StoryGraph">
+  <rect width="32" height="32" rx="6" fill="#0f1c2e"/>
+  <rect x="7" y="18" width="5" height="8" rx="1.5" fill="#f4b942"/>
+  <rect x="13.5" y="12" width="5" height="14" rx="1.5" fill="#e8734a"/>
+  <rect x="20" y="6" width="5" height="20" rx="1.5" fill="#5bc0be"/>
+</svg>

--- a/src/templates/users/import_data.html
+++ b/src/templates/users/import_data.html
@@ -1701,6 +1701,35 @@
           </form>
         </div>
 
+        {# StoryGraph #}
+        <div class="bg-[#39404b] p-4 rounded-lg"
+             x-show="sourceSupports(['reading'])"
+             x-transition.opacity.duration.150ms>
+          <div class="flex items-center mb-3">{% source_display "storygraph" %}</div>
+          <p class="text-sm text-gray-400 mb-3"
+             x-text="importFrequency === 'once' ? 'Import from StoryGraph export (Profile -> Manage Account -> Export StoryGraph Library)' : 'File uploads are not available for periodic imports'">
+          </p>
+          <form method="post"
+                action="{% url 'import_storygraph' %}"
+                enctype="multipart/form-data">
+            {% csrf_token %}
+            <input type="hidden" name="frequency" x-model="importFrequency">
+            <input type="hidden" name="time" x-model="importTime">
+            <input type="hidden" name="mode" x-model="importMode">
+            <label class="flex items-center justify-center w-full px-4 py-2 text-sm rounded-md transition-colors"
+                   :class="importFrequency === 'once' && !standardImportsDisabled() ? 'bg-indigo-600 text-white hover:bg-indigo-700 cursor-pointer' : 'bg-gray-600 text-gray-400 cursor-not-allowed'"
+                   :disabled="importFrequency !== 'once' || standardImportsDisabled()">
+              <input name="storygraph_csv"
+                     accept=".csv"
+                     class="hidden"
+                     type="file"
+                     :disabled="importFrequency !== 'once' || standardImportsDisabled()"
+                     @change="importFrequency === 'once' && !standardImportsDisabled() && $el.form.submit()">
+              Select CSV File
+            </label>
+          </form>
+        </div>
+
       </div>
     </div>
 

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1495,6 +1495,7 @@ class User(AbstractUser):
             "gpodder": ["Import from GPodder", "Import from GPodder (Recurring)"],
             "lastfm": ["Import from Last.fm History"],
             "hardcover": ["Import from Hardcover"],
+            "storygraph": ["Import from StoryGraph"],
         }
         schedule_task_names = {
             **result_task_names,

--- a/src/users/templatetags/user_tags.py
+++ b/src/users/templatetags/user_tags.py
@@ -97,6 +97,10 @@ SOURCES_CONFIG = {
         "name": "Hardcover",
         "logo": static("img/hardcover-logo.png"),
     },
+    "storygraph": {
+        "name": "StoryGraph",
+        "logo": static("img/storygraph-logo.svg"),
+    },
     "radarr": {
         "name": "Radarr",
         "logo": static("img/plex-logo.svg"),


### PR DESCRIPTION
## Summary

Adds a StoryGraph CSV importer for books. Refs #226 here, and FuzzyGrim/Yamtrack#957 and FuzzyGrim/Yamtrack#1268 upstream (the StoryGraph half only — Ryot, also asked for in #957, is out of scope).

**Problem** — StoryGraph has no public API ([their roadmap confirms it](https://roadmap.thestorygraph.com/features/posts/an-api)), and the third-party packages that claim one scrape HTML. The account export CSV is the only supported path, and Yamtrack had no importer for it.

**Solution** — A new `integrations/imports/storygraph.py` following the `goodreads.py` / `hardcover.py` shape, wired in at the usual eight touchpoints. Three decisions worth review:

**One `Book` row per read.** StoryGraph's `Dates Read` column holds a comma-separated list of reads, each either `A-B` (start and end) or a bare date. Yamtrack already models re-reads as multiple tracking rows — `BasicMedia.filter_media` returns a queryset and `history_cache_day_builder.py` builds the calendar from live `Book.start_date`/`end_date` — so each read becomes its own row rather than a hand-written `HistoricalBook` record, which would appear in neither the calendar nor statistics. A bare date is treated as a finish date with `start_date` left null rather than inventing a same-day read. `Date Added` is never used as a start date: it is when a book was shelved, and real exports contain `currently-reading` rows shelved years earlier.

**Deduplication by end date, so re-imports are safe.** Reads are keyed per item by end date at date granularity. In `new` mode an already-tracked book still accepts reads whose end date is not yet tracked — a deliberate departure from `helpers.should_process_media`, which skips a known item wholesale and would make a read logged after the first import unreachable forever. Dateless entries are tracked separately per status, so a book going Planning → read-with-no-recorded-date is not swallowed. `overwrite` mode goes through `cleanup_existing_media` as usual.

**Resolution falls back to Open Library.** About 40% of rows in a real export have no usable ISBN (Amazon ASINs and blanks), so the ladder is ISBN then title+author on Hardcover, then the same on Open Library, accepting a candidate only when its title matches and its author does not conflict — the tiering `storyteller.py` uses. This also means self-hosters without `HARDCOVER_API` configured still get results. A `ProviderAPIError` does not abort the row; the ladder continues, and the error only surfaces if no provider ever completed a check, so an outage is reported as an outage rather than as "book not found".

Smaller pieces: `Star Rating` ×2 → score and `Review` → notes, both on the newest read only so one rating is not counted once per re-read; `Tags` mirror as custom lists; `Format` maps to `Item.format` only when empty, since `Item` is shared across users; page count for completed reads comes from the resolved provider's `max_progress` (skipped for audiobooks, where progress renders as a runtime).

Because StoryGraph exports so often lack dates, the import summary ends with two informational lines naming the affected books, so the user can fix them at the source and re-import — which the deduplication above makes safe.

## Validation

- `pytest src/integrations/tests/imports/test_storygraph.py` — 58 passed
- `pytest src/integrations/tests` — 555 passed
- `pytest src/users/tests src/app/tests/providers` — 376 passed, 1 failed: `UserGetImportTasksTests::test_get_import_tasks_results`, which fails identically on the merge base (`0bfd7ad6`). It hits `AsyncResult` against a real `CELERY_RESULT_BACKEND` that `config/test_settings.py` does not override; untouched by this branch.
- `ruff check` (0.15.8, the pin in `requirements-dev.txt`) on the two new files — clean

**On the failing CI Ruff step:** it fails on the base branch too, and on every other open branch — `ruff check src` reports **10,059 errors on `latest` (`0bfd7ad6`)** against `select = ["ALL"]`. This branch is delta-neutral: it initially added one finding, an `F401` for the `import_storygraph` re-export in `integrations/tasks/__init__.py` (the 121st identical unused-import finding in that file), and `48d5ba42` silences it, bringing the count back to exactly 10,059. Fixing the pre-existing violations is out of scope here per CONTRIBUTING's rule against fixing unrelated lint as a side effect, but it does mean no branch's tests currently run in CI, since Ruff gates the test step.
- Parsers run against a real 280-row export: 280 rows, 210 reads, zero unparseable date chunks, and the date-gap report reproduced an independently computed 38 dateless books / 93 finish-date-only reads exactly.
- No migrations in this change.
- `src/static/css/main.css` not regenerated: the new card reuses the Hardcover card's classes verbatim, introducing no new utilities.

## Screenshots

The new card on the import page, rendered locally against the dev server. It sits beside Hardcover in the same reading-sources grid and reuses that card's markup and classes exactly — same `x-show="sourceSupports(['reading'])"` predicate, same button styling, same disabled-for-periodic-imports behavior. No novel visual pattern is introduced. The logo is a simple three-bar SVG mark, deliberately not StoryGraph's wordmark.

<img width="357" height="156" alt="storygraph-card" src="https://github.com/user-attachments/assets/bffd030a-6ff9-4d4d-85da-0c40caded5df" />

## Notes

Refs #226, FuzzyGrim/Yamtrack#957, FuzzyGrim/Yamtrack#1268

## AI Assistance

Generated with Claude Code (claude-opus-5 coordinating, claude-sonnet-5 and claude-haiku-4.5 subagents for implementation and review). Each task was implemented and independently reviewed before the next began; a whole-branch review at the end found two bugs — a dateless status transition being dropped on re-import, and provider errors being reported as "not found" — both fixed in `cf5a0cc1` and re-verified. Design spec and implementation plan are committed under `docs/superpowers/`. Reviewed and tested manually.
