### PR TITLE
Stop losing and mishandling login sessions

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -44,6 +44,8 @@ services:
     container_name: yamtrack-redis
     image: redis:8-alpine
     restart: unless-stopped
+    # Persist to disk so a restart doesn't drop the cache wholesale (#386).
+    command: redis-server --appendonly yes
     volumes:
       - redis_data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     container_name: yamtrack-redis
     image: redis:8-alpine
     restart: unless-stopped
+    # Persist to disk so a restart doesn't drop the cache wholesale (#386).
+    command: redis-server --appendonly yes
     volumes:
       - redis_data:/data
     networks:

--- a/src/app/error_views.py
+++ b/src/app/error_views.py
@@ -1,10 +1,11 @@
 import traceback
+from urllib.parse import urlparse
 
 from django.contrib import messages
 from django.contrib.auth.views import redirect_to_login
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 
@@ -212,6 +213,20 @@ def server_error(request: HttpRequest) -> HttpResponse:
     )
 
 
+def _is_entrance_url(path: str) -> bool:
+    """Return whether a path is a login/signup page.
+
+    Redirecting a CSRF failure to one of these produces an infinite loop.
+    """
+    entrance_paths = set()
+    for name in ("account_login", "account_signup"):
+        try:
+            entrance_paths.add(reverse(name))
+        except NoReverseMatch:  # pragma: no cover - both names are always wired
+            continue
+    return path in entrance_paths
+
+
 def _safe_return_url(request: HttpRequest) -> str:
     """Return a same-host URL to send the user back to, falling back to home."""
     referer = request.META.get("HTTP_REFERER")
@@ -241,9 +256,19 @@ def csrf_failure(
     if user is not None:
         return_url = _safe_return_url(request)
         if not user.is_authenticated:
-            return redirect_to_login(return_url)
-        messages.info(request, "That action needed a quick refresh - please try again.")
-        return redirect(return_url)
+            # Never bounce an unauthenticated user to a page that is itself an
+            # entrance page: the login POST would fail CSRF again and land back
+            # on the same form with no explanation, looping forever (#386).
+            if not _is_entrance_url(request.path) and not _is_entrance_url(
+                urlparse(return_url).path,
+            ):
+                return redirect_to_login(return_url)
+        else:
+            messages.info(
+                request,
+                "That action needed a quick refresh - please try again.",
+            )
+            return redirect(return_url)
 
     return render_error_page(
         request,
@@ -253,7 +278,10 @@ def csrf_failure(
         heading="Access Forbidden",
         error_message=(
             "CSRF verification failed for this request. This usually means the CSRF "
-            "cookie was missing, expired, or didn't match the form token."
+            "cookie was missing, expired, or didn't match the form token. If "
+            "Yamtrack is behind an HTTPS reverse proxy, set the CSRF (or URLS) "
+            "environment variable to the address you use to reach it, and set "
+            "USE_X_FORWARDED=true."
         ),
         traceback_text=(
             "Traceback unavailable. Django rejected the request during CSRF "

--- a/src/app/middleware.py
+++ b/src/app/middleware.py
@@ -1,11 +1,13 @@
 import logging
 import time
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login
 from django.db import connection
 from django.db.utils import OperationalError
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import resolve_url
 from django.urls import reverse
 
 from app.db_retry import is_retryable_error
@@ -45,6 +47,38 @@ class AutoLoginMiddleware:
                 pass
 
         return self.get_response(request)
+
+
+class HtmxAuthRedirectMiddleware:
+    """Turn login redirects into HX-Redirect for htmx requests.
+
+    ``LoginRequiredMiddleware`` answers a lost session with a plain 302 to the
+    login page. htmx follows that redirect transparently, gets a 200 carrying
+    the whole login document, and swaps it into whatever fragment slot made the
+    request - so a poller paints a login form partway down the page (#386).
+    Answering with 204 + HX-Redirect makes htmx navigate instead.
+    """
+
+    def __init__(self, get_response):
+        """Initialize the middleware with the get_response callable."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Rewrite login redirects on htmx requests into HX-Redirect."""
+        response = self.get_response(request)
+
+        if not request.headers.get("HX-Request"):
+            return response
+        if response.status_code not in {301, 302}:
+            return response
+
+        location = response.headers.get("Location", "")
+        if urlparse(location).path != urlparse(resolve_url(settings.LOGIN_URL)).path:
+            return response
+
+        redirect_response = HttpResponse(status=204)
+        redirect_response.headers["HX-Redirect"] = location
+        return redirect_response
 
 
 class RequestPerformanceLoggingMiddleware:

--- a/src/app/tests/test_collection_quick_add.py
+++ b/src/app/tests/test_collection_quick_add.py
@@ -82,10 +82,15 @@ class CollectionQuickAddTest(TestCase):
         self.assertFalse(CollectionEntry.objects.filter(user=self.user).exists())
 
     def test_quick_add_requires_login(self):
-        """Anonymous requests are redirected to login."""
+        """Anonymous htmx requests get HX-Redirect to login, not a 302.
+
+        htmx would follow a 302 and swap the whole login page into the page
+        (#386), so the redirect is handed to the client instead.
+        """
         self.client.logout()
         response = self._post_episode()
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 204)
+        self.assertIn("/accounts/login/", response.headers["HX-Redirect"])
         self.assertFalse(CollectionEntry.objects.exists())
 
     @patch("app.providers.services.get_media_metadata")

--- a/src/app/tests/test_error_views.py
+++ b/src/app/tests/test_error_views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.test import Client, RequestFactory, TestCase, override_settings
+from django.urls import reverse
 
 from app.error_views import csrf_failure
 
@@ -134,6 +135,24 @@ class ErrorPageTests(TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("/accounts/login/", response.headers["Location"])
+
+    def test_csrf_failure_on_login_page_does_not_loop(self):
+        """A CSRF-rejected login POST must explain itself, not bounce to login.
+
+        Redirecting here sends the user back to the form they just submitted,
+        so they retry, fail CSRF again, and loop forever with no diagnostics
+        (#386).
+        """
+        with override_settings(ROOT_URLCONF="config.urls"):
+            login_url = reverse("account_login")
+            response = self.csrf_client.post(
+                login_url,
+                {"login": "someone", "password": "12345"},
+                HTTP_REFERER="http://testserver" + login_url,
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(response, "USE_X_FORWARDED", status_code=403)
 
     def test_csrf_failure_page_includes_copyable_report(self):
         """The rendered CSRF page should expose a copyable diagnostic report.

--- a/src/app/tests/test_middleware.py
+++ b/src/app/tests/test_middleware.py
@@ -1,7 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import Client, RequestFactory, TestCase, override_settings
+from django.urls import reverse
 
 from app.middleware import AutoLoginMiddleware
 
@@ -73,3 +74,66 @@ class AutoLoginMiddlewareTest(TestCase):
         self.run_middleware(request)
 
         self.assertFalse(request.user.is_authenticated)
+
+
+class HtmxAuthRedirectMiddlewareTest(TestCase):
+    """Test cases for HtmxAuthRedirectMiddleware (#386)."""
+
+    def setUp(self):
+        """Use a logged-out client against a login-required fragment."""
+        self.client = Client()
+        self.url = reverse("active_playback_fragment")
+
+    def test_htmx_request_gets_hx_redirect(self):
+        """An htmx request must get 204 + HX-Redirect, not a followable 302.
+
+        Following the 302 returns the whole login page with a 200, which htmx
+        would happily swap into the fragment slot that made the request.
+        """
+        response = self.client.get(self.url, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertIn(
+            reverse("account_login"),
+            response.headers["HX-Redirect"],
+        )
+        self.assertEqual(response.content, b"")
+
+    def test_plain_request_still_redirects(self):
+        """A non-htmx request keeps the normal 302 to the login page."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("HX-Redirect", response.headers)
+        self.assertIn(reverse("account_login"), response.headers["Location"])
+
+    def test_non_login_redirect_is_untouched(self):
+        """Redirects that aren't to the login page pass through unchanged."""
+        user = UserModel.objects.create_user(
+            username="htmx_user",
+            password="htmx_user_password",  # noqa: S106
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(self.url, HTTP_HX_REQUEST="true")
+
+        self.assertNotEqual(response.status_code, 204)
+
+
+class SessionDurabilityTest(TestCase):
+    """A cache loss must not log the user out (#386)."""
+
+    def test_session_survives_cache_flush(self):
+        """Redis restart/eviction falls back to the database session row."""
+        from django.core.cache import cache  # noqa: PLC0415
+
+        user = UserModel.objects.create_user(
+            username="session_user",
+            password="session_user_password",  # noqa: S106
+        )
+        self.client.force_login(user)
+        self.assertEqual(self.client.get("/").status_code, 200)
+
+        cache.clear()
+
+        self.assertEqual(self.client.get("/").status_code, 200)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -236,6 +236,9 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.auth.middleware.LoginRequiredMiddleware",
+    # Answer htmx requests with HX-Redirect instead of a followable 302 to the
+    # login page, which htmx would otherwise swap into a fragment slot (#386)
+    "app.middleware.HtmxAuthRedirectMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "app.middleware.ProviderAPIErrorMiddleware",
@@ -411,10 +414,17 @@ CACHES = {
 warnings.simplefilter("ignore", CacheKeyWarning)
 
 # Sessions
-# Use Redis cache backend for sessions to avoid database dependency
-# This improves resilience to disk I/O errors
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+# Read through Redis for speed, but persist to the database too. The pure cache
+# backend silently treats any Redis error - a restart, an eviction, a socket
+# timeout - as "no session", logging the user out with no log line (#386).
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 SESSION_CACHE_ALIAS = "default"
+
+# Deliberately NOT setting SESSION_SAVE_EVERY_REQUEST: it would slide the
+# expiry on activity, but at the cost of a session UPDATE on every request.
+# On SQLite that is write-lock pressure on the hot path - the same class of
+# fragility this section exists to fix. Session lifetime therefore stays fixed
+# from login, per the user's session_duration preference.
 
 
 # Password validation

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -58,6 +58,24 @@
           htmx.config.historyCacheSize = 0;
           htmx.config.refreshOnHistoryMiss = true;
 
+          // Belt-and-braces for HtmxAuthRedirectMiddleware: if a fragment
+          // response is actually a login/signup page (a redirect htmx followed
+          // transparently), navigate to it instead of swapping a whole
+          // document into a fragment slot (#386).
+          document.body.addEventListener("htmx:beforeSwap", function(event) {
+            const xhr = event.detail && event.detail.xhr;
+            if (!xhr) {
+              return;
+            }
+            const body = xhr.responseText || "";
+            if (body.indexOf('name="yamtrack-page" content="entrance"') === -1) {
+              return;
+            }
+            event.detail.shouldSwap = false;
+            event.detail.isError = false;
+            window.location.assign(xhr.responseURL || "{% url 'account_login' %}");
+          });
+
           document.body.addEventListener("htmx:configRequest", function(event) {
             // Send CSRF via header rather than relying on a body-encoded
             // token, so htmx-driven POSTs don't depend on a native form's

--- a/src/templates/base_public.html
+++ b/src/templates/base_public.html
@@ -12,6 +12,9 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="mobile-web-app-title" content="Yamtrack">
+    {# Lets base.html's htmx guard recognize an entrance page that arrived as a
+       fragment response and navigate instead of swapping it in (#386). #}
+    <meta name="yamtrack-page" content="entrance">
 
     <title>
       {% block title %}


### PR DESCRIPTION
Fixes #386 — "Yamtrack forgets that the user is logged in".

Two independent bugs plus one underlying fragility. All three were reproduced before fixing.

## Bug A — login loop

`51f7b2ee` (#354) made `csrf_failure` redirect unauthenticated users to login instead of showing a dead-end 403. On a **failed login POST** the user is unauthenticated and the referer *is* the login page, so it redirects to the form they just submitted — forever, with no error shown.

The trigger is an old misconfiguration: `CSRF_TRUSTED_ORIGINS` defaults to empty and `USE_X_FORWARDED` is off, so an HTTPS reverse proxy without `CSRF=`/`URLS=` fails Django's origin check. That was always broken; the regression is that it became **silent**.

Fixed by not redirecting when the failing path or return URL is an entrance page. The 403 template already had good reverse-proxy guidance that the regression made unreachable; the copy now also names `CSRF`/`URLS` and `USE_X_FORWARDED`.

## Bug B — login form injected into a content page

`LoginRequiredMiddleware` answers a lost session with a plain 302 and no `HX-Redirect`. htmx follows it transparently, gets 200 + the entire login document, and swaps ~11 KB of it into whatever fragment slot polled — so the 10s home poller paints a login form partway down the page.

Fixed with `HtmxAuthRedirectMiddleware`: login redirects on an `HX-Request` become `204 + HX-Redirect`. A client-side `htmx:beforeSwap` guard in `base.html` (keyed off a new `yamtrack-page` meta tag) is belt-and-braces.

## Fragility C — silent logout on any Redis hiccup

`SESSION_ENGINE` was the pure cache backend against the single Redis alias shared with all app data. Django's `SessionStore.load()` swallows every exception and returns `{}`, so a restart, eviction, or socket timeout silently logs users out with no log line. The `SOCKET_TIMEOUT` added in `21aca59b` made slow-Redis raise rather than hang, feeding straight into this.

Switched to `cached_db` and enabled Redis `appendonly`.

**Deliberately not** setting `SESSION_SAVE_EVERY_REQUEST`: sliding the expiry costs a session write per request, which on SQLite is write-lock pressure on the hot path. Sessions still expire at a fixed point from login.

## Verification

| | Before | After |
|---|---|---|
| CSRF failure on login POST | 302 loop (`?next=…/accounts/login/`) | 403 with reason + proxy guidance |
| htmx poller, dead session | 10,988-byte login page swapped into fragment | `204` + `HX-Redirect`, clean navigation |
| Redis flush while logged in | logged out | stays logged in |

- Test-client repros of all three, before and after
- Fast suite: 2810 tests green; targeted suites green against this branch's base
- Live browser run against pre-fix and post-fix servers side by side (isolated DB + namespaced Redis)

## Notes for review

- **`cached_db` logs existing users out once on upgrade** — current sessions live only in Redis and have no DB row. Worth a release note.
- `test_quick_add_requires_login` changed from asserting 302 to 204; `_post_episode` sends `HX-Request`, so that is the intended new behavior.
- An earlier hypothesis — preloaded Gunicorn workers sharing a corrupted Redis fd — was checked and **rejected**: redis-py 7.x `ConnectionPool._checkpid()` makes the fork safe.
- This makes the CSRF misconfiguration diagnosable, not impossible. Worth getting the reporter's `django.security.csrf` log line to confirm an origin mismatch is their actual trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
