### PR TITLE
Gate ruff on changed lines so the test step can report

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -62,12 +64,87 @@ jobs:
           playwright install
 
       - name: Ruff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
-          ruff check src
+          if [ "$IS_PR" != "true" ]; then
+            echo "Not a pull request - running full check."
+            ruff check src
+            exit $?
+          fi
+          python - <<'PY'
+          import json, os, re, subprocess, sys
+
+          base, head = os.environ["BASE_SHA"], os.environ["HEAD_SHA"]
+
+          # Lines added/modified by this PR, per file.
+          diff = subprocess.run(
+              ["git", "diff", "--unified=0", f"{base}...{head}", "--", "src"],
+              capture_output=True, text=True, check=True,
+          ).stdout
+
+          changed: dict[str, set[int]] = {}
+          path = None
+          hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+          for line in diff.splitlines():
+              if line.startswith("+++ b/"):
+                  path = line[6:]
+              elif line.startswith("@@") and path:
+                  m = hunk.match(line)
+                  if m:
+                      start = int(m.group(1))
+                      count = int(m.group(2) or 1)
+                      changed.setdefault(path, set()).update(
+                          range(start, start + count)
+                      )
+
+          changed = {p: lines for p, lines in changed.items() if p.endswith(".py")}
+
+          if not changed:
+              print("No changed Python lines under src/ - nothing to lint.")
+              sys.exit(0)
+
+          proc = subprocess.run(
+              ["ruff", "check", "src", "--output-format=json", "--no-cache"],
+              capture_output=True, text=True,
+          )
+          if proc.returncode not in (0, 1):
+              sys.stderr.write(proc.stderr)
+              sys.exit(proc.returncode)
+          diagnostics = json.loads(proc.stdout or "[]")
+
+          repo = os.getcwd()
+          offending = []
+          for d in diagnostics:
+              rel = os.path.relpath(d["filename"], repo)
+              row = (d.get("location") or {}).get("row")
+              if row is not None and row in changed.get(rel, ()):
+                  offending.append((rel, row, d["code"], d["message"]))
+
+          total = len(diagnostics)
+          print(f"{total} violations exist in src/; gating on changed lines only.")
+
+          if offending:
+              print(f"\n{len(offending)} violation(s) on lines this PR changed:\n")
+              for rel, row, code, msg in sorted(offending):
+                  print(f"  {rel}:{row}: {code} {msg}")
+              sys.exit(1)
+
+          print("No violations on changed lines.")
+          PY
 
       - name: Set environment variables from secrets
         run: |
           if [ -n "${{ secrets.SECRET }}" ]; then echo "SECRET=${{ secrets.SECRET }}" >> $GITHUB_ENV; fi
+          # Pull requests from forks cannot read repository secrets, so this
+          # expands to empty for them and Django then refuses to start. SECRET is
+          # the only variable settings.py treats as mandatory, so fall back to an
+          # ephemeral one: nothing signed during a test run outlives the job.
+          if [ -z "${{ secrets.SECRET }}" ]; then
+            echo "SECRET=$(python -c 'import secrets; print(secrets.token_urlsafe(50))')" >> $GITHUB_ENV
+          fi
           if [ -n "${{ secrets.TMDB_API }}" ]; then echo "TMDB_API=${{ secrets.TMDB_API }}" >> $GITHUB_ENV; fi
           if [ -n "${{ secrets.MAL_API }}" ]; then echo "MAL_API=${{ secrets.MAL_API }}" >> $GITHUB_ENV; fi
           if [ -n "${{ secrets.IGDB_ID }}" ]; then echo "IGDB_ID=${{ secrets.IGDB_ID }}" >> $GITHUB_ENV; fi


### PR DESCRIPTION
## Problem

`.github/workflows/app-tests.yml` runs `ruff check src` before `Run Tests`. When the lint step exits non-zero the test step never runs, so the suite can't report on `latest` at the moment. There are currently 10,065 violations against `select = ["ALL"]`, which is an accumulation from a lot of shipped work rather than a config error.

The immediate effect is that a contributor's PR shows a red check that has nothing to do with their change.

Refs #390

## Solution

Lint only the lines a pull request adds or modifies, so the signal reflects what the PR actually touched.

* On `pull_request`, ruff still runs over all of `src`, but only diagnostics landing on changed lines fail the build. The outstanding tree-wide total is printed on every run so the backlog stays visible rather than forgotten.
* On `push` to `main` and `dev`, the full-tree check is unchanged. Those branches mirror upstream and are clean, so strictness there costs nothing.
* The gate fails closed. `ruff check --output-format=json` exits 2 when it cannot run at all, writing to stderr and leaving stdout empty, which a naive JSON parse would read as zero violations and wave every PR through. The step now checks the return code and surfaces ruff's own stderr.
* Non-Python paths under `src` are filtered out of the changed-line set, so the "nothing to lint" early exit stays accurate.

This PR contains only the workflow file. The workflow's own `check-workflow-changes` job fails any PR that touches `.github/workflows/**` alongside other files, so it has to ship on its own.

Once this is in, the other two PRs in the series get a meaningful check.

### Also: an ephemeral SECRET for fork pull requests

Once the lint step stops failing first, the next step fails too. GitHub does not expose repository secrets to pull requests from forks, so this:

```yaml
if [ -n "${{ secrets.SECRET }}" ]; then echo "SECRET=..." >> $GITHUB_ENV; fi
```

expands to empty on any fork PR, `SECRET` is never set, and Django refuses to start:

```
django.core.exceptions.ImproperlyConfigured: SECRET env var is not set
```

`SECRET` is the only variable `settings.py` treats as mandatory, so the step now falls back to a generated value when the repository secret is unavailable. Nothing signed during a test run outlives the job, so an ephemeral key is safe here. The real secret is still used whenever it is available, and the optional API keys are untouched.

This was invisible until now, because the lint step failed before the test step could run.


## Validation

The gate logic cannot be exercised by pushing, since that needs the workflow already merged, so it was extracted and run directly against real history in throwaway worktrees:

| Case | Expectation | Result |
|---|---|---|
| No changed Python lines | exit 0 | `No changed Python lines under src/ - nothing to lint.`, exit 0 |
| Changed line introducing `F401` | exit 1 | reported `F401` at the changed line, exit 1 |
| Changed line that is clean, tree-wide backlog present | exit 0 | `10059 violations exist in src/`, `No violations on changed lines`, exit 0 |
| Ruff itself failing (corrupted `pyproject.toml`) | non-zero, not a false pass | ruff's TOML parse error on stderr, exit 2 |

The third case is the property the change exists for. The fourth is the regression test for the fail-open described above.

`git diff --name-only dannyvfilms/latest...HEAD` returns exactly one path, `.github/workflows/app-tests.yml`.

## Screenshots

Not applicable, CI configuration only.

## AI Assistance

Generated with Claude Code (Claude Opus 5). Reviewed and tested manually.

## Notes

Refs #390. First of three, see the issue for the full picture.
