### PR TITLE
Add DEMO_ACCOUNT_ENABLED to let users disable the built-in demo login

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ The only universally required variable is `SECRET` for Django's secret key. For 
 - `WEB_CONCURRENCY` / `GUNICORN_THREADS` - web server concurrency (defaults: 2 worker processes x 4 threads). Total concurrent requests = workers x threads; keep at least 2 workers so one slow request never blocks the whole UI
 - `DEBUG` - leave unset or `False` in production; enabling it slows every request (debug toolbar, no template caching) and is only meant for troubleshooting
 - `REGISTRATION` - set to `True` to allow new signups (needed for your first account), then set to `False` afterward to stop strangers from registering if your instance is reachable from the internet
+- `DEMO_ACCOUNT_ENABLED` - defaults to `True`, provisioning the built-in `demo` / `demodemo` account after migrations; set to `False` if your instance is reachable from the internet and you don't want a publicly known login active
 - `ALLOWED_HOSTS` / `PUID` / `PGID` - `ALLOWED_HOSTS` is a comma-separated list of hostnames/IPs Django will accept requests for; `PUID` / `PGID` set the file-ownership user/group inside the container (match your host user, e.g. Unraid's `99`/`100`, if you hit permission errors)
 
 For a complete list, see the [Environment Variables documentation](wiki/6.-Admin-and-Operations.md#environment-variables).
@@ -461,6 +462,8 @@ The fork also provisions a built-in demo account after migrations:
 
 - Username: `demo`
 - Password: `demodemo`
+
+Set `DEMO_ACCOUNT_ENABLED=False` to disable this (recommended if your instance is reachable from the internet).
 
 ## Support the Project
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1283,6 +1283,8 @@ if not REGISTRATION:
 
 REDIRECT_LOGIN_TO_SSO = config("REDIRECT_LOGIN_TO_SSO", default=False, cast=bool)
 
+DEMO_ACCOUNT_ENABLED = config("DEMO_ACCOUNT_ENABLED", default=True, cast=bool)
+
 # Configure LoginRequiredMiddleware to exclude static files
 LOGIN_REQUIRED_EXEMPT = [
     r"^/static/.*$",

--- a/src/users/signals.py
+++ b/src/users/signals.py
@@ -50,6 +50,9 @@ def ensure_demo_user_after_migrate(sender, **kwargs):  # noqa: ARG001
     if getattr(settings, "TESTING", False):
         return
 
+    if not getattr(settings, "DEMO_ACCOUNT_ENABLED", True):
+        return
+
     if getattr(sender, "label", None) != "users":
         return
 

--- a/src/users/tests/test_demo.py
+++ b/src/users/tests/test_demo.py
@@ -2,10 +2,10 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from users.demo import DEMO_EMAIL, DEMO_PASSWORD, DEMO_USERNAME, ensure_demo_user
-from users.signals import _demo_user_schema_ready
+from users.signals import _demo_user_schema_ready, ensure_demo_user_after_migrate
 
 
 class EnsureDemoUserTests(TestCase):
@@ -25,6 +25,15 @@ class EnsureDemoUserTests(TestCase):
         self.assertFalse(user.is_superuser)
         self.assertEqual(user.email, DEMO_EMAIL)
         self.assertTrue(user.check_password(DEMO_PASSWORD))
+
+    @override_settings(TESTING=False, DEMO_ACCOUNT_ENABLED=False)
+    def test_signal_skips_provisioning_when_demo_account_disabled(self):
+        """The post-migrate signal should not create a demo account when disabled."""
+        ensure_demo_user_after_migrate(sender=SimpleNamespace(label="users"))
+
+        self.assertFalse(
+            get_user_model().objects.filter(username=DEMO_USERNAME).exists(),
+        )
 
     def test_schema_ready_returns_false_when_user_table_is_missing_columns(self):
         """Provisioning should wait until the current user schema is present."""


### PR DESCRIPTION
Closes #394. The demo account being active by default is intentional
so a fresh instance always has a usable login, but internet-exposed
instances should be able to turn it off.