### PR TITLE
Fix 500 crash on home page for episode-tracked TV rows (#397)

### DIFF
--- a/src/lists/smart_rules.py
+++ b/src/lists/smart_rules.py
@@ -583,6 +583,7 @@ def _collection_only_item_ids(
     candidate_item_ids = set(
         Item.objects.filter(id__in=collected_item_ids)
         .filter(direct_type_match)
+        .exclude(media_type=MediaTypes.EPISODE.value)
         .values_list("id", flat=True),
     )
 

--- a/src/lists/tests/test_models.py
+++ b/src/lists/tests/test_models.py
@@ -244,6 +244,49 @@ class CustomListManagerTest(TestCase):
         smart_list.sync_smart_items()
         self.assertTrue(smart_list.items.filter(id=tv_item.id).exists())
 
+    def test_collect_matching_item_ids_excludes_collected_episode_items_for_tv(self):
+        """Collection-only fallback shouldn't surface bare episode items for a TV row.
+
+        Episodes carrying `library_media_type="tv"` (normal per-episode TV tracking)
+        match the "tv" media type via `library_media_type`, but the Episode model has
+        no `user` field, so returning their raw item ids crashes any downstream code
+        that resolves them with `Episode.objects.filter(user=...)` (issue #397).
+        """
+        tv_item = Item.objects.create(
+            title="Collected Show",
+            media_id="778",
+            media_type=MediaTypes.TV.value,
+            library_media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            image="https://example.com/tv.jpg",
+        )
+        TV.objects.create(item=tv_item, user=self.user, status=Status.IN_PROGRESS.value)
+
+        untracked_episode_item = Item.objects.create(
+            title="Untracked Episode",
+            media_id="779",
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            season_number=1,
+            episode_number=1,
+            image="https://example.com/episode.jpg",
+        )
+        CollectionEntry.objects.create(user=self.user, item=untracked_episode_item)
+
+        normalized_rules = smart_rules.normalize_rule_payload(
+            {"media_types": [MediaTypes.TV.value], "status": "all"},
+            self.user,
+        )
+        matched_ids = smart_rules.collect_matching_item_ids(
+            self.user,
+            normalized_rules,
+            include_collection_only_untracked=True,
+        )
+
+        self.assertIn(tv_item.id, matched_ids)
+        self.assertNotIn(untracked_episode_item.id, matched_ids)
+
     def test_smart_list_language_filter(self):
         """Language filter should match item language metadata."""
         item = Item.objects.create(

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -1606,10 +1606,17 @@ def _media_lookup_for_items(
     lookup: dict[int, object] = {}
     for actual_media_type, type_items in items_by_media_type.items():
         model = apps.get_model("app", actual_media_type)
-        queryset = model.objects.filter(
-            user=user,
-            item_id__in=[item.id for item in type_items],
-        ).select_related("item")
+        item_ids = [item.id for item in type_items]
+        if actual_media_type == MediaTypes.EPISODE.value:
+            queryset = model.objects.filter(
+                related_season__user=user,
+                item_id__in=item_ids,
+            ).select_related("item")
+        else:
+            queryset = model.objects.filter(
+                user=user,
+                item_id__in=item_ids,
+            ).select_related("item")
         if actual_media_type == MediaTypes.PODCAST.value:
             queryset = queryset.select_related("show", "episode")
         if actual_media_type == MediaTypes.MUSIC.value:

--- a/src/users/tests/views/test_home_screen.py
+++ b/src/users/tests/views/test_home_screen.py
@@ -215,6 +215,62 @@ class HomeScreenViewTests(TestCase):
             ["Still In Progress TV"],
         )
 
+    def test_home_tv_row_with_status_all_ignores_collected_episode_items(self):
+        """A TV row with status "all" shouldn't crash on collected-but-untracked episodes.
+
+        Episodes tracked under a plain TV show carry `library_media_type="tv"`. A
+        row's "status: all" library query falls back to including collection-only
+        items, whose lookup matched those episode items directly by
+        `library_media_type` even though the Episode model has no `user` field,
+        crashing the whole home page with a 500 (issue #397).
+        """
+        self._set_enabled_media_types(MediaTypes.TV.value)
+
+        tv_item = Item.objects.create(
+            media_id="home-tv-episode-tracked",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            library_media_type=MediaTypes.TV.value,
+            title="Episode Tracked Show",
+            image="https://example.com/tv-show.jpg",
+        )
+        TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        untracked_episode_item = Item.objects.create(
+            media_id="home-tv-episode-tracked-untracked",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            library_media_type=MediaTypes.TV.value,
+            title="Untracked Episode",
+            image="https://example.com/tv-episode.jpg",
+        )
+        CollectionEntry.objects.create(user=self.user, item=untracked_episode_item)
+
+        HomeScreenRow.objects.create(
+            user=self.user,
+            media_type=MediaTypes.TV.value,
+            position=0,
+            enabled=True,
+            row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+            sort_by=MediaSortChoices.TITLE,
+            direction=DirectionChoices.ASC,
+            filters={"status": "all", "progress": "all"},
+        )
+
+        groups = home_screen.build_home_page_groups(self.user, items_limit=10)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(groups[0]["rows"]), 1)
+        self.assertEqual(
+            [entry.item.title for entry in groups[0]["rows"][0]["items"]],
+            ["Episode Tracked Show"],
+        )
+
     @patch("app.models.providers.services.get_media_metadata")
     def test_home_in_progress_row_hides_fully_watched_stale_seasons(
         self,


### PR DESCRIPTION
Episode has no `user` field (it's reached via related_season), but two
places treated episode-typed items as if it did:

- users/home_screen.py: `_media_lookup_for_items` filtered every media
  model with `user=user`, including Episode, whenever a TV/anime row's
  item set contained an episode-typed item.
- lists/smart_rules.py: `_collection_only_item_ids`'s collection-only
  fallback (used whenever a library row's status filter is "all")
  matched collected episode items directly via `library_media_type`,
  leaking their raw item ids into a TV row's result set instead of
  routing them through the existing show-level mapping.

Episode items reach a plain TV row this way because per-episode TV
tracking sets `library_media_type="tv"` on the episode's Item, so it
satisfies a TV row's media-type match even though it isn't tracked at
the top level.