### PR TITLE
Fix TVDB episode track modal routing to TMDB

### DIFF
--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -1928,6 +1928,11 @@ def process_episodes(season_metadata, episodes_in_db):
             tmdb_media_id=season_metadata.get("media_id"),
         )
 
+    # TVDB season payloads are also processed here, so episode rows must keep the
+    # season's own source. Hardcoding TMDB sends track/detail routes for a TVDB
+    # show to /tmdb/<tvdb_id>, which 404s at TMDB.
+    episode_source = season_metadata.get("source") or Sources.TMDB.value
+
     for episode in season_metadata["episodes"]:
         episode_number = episode["episode_number"]
 
@@ -1968,7 +1973,7 @@ def process_episodes(season_metadata, episodes_in_db):
             {
                 "media_id": season_metadata["media_id"],
                 "media_type": MediaTypes.EPISODE.value,
-                "source": Sources.TMDB.value,
+                "source": episode_source,
                 "season_number": season_metadata["season_number"],
                 "episode_number": episode_number,
                 "air_date": air_date,  # when unknown, response returns null

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -338,6 +338,44 @@ class Metadata(TestCase):
         )
 
     @patch("app.helpers.get_tmdb_backdrop_image")
+    @patch("app.providers.tmdb.get_tvdb_episode_image_map")
+    def test_process_episodes_keeps_season_source(
+        self,
+        mock_get_tvdb_episode_image_map,
+        mock_get_tmdb_backdrop_image,
+    ):
+        """TVDB season payloads must not be relabelled as TMDB episodes.
+
+        Stamping TMDB on them points episode track/detail routes at
+        /tmdb/<tvdb_id>, which 404s at TMDB.
+        """
+        mock_get_tvdb_episode_image_map.return_value = {}
+        mock_get_tmdb_backdrop_image.return_value = None
+
+        season_metadata = {
+            "media_id": "480759",
+            "source": Sources.TVDB.value,
+            "season_number": 1,
+            "episodes": [
+                {
+                    "episode_number": 1,
+                    "name": "Episode 1",
+                    "overview": "",
+                    "runtime": None,
+                    "still_path": None,
+                },
+            ],
+        }
+
+        result = tmdb.process_episodes(season_metadata, [])
+        self.assertEqual(result[0]["source"], Sources.TVDB.value)
+
+        # A payload without an explicit source still defaults to TMDB.
+        del season_metadata["source"]
+        result = tmdb.process_episodes(season_metadata, [])
+        self.assertEqual(result[0]["source"], Sources.TMDB.value)
+
+    @patch("app.helpers.get_tmdb_backdrop_image")
     def test_process_episodes_uses_show_backdrop_when_still_missing(
         self,
         mock_get_tmdb_backdrop_image,


### PR DESCRIPTION
## Problem

Opening the track modal from an episode row on a **TVDB-sourced** show returns a 500:

```
ProviderAPIError: There was an error contacting The Movie Database (HTTP 404):
cached episode lookup failure.
Path: /track_modal/tmdb/episode/480759/1
Referer: /details/tvdb/tv/480759/toonout/season/1
```

Note the mismatch: a TVDB series id (`480759`) is being sent to **TMDB**.

## Cause

`tmdb.process_episodes()` is used for both TMDB and TVDB season payloads —
`season_details_views.py` only special-cases `manual`, everything else goes through
the TMDB processor. But it stamped every processed episode row with
`"source": Sources.TMDB.value` unconditionally.

The per-episode track button builds its URL from that row via `media_view_url()`, so
for a TVDB show it emits `/track_modal/tmdb/episode/<tvdb_id>/<season>`.
`services.get_media_metadata()` then routes `source=tmdb` to `tmdb.episode()` instead
of `tvdb.episode()`, and asks TMDB for a TVDB id.

Two failure modes:

- **id not on TMDB** → 404 → 500. The episode negative cache then pins it for an hour
  and replaces the HTTP error with `"cached episode lookup failure"`, which makes it
  read like a caching bug. The negative cache is working correctly; it is only the
  messenger here.
- **id also valid on TMDB** → silently returns *a different show's* episode metadata,
  with no error at all. This is the more concerning case.

The season page's hero track button was never affected — it reads `source` from the
page context rather than from the episode row.

## Fix

Derive the source from the season payload. Both `process_season()` and
`tvdb._normalize_season_metadata()` already set `"source"`, and payloads lacking one
still fall back to TMDB, so TMDB behaviour is unchanged.

This also corrects the same latent defect in the other `process_episodes()` consumers:
the API (`api/views.py`), `tasks_episode`, `stats_time`, metadata sync, and the
MAL flat-anime next-episode redirect in `views.py`, which built
`anime_episode_details` URLs from `next_ep["source"]`.

## Tests

Added `test_process_episodes_keeps_season_source`: a TVDB season payload yields
`source='tvdb'` rows, and a payload with no explicit source still defaults to TMDB.

Run against `python:3.12` with the project's dev deps:

| Suite | Result |
| --- | --- |
| `app/tests/providers/test_metadata.py` | 75 passed |
| `test_media_details.py`, `test_collection_quick_add.py`, `api/tests/test_media_season.py`, `api/tests/test_media_episode.py` | 184 passed, 8 subtests, 1 failed (pre-existing, see below) |
| `test_track_modal.py`, `test_episode_bulk_save.py`, `test_episode_history_poll.py`, `test_episode_score_invalidation.py`, `test_sync_metadata.py`, `test_tasks_tv_provider_migration.py`, `test_repair_local_only_seasons.py`, `test_tracking_hydration.py` | 61 passed |

`ruff check` shows no new findings versus the base commit.

### Pre-existing failure, unrelated to this change

```
FAILED test_media_details.py::MediaDetailsViewTests::test_season_details_swaps_show_and_season_heading_sizes
AssertionError: 'class="relative hidden md:block"' not found in ...
```

Confirmed failing on a clean checkout of the base commit without this patch. It's a
template-markup assertion that has drifted from the current season-page HTML — likely
belongs with the recent heading-size / Tailwind rebuild work. Flagging rather than
touching it here.

## Data impact

None found. On a library with 5 TVDB series (197 items), there are zero
`source='tmdb'` items carrying a TVDB `media_id`, which fits — the modal 500'd before
it could render a form, so there was nothing to submit. No migration or repair command
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
