### PR TITLE
Fix statistics page gaps for undated entries, status buckets, and category ordering

### DIFF
--- a/src/app/statistics_aggregator.py
+++ b/src/app/statistics_aggregator.py
@@ -709,53 +709,63 @@ def _aggregate_statistics_from_days(
         items_by_type.pop(MediaTypes.SEASON.value, None)
         top_played_by_type.pop(MediaTypes.SEASON.value, None)
 
-    if start_date is None and end_date is None:
-        undated_models = [MediaTypes.MOVIE.value, MediaTypes.ANIME.value, MediaTypes.GAME.value, MediaTypes.BOARDGAME.value, MediaTypes.MUSIC.value, MediaTypes.PODCAST.value, MediaTypes.MANGA.value, MediaTypes.BOOK.value, MediaTypes.COMIC.value]
-        for media_type in undated_models:
-            if media_type not in active_types:
+    # Entries without any start/end date can never land in a calendar-day
+    # bucket, so the day-builder pipeline above never sees them. Pick them up
+    # here directly so undated items (e.g. Planning-status items that haven't
+    # been started, or imports missing dates) still count towards status,
+    # score and media-count aggregates regardless of the selected date range.
+    undated_models = [
+        MediaTypes.TV.value, MediaTypes.MOVIE.value, MediaTypes.ANIME.value,
+        MediaTypes.MANGA.value, MediaTypes.GAME.value, MediaTypes.BOARDGAME.value,
+        MediaTypes.MUSIC.value, MediaTypes.PODCAST.value, MediaTypes.BOOK.value,
+        MediaTypes.COMIC.value,
+    ]
+    for media_type in undated_models:
+        if media_type not in active_types:
+            continue
+        model = apps.get_model("app", media_type)
+        qs = model.objects.filter(
+            user=user,
+            start_date__isnull=True,
+            end_date__isnull=True,
+            status__in=[
+                Status.IN_PROGRESS.value,
+                Status.COMPLETED.value,
+                Status.DROPPED.value,
+                Status.PAUSED.value,
+                Status.PLANNING.value,
+            ],
+        ).values("id", "item_id", "status", "score", "created_at")
+        for row in qs.iterator(chunk_size=500):
+            activity_dt = _parse_activity_dt(row.get("created_at"))
+            score = row.get("score")
+            score_dt = activity_dt if score is not None else None
+            existing = items_by_type[media_type].get(row["item_id"])
+            if not existing:
+                items_by_type[media_type][row["item_id"]] = {
+                    "item_id": row["item_id"],
+                    "media_id": row["id"],
+                    "media_type": media_type,
+                    "status": row.get("status"),
+                    "score": float(score) if score is not None else None,
+                    "score_dt": score_dt,
+                    "activity_dt": activity_dt,
+                }
                 continue
-            model = apps.get_model("app", media_type)
-            qs = model.objects.filter(
-                user=user,
-                start_date__isnull=True,
-                end_date__isnull=True,
-                status__in=[
-                    Status.IN_PROGRESS.value,
-                    Status.COMPLETED.value,
-                    Status.DROPPED.value,
-                    Status.PAUSED.value,
-                ],
-            ).values("id", "item_id", "status", "score", "created_at")
-            for row in qs.iterator(chunk_size=500):
-                activity_dt = _parse_activity_dt(row.get("created_at"))
-                score = row.get("score")
-                score_dt = activity_dt if score is not None else None
-                existing = items_by_type[media_type].get(row["item_id"])
-                if not existing:
-                    items_by_type[media_type][row["item_id"]] = {
-                        "item_id": row["item_id"],
-                        "media_id": row["id"],
-                        "media_type": media_type,
-                        "status": row.get("status"),
-                        "score": float(score) if score is not None else None,
-                        "score_dt": score_dt,
-                        "activity_dt": activity_dt,
-                    }
-                    continue
 
-                existing_activity = existing.get("activity_dt")
-                if activity_dt and (not existing_activity or activity_dt > existing_activity):
-                    existing["media_id"] = row["id"] or existing.get("media_id")
-                    existing["status"] = row.get("status")
-                    existing["activity_dt"] = activity_dt
+            existing_activity = existing.get("activity_dt")
+            if activity_dt and (not existing_activity or activity_dt > existing_activity):
+                existing["media_id"] = row["id"] or existing.get("media_id")
+                existing["status"] = row.get("status")
+                existing["activity_dt"] = activity_dt
 
-                if score is not None:
-                    existing_score_dt = existing.get("score_dt")
-                    if existing_score_dt is None or (score_dt and score_dt > existing_score_dt):
-                        existing["score"] = float(score)
-                        existing["score_dt"] = score_dt
+            if score is not None:
+                existing_score_dt = existing.get("score_dt")
+                if existing_score_dt is None or (score_dt and score_dt > existing_score_dt):
+                    existing["score"] = float(score)
+                    existing["score_dt"] = score_dt
 
-                items_by_type[media_type][row["item_id"]] = existing
+            items_by_type[media_type][row["item_id"]] = existing
 
     media_count = {"total": 0}
     for media_type in active_types:
@@ -764,18 +774,25 @@ def _aggregate_statistics_from_days(
             media_count[media_type] = count
             media_count["total"] += count
 
-    status_order = list(Status.values)
+    # TV Seasons roll up into their parent TV Show bar here, matching how
+    # Media Type Distribution already merges season minutes into "tv".
+    distribution_types = list(active_types)
+    if MediaTypes.SEASON.value in distribution_types and MediaTypes.TV.value in distribution_types:
+        distribution_types = [mt for mt in distribution_types if mt != MediaTypes.SEASON.value]
+
+    no_status_label = "No status"
+    status_order = [*Status.values, no_status_label]
     status_distribution = {}
     total_completed = 0
-    for media_type in active_types:
-        items = items_by_type.get(media_type, {})
+    for media_type in distribution_types:
+        items = dict(items_by_type.get(media_type, {}))
+        if media_type == MediaTypes.TV.value:
+            items.update(items_by_type.get(MediaTypes.SEASON.value, {}))
         if not items:
             continue
         status_counts = dict.fromkeys(status_order, 0)
         for meta in items.values():
-            status_value = meta.get("status")
-            if not status_value:
-                continue
+            status_value = meta.get("status") or no_status_label
             status_counts[status_value] = status_counts.get(status_value, 0) + 1
             if status_value == Status.COMPLETED.value:
                 total_completed += 1
@@ -810,8 +827,10 @@ def _aggregate_statistics_from_days(
         score_scale_max = 10
     score_range = range(score_scale_max + 1)
 
-    for media_type in active_types:
-        items = items_by_type.get(media_type, {})
+    for media_type in distribution_types:
+        items = dict(items_by_type.get(media_type, {}))
+        if media_type == MediaTypes.TV.value:
+            items.update(items_by_type.get(MediaTypes.SEASON.value, {}))
         if not items:
             continue
         score_counts = dict.fromkeys(score_range, 0)

--- a/src/app/statistics_views.py
+++ b/src/app/statistics_views.py
@@ -612,6 +612,9 @@ def statistics(request):
                 "game": config.get_stats_color(MediaTypes.GAME.value),
                 "music": config.get_stats_color(MediaTypes.MUSIC.value),
                 "podcast": config.get_stats_color(MediaTypes.PODCAST.value),
+                "book": config.get_stats_color(MediaTypes.BOOK.value),
+                "comic": config.get_stats_color(MediaTypes.COMIC.value),
+                "manga": config.get_stats_color(MediaTypes.MANGA.value),
             },
         }
 
@@ -636,6 +639,9 @@ def statistics(request):
                 "game": config.get_stats_color(MediaTypes.GAME.value),
                 "music": config.get_stats_color(MediaTypes.MUSIC.value),
                 "podcast": config.get_stats_color(MediaTypes.PODCAST.value),
+                "book": config.get_stats_color(MediaTypes.BOOK.value),
+                "comic": config.get_stats_color(MediaTypes.COMIC.value),
+                "manga": config.get_stats_color(MediaTypes.MANGA.value),
             },
             "score_distribution": {},
             "top_rated": [],

--- a/src/app/stats_utils.py
+++ b/src/app/stats_utils.py
@@ -17,11 +17,14 @@ from app.models import MediaTypes
 MEDIA_TYPE_HOURS_ORDER = [
     MediaTypes.TV.value,
     MediaTypes.MOVIE.value,
-    MediaTypes.GAME.value,
-    MediaTypes.PODCAST.value,
-    MediaTypes.BOARDGAME.value,
     MediaTypes.ANIME.value,
+    MediaTypes.MANGA.value,
+    MediaTypes.GAME.value,
+    MediaTypes.BOARDGAME.value,
+    MediaTypes.PODCAST.value,
     MediaTypes.MUSIC.value,
+    MediaTypes.BOOK.value,
+    MediaTypes.COMIC.value,
 ]
 
 

--- a/src/templates/app/components/statistics_media_type_hours_cards.html
+++ b/src/templates/app/components/statistics_media_type_hours_cards.html
@@ -508,7 +508,88 @@
           </div>
         </div>
         {% endif %}
-        
+
+        {% if user.manga_enabled and hours_per_media_type.manga and hours_per_media_type.manga != "0h 0min" %}
+        <div class="bg-[#2a2f35] rounded-lg p-4 sm:p-6 flex items-center min-w-0" data-media-card x-show="isMediaTypeVisible('manga')">
+          <div class="stats-media-card-icon" style="background-color: {{ media_type_colors.manga }}33;">
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="24"
+                 height="24"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 class="w-5 h-5 sm:w-8 sm:h-8" style="color: {{ media_type_colors.manga }};">
+              <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/>
+              <path d="M14 2v4a2 2 0 0 0 2 2h4"/>
+              <path d="M10 9H8"/>
+              <path d="M16 13H8"/>
+              <path d="M16 17H8"/>
+            </svg>
+          </div>
+          <div class="stats-media-card-copy min-w-0">
+            <h3 class="stats-media-card-title text-xs sm:text-sm font-medium text-gray-400">Manga</h3>
+            <p class="stats-media-card-value text-xl sm:text-2xl font-bold">{{ hours_per_media_type.manga }}</p>
+            {% with compare=hours_per_media_type_comparison.manga %}
+              <div class="stats-media-card-meta">
+                <p class="stats-media-card-range">
+                  <span class="stats-media-card-range-desktop">
+                    {{ selected_range_dates_label }}{% if compare and compare.badge %} ({{ compare.badge|lower }}){% endif %}
+                  </span>
+                  <span class="stats-media-card-range-mobile">
+                    {% if compare and compare.badge_short %}
+                      {% if compare.badge_state == "up" %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-up">
+                          {% include "app/icons/chevron-up.svg" with classes="stats-media-card-mobile-badge-icon" %}
+                          <span>{{ compare.badge_short }}</span>
+                        </span>
+                      {% elif compare.badge_state == "down" %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-down">
+                          {% include "app/icons/chevron-down.svg" with classes="stats-media-card-mobile-badge-icon" %}
+                          <span>{{ compare.badge_short }}</span>
+                        </span>
+                      {% else %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-{{ compare.badge_state }}">{{ compare.badge_short }}</span>
+                      {% endif %}
+                    {% endif %}
+                  </span>
+                </p>
+                {% if compare and compare.tooltip %}
+                  <div class="relative" x-data="{ tooltipOpen: false }">
+                    <button @mouseenter="tooltipOpen = true" @mouseleave="tooltipOpen = false" @click="tooltipOpen = !tooltipOpen" @click.outside="tooltipOpen = false" class="stats-media-card-tooltip-trigger inline-flex items-center cursor-pointer" type="button" aria-label="Show comparison totals">
+                      {% include "app/icons/info.svg" with classes="w-3.5 h-3.5" %}
+                    </button>
+                    <div x-show="tooltipOpen"
+                         x-transition:enter="transition ease-out duration-200"
+                         x-transition:enter-start="opacity-0 scale-95"
+                         x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-150"
+                         x-transition:leave-start="opacity-100 scale-100"
+                         x-transition:leave-end="opacity-0 scale-95"
+                         class="stats-media-card-tooltip-panel absolute right-0 bottom-full mb-2 w-56 max-w-[calc(100vw-2rem)] p-3 text-white text-xs rounded-lg z-10 stats-tooltip"
+                         style="display: none;">
+                      <div class="stats-tooltip-lines">
+                        <div class="stats-tooltip-line">
+                          <span class="stats-tooltip-label">{{ compare.tooltip.current_label }}</span>
+                          <span class="stats-tooltip-value">{{ compare.tooltip.current_total }}</span>
+                        </div>
+                        <div class="stats-tooltip-line">
+                          <span class="stats-tooltip-label">{{ compare.tooltip.comparison_label }}</span>
+                          <span class="stats-tooltip-value">{{ compare.tooltip.comparison_total }}</span>
+                        </div>
+                      </div>
+                      <div class="stats-media-card-tooltip-arrow absolute right-3 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent stats-tooltip-arrow"></div>
+                    </div>
+                  </div>
+                {% endif %}
+              </div>
+            {% endwith %}
+          </div>
+        </div>
+        {% endif %}
+
         {% if user.music_enabled and hours_per_media_type.music and hours_per_media_type.music != "0h 0min" %}
         <div class="bg-[#2a2f35] rounded-lg p-4 sm:p-6 flex items-center min-w-0" data-media-card x-show="isMediaTypeVisible('music')">
           <div class="stats-media-card-icon" style="background-color: {{ media_type_colors.music }}33;">
@@ -531,6 +612,162 @@
             <h3 class="stats-media-card-title text-xs sm:text-sm font-medium text-gray-400">Music</h3>
             <p class="stats-media-card-value text-xl sm:text-2xl font-bold">{{ hours_per_media_type.music }}</p>
             {% with compare=hours_per_media_type_comparison.music %}
+              <div class="stats-media-card-meta">
+                <p class="stats-media-card-range">
+                  <span class="stats-media-card-range-desktop">
+                    {{ selected_range_dates_label }}{% if compare and compare.badge %} ({{ compare.badge|lower }}){% endif %}
+                  </span>
+                  <span class="stats-media-card-range-mobile">
+                    {% if compare and compare.badge_short %}
+                      {% if compare.badge_state == "up" %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-up">
+                          {% include "app/icons/chevron-up.svg" with classes="stats-media-card-mobile-badge-icon" %}
+                          <span>{{ compare.badge_short }}</span>
+                        </span>
+                      {% elif compare.badge_state == "down" %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-down">
+                          {% include "app/icons/chevron-down.svg" with classes="stats-media-card-mobile-badge-icon" %}
+                          <span>{{ compare.badge_short }}</span>
+                        </span>
+                      {% else %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-{{ compare.badge_state }}">{{ compare.badge_short }}</span>
+                      {% endif %}
+                    {% endif %}
+                  </span>
+                </p>
+                {% if compare and compare.tooltip %}
+                  <div class="relative" x-data="{ tooltipOpen: false }">
+                    <button @mouseenter="tooltipOpen = true" @mouseleave="tooltipOpen = false" @click="tooltipOpen = !tooltipOpen" @click.outside="tooltipOpen = false" class="stats-media-card-tooltip-trigger inline-flex items-center cursor-pointer" type="button" aria-label="Show comparison totals">
+                      {% include "app/icons/info.svg" with classes="w-3.5 h-3.5" %}
+                    </button>
+                    <div x-show="tooltipOpen"
+                         x-transition:enter="transition ease-out duration-200"
+                         x-transition:enter-start="opacity-0 scale-95"
+                         x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-150"
+                         x-transition:leave-start="opacity-100 scale-100"
+                         x-transition:leave-end="opacity-0 scale-95"
+                         class="stats-media-card-tooltip-panel absolute right-0 bottom-full mb-2 w-56 max-w-[calc(100vw-2rem)] p-3 text-white text-xs rounded-lg z-10 stats-tooltip"
+                         style="display: none;">
+                      <div class="stats-tooltip-lines">
+                        <div class="stats-tooltip-line">
+                          <span class="stats-tooltip-label">{{ compare.tooltip.current_label }}</span>
+                          <span class="stats-tooltip-value">{{ compare.tooltip.current_total }}</span>
+                        </div>
+                        <div class="stats-tooltip-line">
+                          <span class="stats-tooltip-label">{{ compare.tooltip.comparison_label }}</span>
+                          <span class="stats-tooltip-value">{{ compare.tooltip.comparison_total }}</span>
+                        </div>
+                      </div>
+                      <div class="stats-media-card-tooltip-arrow absolute right-3 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent stats-tooltip-arrow"></div>
+                    </div>
+                  </div>
+                {% endif %}
+              </div>
+            {% endwith %}
+          </div>
+        </div>
+        {% endif %}
+
+        {% if user.book_enabled and hours_per_media_type.book and hours_per_media_type.book != "0h 0min" %}
+        <div class="bg-[#2a2f35] rounded-lg p-4 sm:p-6 flex items-center min-w-0" data-media-card x-show="isMediaTypeVisible('book')">
+          <div class="stats-media-card-icon" style="background-color: {{ media_type_colors.book }}33;">
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="24"
+                 height="24"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 class="w-5 h-5 sm:w-8 sm:h-8" style="color: {{ media_type_colors.book }};">
+              <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/>
+            </svg>
+          </div>
+          <div class="stats-media-card-copy min-w-0">
+            <h3 class="stats-media-card-title text-xs sm:text-sm font-medium text-gray-400">Books</h3>
+            <p class="stats-media-card-value text-xl sm:text-2xl font-bold">{{ hours_per_media_type.book }}</p>
+            {% with compare=hours_per_media_type_comparison.book %}
+              <div class="stats-media-card-meta">
+                <p class="stats-media-card-range">
+                  <span class="stats-media-card-range-desktop">
+                    {{ selected_range_dates_label }}{% if compare and compare.badge %} ({{ compare.badge|lower }}){% endif %}
+                  </span>
+                  <span class="stats-media-card-range-mobile">
+                    {% if compare and compare.badge_short %}
+                      {% if compare.badge_state == "up" %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-up">
+                          {% include "app/icons/chevron-up.svg" with classes="stats-media-card-mobile-badge-icon" %}
+                          <span>{{ compare.badge_short }}</span>
+                        </span>
+                      {% elif compare.badge_state == "down" %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-down">
+                          {% include "app/icons/chevron-down.svg" with classes="stats-media-card-mobile-badge-icon" %}
+                          <span>{{ compare.badge_short }}</span>
+                        </span>
+                      {% else %}
+                        <span class="stats-media-card-mobile-badge stats-media-card-mobile-badge-{{ compare.badge_state }}">{{ compare.badge_short }}</span>
+                      {% endif %}
+                    {% endif %}
+                  </span>
+                </p>
+                {% if compare and compare.tooltip %}
+                  <div class="relative" x-data="{ tooltipOpen: false }">
+                    <button @mouseenter="tooltipOpen = true" @mouseleave="tooltipOpen = false" @click="tooltipOpen = !tooltipOpen" @click.outside="tooltipOpen = false" class="stats-media-card-tooltip-trigger inline-flex items-center cursor-pointer" type="button" aria-label="Show comparison totals">
+                      {% include "app/icons/info.svg" with classes="w-3.5 h-3.5" %}
+                    </button>
+                    <div x-show="tooltipOpen"
+                         x-transition:enter="transition ease-out duration-200"
+                         x-transition:enter-start="opacity-0 scale-95"
+                         x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-150"
+                         x-transition:leave-start="opacity-100 scale-100"
+                         x-transition:leave-end="opacity-0 scale-95"
+                         class="stats-media-card-tooltip-panel absolute right-0 bottom-full mb-2 w-56 max-w-[calc(100vw-2rem)] p-3 text-white text-xs rounded-lg z-10 stats-tooltip"
+                         style="display: none;">
+                      <div class="stats-tooltip-lines">
+                        <div class="stats-tooltip-line">
+                          <span class="stats-tooltip-label">{{ compare.tooltip.current_label }}</span>
+                          <span class="stats-tooltip-value">{{ compare.tooltip.current_total }}</span>
+                        </div>
+                        <div class="stats-tooltip-line">
+                          <span class="stats-tooltip-label">{{ compare.tooltip.comparison_label }}</span>
+                          <span class="stats-tooltip-value">{{ compare.tooltip.comparison_total }}</span>
+                        </div>
+                      </div>
+                      <div class="stats-media-card-tooltip-arrow absolute right-3 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent stats-tooltip-arrow"></div>
+                    </div>
+                  </div>
+                {% endif %}
+              </div>
+            {% endwith %}
+          </div>
+        </div>
+        {% endif %}
+
+        {% if user.comic_enabled and hours_per_media_type.comic and hours_per_media_type.comic != "0h 0min" %}
+        <div class="bg-[#2a2f35] rounded-lg p-4 sm:p-6 flex items-center min-w-0" data-media-card x-show="isMediaTypeVisible('comic')">
+          <div class="stats-media-card-icon" style="background-color: {{ media_type_colors.comic }}33;">
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="24"
+                 height="24"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 class="w-5 h-5 sm:w-8 sm:h-8" style="color: {{ media_type_colors.comic }};">
+              <rect width="8" height="18" x="3" y="3" rx="1"/>
+              <path d="M7 3v18"/>
+              <path d="M20.4 18.9c.2.5-.1 1.1-.6 1.3l-1.9.7c-.5.2-1.1-.1-1.3-.6L11.1 5.1c-.2-.5.1-1.1.6-1.3l1.9-.7c.5-.2 1.1.1 1.3.6Z"/>
+            </svg>
+          </div>
+          <div class="stats-media-card-copy min-w-0">
+            <h3 class="stats-media-card-title text-xs sm:text-sm font-medium text-gray-400">Comics</h3>
+            <p class="stats-media-card-value text-xl sm:text-2xl font-bold">{{ hours_per_media_type.comic }}</p>
+            {% with compare=hours_per_media_type_comparison.comic %}
               <div class="stats-media-card-meta">
                 <p class="stats-media-card-range">
                   <span class="stats-media-card-range-desktop">

--- a/src/templates/app/statistics.html
+++ b/src/templates/app/statistics.html
@@ -670,13 +670,13 @@
       {value: 'tv', label: 'TV Shows'},
       {value: 'movie', label: 'Movies'},
       {value: 'anime', label: 'Anime'},
+      {% if user.manga_enabled %}{value: 'manga', label: 'Manga'},{% endif %}
       {value: 'game', label: 'Games'},
       {% if user.boardgame_enabled %}{value: 'boardgame', label: 'Board Games'},{% endif %}
       {% if user.music_enabled %}{value: 'music', label: 'Music'},{% endif %}
       {% if user.podcast_enabled %}{value: 'podcast', label: 'Podcasts'},{% endif %}
       {% if user.book_enabled %}{value: 'book', label: 'Books'},{% endif %}
       {% if user.comic_enabled %}{value: 'comic', label: 'Comics'},{% endif %}
-      {% if user.manga_enabled %}{value: 'manga', label: 'Manga'},{% endif %}
     ]
   })" x-init="init()">
     <div class="stats-range-row flex flex-wrap items-center justify-end gap-2 mb-4 sm:mb-6">
@@ -1431,6 +1431,12 @@
         </div>
       {% endif %}
 
+      {% if user.manga_enabled and manga_consumption.has_data %}
+        <div x-show="isMediaTypeVisible('manga')">
+          {% include "app/components/reading_consumption_section.html" with media_name="Manga" consumption=manga_consumption media_type_slug='manga' chart_prefix='manga' top_rated_list=top_rated_manga %}
+        </div>
+      {% endif %}
+
       {% if movie_consumption.has_data %}
         <div x-show="isMediaTypeVisible('movie')">
           {% include "app/components/statistics/movie_activity_overview.html" %}
@@ -1452,12 +1458,6 @@
       {% if user.comic_enabled and comic_consumption.has_data %}
         <div x-show="isMediaTypeVisible('comic')">
           {% include "app/components/reading_consumption_section.html" with media_name="Comics" consumption=comic_consumption media_type_slug='comic' chart_prefix='comic' top_rated_list=top_rated_comic %}
-        </div>
-      {% endif %}
-
-      {% if user.manga_enabled and manga_consumption.has_data %}
-        <div x-show="isMediaTypeVisible('manga')">
-          {% include "app/components/reading_consumption_section.html" with media_name="Manga" consumption=manga_consumption media_type_slug='manga' chart_prefix='manga' top_rated_list=top_rated_manga %}
         </div>
       {% endif %}
 


### PR DESCRIPTION
- Undated items (e.g. Planning-status entries with no start/end date) now
  count towards status/score distribution and media counts for every date
  range, not just "All Time"; TV was also added to that fallback query.
- Status Distribution now shows a "No status" bucket instead of silently
  dropping items with no status, and Planning items are now included.
- Status Distribution by Media Type and Score Distribution by Media Type
  now merge TV Season into TV Show, matching Media Type Distribution.
- Manga now sits between Anime and Games in the media-type filter, section
  order, and internal ordering lists instead of after Podcasts/Comics.
- Media Type Hours Cards section now includes Books, Comics, and Manga
  cards alongside the existing media types.