### PR TITLE
Fix multi-line Django comments leaking as literal text (#399)

### DIFF
--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -184,11 +184,13 @@
                     {% if ep_status == Status.IN_PROGRESS.value %}
                       {% next_episode_url item media as next_ep_href %}
                       {% if next_ep_href %}
-                        {# No hx-boost: this link lives inside the home row's
-                           hx-target="this"/hx-swap="beforeend" scroll container,
-                           and a boosted link would inherit those attributes and
-                           swap the episode page into the row instead of
-                           navigating. A plain link navigates normally. #}
+                        {% comment %}
+                          No hx-boost: this link lives inside the home row's
+                          hx-target="this"/hx-swap="beforeend" scroll container,
+                          and a boosted link would inherit those attributes and
+                          swap the episode page into the row instead of
+                          navigating. A plain link navigates normally.
+                        {% endcomment %}
                         <a href="{{ next_ep_href }}"
                            hx-disable
                            class="absolute top-2 right-2 z-20 bg-gray-900/90 hover:bg-indigo-600 text-white text-[11px] font-medium px-2 py-1 rounded-md flex items-center gap-0.5 shadow-md transition-colors"

--- a/src/templates/base_public.html
+++ b/src/templates/base_public.html
@@ -12,8 +12,10 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="mobile-web-app-title" content="Yamtrack">
-    {# Lets base.html's htmx guard recognize an entrance page that arrived as a
-       fragment response and navigate instead of swapping it in (#386). #}
+    {% comment %}
+      Lets base.html's htmx guard recognize an entrance page that arrived as a
+      fragment response and navigate instead of swapping it in (#386).
+    {% endcomment %}
     <meta name="yamtrack-page" content="entrance">
 
     <title>


### PR DESCRIPTION
Django's {# ... #} shorthand only matches within a single line; used
across multiple lines it isn't recognized as a comment tag at all, so
the raw {# ... #} text renders verbatim into the page. In
base_public.html this landed inside <head>, and since browsers don't
allow text nodes there, they implicitly close <head> and render the
comment text as visible body content on every public list page.
Switch both multi-line comments to {% comment %}/{% endcomment %},
which Django does support across lines.

Fixes #399