### PR TITLE
Import Audiobookshelf podcast episode progress

### DIFF
--- a/src/api/fork_helpers.py
+++ b/src/api/fork_helpers.py
@@ -17,7 +17,11 @@ FORK_MEDIA_MODELS = {
 
 FORK_VALID_SOURCES = {
     MediaTypes.MUSIC.value: [Sources.MUSICBRAINZ.value, Sources.MANUAL.value],
-    MediaTypes.PODCAST.value: [Sources.POCKETCASTS.value, Sources.GPODDER.value],
+    MediaTypes.PODCAST.value: [
+        Sources.POCKETCASTS.value,
+        Sources.GPODDER.value,
+        Sources.AUDIOBOOKSHELF.value,
+    ],
     MediaTypes.COMIC_ISSUE.value: [Sources.COMICVINE.value, Sources.MANUAL.value],
 }
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -243,7 +243,7 @@ MEDIA_TYPE_CONFIG = {
         "date_key": "release_date",
     },
     MediaTypes.PODCAST.value: {
-        "sources": [Sources.POCKETCASTS, Sources.GPODDER],
+        "sources": [Sources.POCKETCASTS, Sources.GPODDER, Sources.AUDIOBOOKSHELF],
         "default_source": Sources.POCKETCASTS,
         "unicode_icon": "🎙️",
         "verb": ("listen", "listened"),

--- a/src/app/discover/tab_cache.py
+++ b/src/app/discover/tab_cache.py
@@ -72,7 +72,11 @@ DISCOVER_PROVIDER_BY_MEDIA_TYPE = {
     MediaTypes.TV.value: {"trakt"},
     MediaTypes.ANIME.value: {"trakt"},
     MediaTypes.MUSIC.value: {Sources.MUSICBRAINZ.value},
-    MediaTypes.PODCAST.value: {Sources.POCKETCASTS.value, Sources.GPODDER.value},
+    MediaTypes.PODCAST.value: {
+        Sources.POCKETCASTS.value,
+        Sources.GPODDER.value,
+        Sources.AUDIOBOOKSHELF.value,
+    },
     MediaTypes.BOOK.value: {Sources.OPENLIBRARY.value},
     MediaTypes.COMIC.value: {Sources.COMICVINE.value},
     MediaTypes.MANGA.value: {Sources.MAL.value},

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -244,6 +244,7 @@ def media_details(
     if media_type == MediaTypes.PODCAST.value and source in {
         Sources.POCKETCASTS.value,
         Sources.GPODDER.value,
+        Sources.AUDIOBOOKSHELF.value,
     }:
         from app.models import PodcastEpisode, PodcastShow, PodcastShowTracker
 

--- a/src/app/services/bulk_episode_tracking.py
+++ b/src/app/services/bulk_episode_tracking.py
@@ -620,7 +620,11 @@ def build_episode_play_domain(
 ):
     """Return an episode selection domain for detail track modal tabs."""
     if route_media_type == MediaTypes.PODCAST.value:
-        if source not in {Sources.POCKETCASTS.value, Sources.GPODDER.value}:
+        if source not in {
+            Sources.POCKETCASTS.value,
+            Sources.GPODDER.value,
+            Sources.AUDIOBOOKSHELF.value,
+        }:
             return None
         show = podcast_show or PodcastShow.objects.filter(podcast_uuid=media_id).first()
         if show is None:

--- a/src/app/services/tracking_hydration.py
+++ b/src/app/services/tracking_hydration.py
@@ -262,6 +262,7 @@ def ensure_item_metadata(
     if media_type == MediaTypes.PODCAST.value and source in {
         Sources.POCKETCASTS.value,
         Sources.GPODDER.value,
+        Sources.AUDIOBOOKSHELF.value,
     }:
         metadata, podcast_show = _enrich_podcast_lookup(metadata, str(media_id))
     metadata = _fallback_metadata(

--- a/src/app/tasks_bulk_plays.py
+++ b/src/app/tasks_bulk_plays.py
@@ -56,6 +56,7 @@ def bulk_episode_plays_task(
     if media_type == MediaTypes.PODCAST.value and source in {
         Sources.POCKETCASTS.value,
         Sources.GPODDER.value,
+        Sources.AUDIOBOOKSHELF.value,
     }:
         podcast_show = PodcastShow.objects.filter(podcast_uuid=media_id).first()
     else:

--- a/src/app/track_modal_views.py
+++ b/src/app/track_modal_views.py
@@ -828,7 +828,11 @@ def track_modal(
     if (
         not standard_modal
         and media_type == MediaTypes.PODCAST.value
-        and source in {Sources.POCKETCASTS.value, Sources.GPODDER.value}
+        and source in {
+            Sources.POCKETCASTS.value,
+            Sources.GPODDER.value,
+            Sources.AUDIOBOOKSHELF.value,
+        }
     ):
         from app.models import PodcastEpisode, PodcastShow
 

--- a/src/integrations/imports/audiobookshelf.py
+++ b/src/integrations/imports/audiobookshelf.py
@@ -1,4 +1,4 @@
-"""Audiobookshelf importer for audiobook progress."""
+"""Audiobookshelf importer for audiobook and podcast progress."""
 
 import hashlib
 import logging
@@ -12,11 +12,20 @@ from urllib.parse import urljoin, urlparse
 import requests
 from django.conf import settings
 from django.utils import timezone
+from django.utils.text import slugify
 
 import app
 from app import helpers as app_helpers
 from app.log_safety import exception_summary
-from app.models import MediaTypes, Sources, Status
+from app.models import (
+    MediaTypes,
+    Podcast,
+    PodcastEpisode,
+    PodcastShow,
+    PodcastShowTracker,
+    Sources,
+    Status,
+)
 from app.providers import services
 from integrations.imports.helpers import MediaImportError, decrypt_or_raise
 from integrations.models import AudiobookshelfAccount
@@ -68,9 +77,16 @@ class AudiobookshelfClient:
         """Return authenticated user payload."""
         return self._request("/api/me")
 
-    def get_library_item(self, library_item_id: str):
-        """Return metadata for an Audiobookshelf library item."""
-        return self._request(f"/api/items/{library_item_id}")
+    def get_library_item(self, library_item_id: str, *, expanded: bool = False):
+        """Return metadata for an Audiobookshelf library item.
+
+        Podcast library items only expose per-episode durations in the
+        expanded payload, so podcast lookups must pass expanded=True.
+        """
+        path = f"/api/items/{library_item_id}"
+        if expanded:
+            path = f"{path}?expanded=1"
+        return self._request(path)
 
 
 def importer(identifier, user, mode):  # noqa: ARG001
@@ -123,7 +139,9 @@ class AudiobookshelfImporter:
 
         progress_entries = me.get("mediaProgress") or []
         last_sync_ms = self.account.last_sync_ms or 0
-        book_progress_entries = self._book_progress_entries(progress_entries)
+        book_progress_entries, podcast_progress_entries = self._split_progress_entries(
+            progress_entries,
+        )
         existing_items = self._existing_book_items(book_progress_entries)
         changed_entries, unchanged_entries = self._partition_book_progress_entries(
             book_progress_entries,
@@ -165,6 +183,26 @@ class AudiobookshelfImporter:
             logger.info(
                 "Audiobookshelf unchanged book repairs applied=%s",
                 repaired_count,
+            )
+
+        changed_podcast_entries, _ = self._partition_book_progress_entries(
+            podcast_progress_entries,
+            last_sync_ms,
+        )
+        podcast_max_seen, podcast_processed = self._import_changed_podcast_episodes(
+            changed_podcast_entries,
+            imported_counts,
+            last_sync_ms,
+        )
+        # The cursor is shared with the book pass, so it has to cover podcast
+        # entries too or their progress is replayed on every run.
+        max_seen = max(max_seen, podcast_max_seen)
+
+        if changed_podcast_entries:
+            logger.info(
+                "Audiobookshelf changed podcast entries processed=%s imported=%s",
+                len(changed_podcast_entries),
+                podcast_processed,
             )
 
         self.account.last_sync_ms = max_seen
@@ -372,19 +410,25 @@ class AudiobookshelfImporter:
         value = f"{base_url.strip().lower()}::{library_item_id}"
         return hashlib.sha256(value.encode("utf-8")).hexdigest()[:20]
 
-    def _book_progress_entries(self, progress_entries):
+    def _split_progress_entries(self, progress_entries):
+        """Split ABS progress entries into book and podcast episode entries.
+
+        A podcast entry carries an episodeId (mediaItemType podcastEpisode);
+        its libraryItemId identifies the show, not the episode.
+        """
         book_progress_entries = []
+        podcast_progress_entries = []
         for entry in progress_entries:
             library_item_id = entry.get("libraryItemId")
             if not library_item_id:
                 continue
 
-            # Skip podcast episode progress in v1.
             if entry.get("episodeId"):
+                podcast_progress_entries.append((str(library_item_id), entry))
                 continue
 
             book_progress_entries.append((str(library_item_id), entry))
-        return book_progress_entries
+        return book_progress_entries, podcast_progress_entries
 
     def _partition_book_progress_entries(self, book_progress_entries, last_sync_ms):
         changed_entries = []
@@ -476,12 +520,363 @@ class AudiobookshelfImporter:
             if media_id in items_by_media_id
         }
 
-    def _fetch_library_item(self, library_item_id: str):
+    def _fetch_library_item(self, library_item_id: str, *, expanded: bool = False):
+        kwargs = {"expanded": True} if expanded else {}
         try:
-            return self.client.get_library_item(library_item_id)
+            return self.client.get_library_item(library_item_id, **kwargs)
         except AudiobookshelfClientError:
             self.warnings.append(f"{library_item_id}: failed to fetch metadata")
             return None
+
+    def _import_changed_podcast_episodes(
+        self,
+        changed_entries,
+        imported_counts,
+        last_sync_ms,
+    ):
+        """Import podcast episode progress, one library fetch per show."""
+        max_seen = last_sync_ms
+        processed = 0
+        entries_by_show = defaultdict(list)
+        for library_item_id, entry in changed_entries:
+            max_seen = max(max_seen, int(entry.get("lastUpdate") or 0))
+            entries_by_show[library_item_id].append(entry)
+
+        for library_item_id, entries in entries_by_show.items():
+            item_metadata = self._fetch_library_item(library_item_id, expanded=True)
+            if item_metadata is None:
+                continue
+
+            show = self._ensure_podcast_show(library_item_id, item_metadata)
+            episodes_by_id = self._index_podcast_episodes(item_metadata)
+
+            for entry in entries:
+                episode_id = str(entry.get("episodeId") or "")
+                episode_metadata = episodes_by_id.get(episode_id)
+                if episode_metadata is None:
+                    self.warnings.append(
+                        f"{library_item_id}: episode {episode_id} "
+                        "missing from library item",
+                    )
+                    continue
+
+                if self._record_podcast_progress(show, episode_metadata, entry):
+                    imported_counts[MediaTypes.PODCAST.value] += 1
+                    processed += 1
+        return max_seen, processed
+
+    def _index_podcast_episodes(self, item_metadata: dict[str, Any]):
+        media_info = item_metadata.get("media") or {}
+        episodes = media_info.get("episodes") or []
+        return {
+            str(episode.get("id")): episode
+            for episode in episodes
+            if isinstance(episode, dict) and episode.get("id")
+        }
+
+    def _podcast_show_uuid(self, library_item_id: str):
+        return f"abs_{self._stable_media_id(self.account.base_url, library_item_id)}"
+
+    def _ensure_podcast_show(self, library_item_id: str, item_metadata: dict[str, Any]):
+        """Create or update the podcast show for an ABS library item."""
+        media_info = item_metadata.get("media") or {}
+        metadata = media_info.get("metadata") or {}
+        feed_url = str(metadata.get("feedUrl") or "").strip()
+        podcast_uuid = self._podcast_show_uuid(library_item_id)
+
+        show = None
+        if feed_url:
+            show = PodcastShow.objects.filter(rss_feed_url=feed_url).first()
+        if show is None:
+            show = PodcastShow.objects.filter(podcast_uuid=podcast_uuid).first()
+
+        title = (
+            metadata.get("title")
+            or item_metadata.get("title")
+            or f"Audiobookshelf {library_item_id}"
+        )
+        defaults = {
+            "title": str(title)[:255],
+            "slug": slugify(title)[:255],
+            "author": str(metadata.get("author") or "")[:255],
+            "description": str(metadata.get("description") or ""),
+            "language": str(metadata.get("language") or "")[:10],
+            "genres": self._extract_genres(metadata),
+            "image": self._podcast_show_image(library_item_id, item_metadata, metadata),
+            "rss_feed_url": feed_url,
+        }
+
+        if show is None:
+            return PodcastShow.objects.create(
+                podcast_uuid=podcast_uuid,
+                source=Sources.AUDIOBOOKSHELF.value,
+                **defaults,
+            )
+
+        # An existing show may have been created by another integration
+        # (Pocket Casts, GPodder) for the same feed; keep its source.
+        update_fields = []
+        for field, value in defaults.items():
+            if value and getattr(show, field) != value:
+                setattr(show, field, value)
+                update_fields.append(field)
+        if update_fields:
+            show.save(update_fields=update_fields)
+        return show
+
+    def _podcast_show_image(
+        self,
+        library_item_id: str,
+        item_metadata: dict[str, Any],
+        metadata: dict[str, Any],
+    ):
+        """Prefer the public feed artwork over the authenticated ABS cover."""
+        image_url = self._normalize_cover_url(metadata.get("imageUrl"))
+        if image_url and urlparse(image_url).netloc.lower() != urlparse(
+            self.account.base_url,
+        ).netloc.lower():
+            return image_url
+        if item_metadata.get("coverPath") or image_url:
+            base = self.account.base_url.rstrip("/")
+            return f"{base}/api/items/{library_item_id}/cover"
+        return ""
+
+    def _ensure_podcast_episode(self, show, episode_metadata: dict[str, Any]):
+        """Create or update the catalog episode for an ABS podcast episode."""
+        episode_id = str(episode_metadata.get("id") or "")
+        enclosure = episode_metadata.get("enclosure") or {}
+        audio_url = str(enclosure.get("url") or "")[:500]
+        guid = str(episode_metadata.get("guid") or "").strip()
+        episode_uuid = (guid or audio_url or f"abs_{episode_id}")[:500]
+
+        episode = PodcastEpisode.objects.filter(
+            show=show,
+            episode_uuid=episode_uuid,
+        ).first()
+        if episode is None and audio_url:
+            episode = PodcastEpisode.objects.filter(
+                show=show,
+                audio_url=audio_url,
+            ).first()
+
+        title = str(episode_metadata.get("title") or "Unknown Episode")
+        updates = {
+            "title": title[:500],
+            "slug": slugify(title)[:255],
+            "published": self._parse_datetime(episode_metadata.get("publishedAt")),
+            "duration": self._podcast_episode_duration(episode_metadata),
+            "audio_url": audio_url,
+            "episode_number": self._coerce_positive_int(
+                episode_metadata.get("episode"),
+            ),
+            "season_number": self._coerce_positive_int(
+                episode_metadata.get("season"),
+            ),
+            "file_type": str(enclosure.get("type") or "")[:50],
+            "episode_type": str(episode_metadata.get("episodeType") or "")[:50],
+        }
+
+        if episode is None:
+            episode, _ = PodcastEpisode.objects.get_or_create(
+                show=show,
+                episode_uuid=episode_uuid,
+                defaults=updates,
+            )
+            return episode
+
+        update_fields = []
+        for field, value in updates.items():
+            if value not in (None, "") and getattr(episode, field) != value:
+                setattr(episode, field, value)
+                update_fields.append(field)
+        if update_fields:
+            episode.save(update_fields=update_fields)
+        return episode
+
+    def _podcast_episode_duration(self, episode_metadata: dict[str, Any]):
+        duration = episode_metadata.get("duration")
+        if not duration:
+            audio_file = episode_metadata.get("audioFile") or {}
+            duration = audio_file.get("duration")
+        try:
+            seconds = int(float(duration))
+        except (TypeError, ValueError):
+            return None
+        return seconds if seconds > 0 else None
+
+    def _coerce_positive_int(self, value):
+        """Coerce ABS season/episode numbers, which arrive as strings."""
+        if value in (None, ""):
+            return None
+        try:
+            number = int(float(value))
+        except (TypeError, ValueError):
+            return None
+        return number if number >= 0 else None
+
+    def _ensure_podcast_item(self, show, episode, total_seconds):
+        """Return the trackable item for a podcast episode."""
+        runtime_minutes = None
+        if total_seconds:
+            runtime_minutes = max(1, total_seconds // 60)
+        elif episode.duration:
+            runtime_minutes = max(1, episode.duration // 60)
+
+        defaults = {
+            "title": episode.title,
+            "image": show.image or settings.IMG_NONE,
+        }
+        if runtime_minutes:
+            defaults["runtime_minutes"] = runtime_minutes
+        if episode.published:
+            defaults["release_datetime"] = episode.published
+
+        # Keyed on the show source so a feed already tracked through another
+        # integration keeps a single item per episode.
+        item, _ = app.models.Item.objects.get_or_create(
+            media_id=episode.episode_uuid,
+            source=show.source,
+            media_type=MediaTypes.PODCAST.value,
+            defaults=defaults,
+        )
+        update_fields = []
+        if item.title != episode.title:
+            item.title = episode.title
+            update_fields.append("title")
+        if runtime_minutes and item.runtime_minutes != runtime_minutes:
+            item.runtime_minutes = runtime_minutes
+            update_fields.append("runtime_minutes")
+        if episode.published and item.release_datetime != episode.published:
+            item.release_datetime = episode.published
+            update_fields.append("release_datetime")
+        if update_fields:
+            item.save(update_fields=update_fields)
+        return item
+
+    def _record_podcast_progress(
+        self,
+        show,
+        episode_metadata: dict[str, Any],
+        progress_entry: dict[str, Any],
+    ):
+        """Write a single ABS podcast episode progress entry."""
+        is_completed = self._is_finished_progress_entry(progress_entry)
+        position_seconds = int(float(progress_entry.get("currentTime") or 0))
+        if not is_completed and position_seconds <= 0:
+            # Touched but never started; ABS keeps such rows around.
+            return False
+
+        episode = self._ensure_podcast_episode(show, episode_metadata)
+        total_seconds = (
+            int(float(progress_entry.get("duration") or 0)) or episode.duration or None
+        )
+
+        # Completed rows get lifted to the full runtime by Media.process_status.
+        progress_minutes = max(1, position_seconds // 60) if position_seconds > 0 else 0
+
+        item = self._ensure_podcast_item(show, episode, total_seconds)
+        PodcastShowTracker.objects.get_or_create(
+            user=self.user,
+            show=show,
+            defaults={"status": Status.IN_PROGRESS.value},
+        )
+
+        end_date = None
+        if is_completed:
+            end_date = self._parse_datetime(
+                progress_entry.get("finishedAt"),
+            ) or self._parse_datetime(progress_entry.get("lastUpdate"))
+
+        status_value = (
+            Status.COMPLETED.value if is_completed else Status.IN_PROGRESS.value
+        )
+        provider_status = 3 if is_completed else 2
+
+        entries = list(
+            Podcast.objects.filter(user=self.user, item=item)
+            .select_related("episode", "show", "item")
+            .order_by("-created_at"),
+        )
+        latest_in_progress = next(
+            (entry for entry in entries if entry.end_date is None),
+            None,
+        )
+        latest_completed = next(
+            (entry for entry in entries if entry.end_date is not None),
+            None,
+        )
+
+        if latest_in_progress is not None:
+            if (
+                latest_in_progress.played_up_to_seconds == (position_seconds or None)
+                and latest_in_progress.end_date == end_date
+                and latest_in_progress.status == status_value
+            ):
+                return False
+            self._update_podcast_row(
+                latest_in_progress,
+                show=show,
+                episode=episode,
+                status=status_value,
+                progress_minutes=progress_minutes,
+                position_seconds=position_seconds,
+                provider_status=provider_status,
+                end_date=end_date,
+            )
+            return True
+
+        if (
+            latest_completed is not None
+            and is_completed
+            and latest_completed.played_up_to_seconds == (position_seconds or None)
+        ):
+            return False
+
+        Podcast.objects.create(
+            user=self.user,
+            item=item,
+            show=show,
+            episode=episode,
+            status=status_value,
+            progress=progress_minutes,
+            played_up_to_seconds=position_seconds or None,
+            last_seen_status=provider_status,
+            start_date=self._parse_datetime(progress_entry.get("startedAt")),
+            end_date=end_date,
+        )
+        return True
+
+    def _update_podcast_row(
+        self,
+        podcast,
+        *,
+        show,
+        episode,
+        status,
+        progress_minutes,
+        position_seconds,
+        provider_status,
+        end_date,
+    ):
+        """Update an existing in-progress podcast row in place."""
+        updates = {
+            "show": show,
+            "episode": episode,
+            "status": status,
+            "progress": progress_minutes,
+            "played_up_to_seconds": position_seconds or None,
+            "last_seen_status": provider_status,
+        }
+        if end_date is not None:
+            updates["end_date"] = end_date
+
+        update_fields = []
+        for field, value in updates.items():
+            if getattr(podcast, field) != value:
+                setattr(podcast, field, value)
+                update_fields.append(field)
+        if update_fields:
+            podcast.save(update_fields=update_fields)
 
     def _needs_book_repair(self, item):
         if item is None:

--- a/src/integrations/tests/imports/test_audiobookshelf.py
+++ b/src/integrations/tests/imports/test_audiobookshelf.py
@@ -8,7 +8,17 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
-from app.models import Book, Item, MediaTypes, Sources, Status
+from app.models import (
+    Book,
+    Item,
+    MediaTypes,
+    Podcast,
+    PodcastEpisode,
+    PodcastShow,
+    PodcastShowTracker,
+    Sources,
+    Status,
+)
 from integrations.imports import helpers
 from integrations.imports.audiobookshelf import (
     AudiobookshelfAuthError,
@@ -17,6 +27,62 @@ from integrations.imports.audiobookshelf import (
 )
 from integrations.imports.helpers import MediaImportError
 from integrations.models import AudiobookshelfAccount
+
+
+def podcast_progress(**overrides):
+    """Return an ABS podcast episode progress entry."""
+    return {
+        "libraryItemId": "podcast-item",
+        "episodeId": "ep-1",
+        "mediaItemId": "ep-1",
+        "mediaItemType": "podcastEpisode",
+        "currentTime": 1200,
+        "duration": 3000,
+        "progress": 0.4,
+        "isFinished": False,
+        "lastUpdate": 2000,
+        "startedAt": 1_700_000_000_000,
+        "finishedAt": None,
+        **overrides,
+    }
+
+
+def podcast_library_item(**overrides):
+    """Return an expanded ABS podcast library item payload."""
+    return {
+        "id": "podcast-item",
+        "mediaType": "podcast",
+        "coverPath": "/metadata/items/podcast-item/cover.jpg",
+        "media": {
+            "id": "pod-1",
+            "metadata": {
+                "title": "Test Show",
+                "author": "Test Network",
+                "description": "A show.",
+                "language": "en",
+                "genres": ["Technology"],
+                "feedUrl": "https://feed.example/rss.xml",
+                "imageUrl": "https://feed.example/cover.jpg",
+            },
+            "episodes": [
+                {
+                    "id": "ep-1",
+                    "title": "Episode 14",
+                    "guid": "guid-1",
+                    "enclosure": {
+                        "url": "https://cdn.example/ep14.mp3",
+                        "type": "audio/mpeg",
+                    },
+                    "season": "2",
+                    "episode": "14",
+                    "episodeType": "full",
+                    "publishedAt": 1_699_516_800_000,
+                    "duration": 3000.4,
+                },
+            ],
+        },
+        **overrides,
+    }
 
 
 class AudiobookshelfImporterTests(TestCase):
@@ -76,25 +142,212 @@ class AudiobookshelfImporterTests(TestCase):
 
     @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
     @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
-    def test_skips_podcast_episode_progress(self, mock_me, mock_item):
-        """Skip ABS podcast episode progress in v1."""
+    def test_imports_podcast_episode_progress(self, mock_me, mock_item):
+        """Import ABS podcast episode progress into Podcast rows."""
+        mock_me.return_value = {"mediaProgress": [podcast_progress()]}
+        mock_item.return_value = podcast_library_item()
+
+        importer = AudiobookshelfImporter(self.user)
+        counts, warnings = importer.import_data()
+
+        self.assertEqual(counts.get(MediaTypes.PODCAST.value), 1)
+        self.assertEqual(warnings, "")
+        mock_item.assert_called_once_with("podcast-item", expanded=True)
+
+        show = PodcastShow.objects.get()
+        self.assertEqual(show.source, Sources.AUDIOBOOKSHELF.value)
+        self.assertEqual(show.title, "Test Show")
+        self.assertEqual(show.rss_feed_url, "https://feed.example/rss.xml")
+
+        episode = PodcastEpisode.objects.get()
+        self.assertEqual(episode.episode_uuid, "guid-1")
+        self.assertEqual(episode.duration, 3000)
+        self.assertEqual(episode.season_number, 2)
+        self.assertEqual(episode.episode_number, 14)
+
+        media = Podcast.objects.get(user=self.user)
+        self.assertEqual(media.status, Status.IN_PROGRESS.value)
+        self.assertEqual(media.played_up_to_seconds, 1200)
+        self.assertEqual(media.progress, 20)
+        self.assertEqual(media.last_seen_status, 2)
+        self.assertIsNone(media.end_date)
+        self.assertEqual(media.item.media_type, MediaTypes.PODCAST.value)
+        self.assertEqual(media.item.media_id, "guid-1")
+        self.assertTrue(
+            PodcastShowTracker.objects.filter(user=self.user, show=show).exists(),
+        )
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_imports_finished_podcast_episode_as_completed(self, mock_me, mock_item):
+        """Map a finished ABS episode onto a completed Podcast row."""
+        finished_at_ms = 1_700_003_600_000
         mock_me.return_value = {
             "mediaProgress": [
-                {
-                    "libraryItemId": "podcast-item",
-                    "episodeId": "ep-1",
-                    "currentTime": 100,
-                    "lastUpdate": 2000,
-                },
+                podcast_progress(
+                    currentTime=3000,
+                    progress=1,
+                    isFinished=True,
+                    finishedAt=finished_at_ms,
+                ),
             ],
         }
+        mock_item.return_value = podcast_library_item()
+
+        importer = AudiobookshelfImporter(self.user)
+        counts, _ = importer.import_data()
+
+        self.assertEqual(counts.get(MediaTypes.PODCAST.value), 1)
+        media = Podcast.objects.get(user=self.user)
+        self.assertEqual(media.status, Status.COMPLETED.value)
+        self.assertEqual(media.last_seen_status, 3)
+        self.assertEqual(
+            media.end_date,
+            datetime.fromtimestamp(finished_at_ms / 1000, tz=UTC),
+        )
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_skips_podcast_episode_without_listening_activity(self, mock_me, mock_item):
+        """Ignore ABS rows that were touched but never played."""
+        mock_me.return_value = {"mediaProgress": [podcast_progress(currentTime=0)]}
+        mock_item.return_value = podcast_library_item()
 
         importer = AudiobookshelfImporter(self.user)
         counts, _ = importer.import_data()
 
         self.assertEqual(counts, {})
-        self.assertFalse(Item.objects.filter(source=Sources.AUDIOBOOKSHELF.value).exists())
+        self.assertFalse(Podcast.objects.exists())
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_podcast_episode_uuid_falls_back_to_enclosure_then_id(
+        self,
+        mock_me,
+        mock_item,
+    ):
+        """Fall back to the enclosure URL, then the ABS episode id."""
+        mock_me.return_value = {"mediaProgress": [podcast_progress()]}
+        library_item = podcast_library_item()
+        library_item["media"]["episodes"][0].pop("guid")
+        mock_item.return_value = library_item
+
+        AudiobookshelfImporter(self.user).import_data()
+        self.assertEqual(
+            PodcastEpisode.objects.get().episode_uuid,
+            "https://cdn.example/ep14.mp3",
+        )
+
+        PodcastEpisode.objects.all().delete()
+        PodcastShow.objects.all().delete()
+        library_item["media"]["episodes"][0].pop("enclosure")
+        mock_me.return_value = {"mediaProgress": [podcast_progress(lastUpdate=9000)]}
+
+        AudiobookshelfImporter(self.user).import_data()
+        self.assertEqual(PodcastEpisode.objects.get().episode_uuid, "abs_ep-1")
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_cursor_covers_podcast_entries(self, mock_me, mock_item):
+        """Advance last_sync_ms past podcast progress so it is not replayed."""
+        mock_me.return_value = {"mediaProgress": [podcast_progress(lastUpdate=5000)]}
+        mock_item.return_value = podcast_library_item()
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        account = AudiobookshelfAccount.objects.get(user=self.user)
+        self.assertEqual(account.last_sync_ms, 5000)
+
+        mock_item.reset_mock()
+        counts, _ = AudiobookshelfImporter(self.user).import_data()
+        self.assertEqual(counts, {})
         mock_item.assert_not_called()
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_updates_existing_in_progress_podcast_row(self, mock_me, mock_item):
+        """Update the open row instead of creating a second play."""
+        mock_me.return_value = {"mediaProgress": [podcast_progress()]}
+        mock_item.return_value = podcast_library_item()
+        AudiobookshelfImporter(self.user).import_data()
+
+        mock_me.return_value = {
+            "mediaProgress": [podcast_progress(currentTime=1800, lastUpdate=9000)],
+        }
+        AudiobookshelfImporter(self.user).import_data()
+
+        media = Podcast.objects.get(user=self.user)
+        self.assertEqual(media.played_up_to_seconds, 1800)
+        self.assertEqual(media.progress, 30)
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_reuses_existing_show_with_same_feed_url(self, mock_me, mock_item):
+        """Attach to a show another integration already created for the feed."""
+        existing = PodcastShow.objects.create(
+            podcast_uuid="gp_existing",
+            source=Sources.GPODDER.value,
+            title="Test Show",
+            rss_feed_url="https://feed.example/rss.xml",
+        )
+        mock_me.return_value = {"mediaProgress": [podcast_progress()]}
+        mock_item.return_value = podcast_library_item()
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        self.assertEqual(PodcastShow.objects.count(), 1)
+        existing.refresh_from_db()
+        self.assertEqual(existing.source, Sources.GPODDER.value)
+        self.assertEqual(
+            Podcast.objects.get(user=self.user).item.source,
+            Sources.GPODDER.value,
+        )
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_warns_when_episode_missing_from_library_item(self, mock_me, mock_item):
+        """Warn instead of failing when ABS omits the episode."""
+        mock_me.return_value = {"mediaProgress": [podcast_progress(episodeId="ep-404")]}
+        mock_item.return_value = podcast_library_item()
+
+        counts, warnings = AudiobookshelfImporter(self.user).import_data()
+
+        self.assertEqual(counts, {})
+        self.assertIn("ep-404", warnings)
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_imports_mixed_book_and_podcast_payload(self, mock_me, mock_item):
+        """Handle a payload containing both media types."""
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "item-1",
+                    "currentTime": 3600,
+                    "duration": 7200,
+                    "isFinished": False,
+                    "lastUpdate": 1000,
+                },
+                podcast_progress(),
+            ],
+        }
+
+        def library_item(library_item_id, *, expanded=False):  # noqa: ARG001
+            if library_item_id == "podcast-item":
+                return podcast_library_item()
+            return {
+                "media": {
+                    "duration": 7200,
+                    "metadata": {"title": "The Hobbit"},
+                },
+            }
+
+        mock_item.side_effect = library_item
+
+        counts, _ = AudiobookshelfImporter(self.user).import_data()
+
+        self.assertEqual(counts.get(MediaTypes.BOOK.value), 1)
+        self.assertEqual(counts.get(MediaTypes.PODCAST.value), 1)
 
     @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
     @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")


### PR DESCRIPTION
Hi!
I found this project when initially looking at YamTrack. I was delighted to see
support for Audiobookshelf already but then noticed podcast tracking does not
work through ABS. I had Claude Opus have a go at it and this is the result.

It has worked very well so far against my actual setup, but of course feel free
to dismiss this if you are not interested in mostly vibe-coded contributions.

## Summary

The Audiobookshelf importer handled books only — every `/api/me` `mediaProgress` entry carrying an `episodeId` was dropped by an explicit `# Skip podcast episode progress in v1.` guard. Users who listen to podcasts in ABS got no tracking for them at all, even though Floppy already has first-class podcast models fed by the Pocket Casts and gpodder importers. This wires ABS into those same models.

How it works:

- `_split_progress_entries` replaces `_book_progress_entries` and returns `(book_entries, podcast_entries)` instead of discarding the podcast half. Books keep their existing path untouched.
- Podcast entries reuse `_partition_book_progress_entries` for cursor filtering, then group by `libraryItemId` — a podcast is one library item, so this is **one** `GET /api/items/{id}?expanded=1` per changed show, not per episode. `expanded=1` is required: only the expanded episode shape carries `duration`.
- `AudiobookshelfClient.get_library_item` gained an `expanded` kwarg, passed only when true so the existing book call signature is unchanged.
- Status mapping: `isFinished` → COMPLETED with `end_date=finishedAt` and `last_seen_status=3`; `currentTime > 0` → IN_PROGRESS, `last_seen_status=2`. Touched-but-unplayed entries are skipped rather than written as zero-progress rows. `played_up_to_seconds` is seconds, `progress` is minutes, per the existing podcast convention. Completed rows are lifted to full runtime by `Media.process_status`, so no back-fill is done here.
- Existing in-progress rows are updated in place instead of accumulating a new row per sync.
- Show artwork prefers the public `metadata.imageUrl` and only falls back to the auth-gated `/api/items/{id}/cover`, so covers render for clients that are not logged into ABS.

Two decisions worth calling out:

**Shared cursor.** Books and podcasts share one `last_sync_ms`. If `max_seen` folded in only book `lastUpdate` values, podcast progress would either replay forever or be skipped the moment a book advanced the cursor past it. `max_seen = max(max_seen, podcast_max_seen)` is the fix, and there is a dedicated test for it.

**Raw RSS guid as `episode_uuid`.** Floppy's own `refresh_show_episodes_from_rss` keys episodes by feed guid. Synthesizing an ABS-specific uuid would make every imported episode duplicate against the next RSS refresh; keeping the guid makes them merge. Verified on live data — visiting an imported show pulled its feed and merged cleanly with zero duplicates. `enclosure.url` then `abs_{episodeId}` cover feeds without guids.

No migration: `Sources.AUDIOBOOKSHELF` is already permitted by the `app_item_source_valid` check constraint and by `0124_podcastshow_source`.

Known pre-existing limitation, not introduced here: the "View activity history" button on an episode card builds `hx-target="#{% component_id 'history' episode.item %}"` from the raw `media_id`, so a guid containing `/` or `.` yields an invalid CSS selector and htmx never fires the request. Reproducible with `gpodder`- and `pocketcasts`-sourced items too. Left alone deliberately — the fix belongs in `component_id`, touches every media type, and does not belong in this PR.

## Validation

- `scripts/test.sh integrations.tests.imports.test_audiobookshelf` → **OK, 25 tests**. The old `test_skips_podcast_episode_progress` is replaced by 9 podcast tests: basic import, completed mapping, no-activity skip, uuid fallback ladder, cursor coverage plus no-refetch, in-place row update, feed-URL convergence onto an existing gpodder show, missing-episode warning, and a mixed book+podcast payload.
- `scripts/test.sh` (fast suite) → 2959 tests, `FAILED (failures=13, errors=3)`. All 16 verified pre-existing: the identical 16 fail at the base commit `59c22f5` in a clean worktree. They are TVDB/genre-backfill, Plex genesis, collection-modal and statistics tests; none touch podcasts or Audiobookshelf.
- `ruff check` on the touched files → same count as the pre-change baseline
- End-to-end against a real Audiobookshelf server

## Notes

- Files touched: `src/integrations/imports/audiobookshelf.py` (the feature), `src/integrations/tests/imports/test_audiobookshelf.py`, and one-line source-allowlist additions in `src/api/fork_helpers.py`, `src/app/config.py`, `src/app/discover/tab_cache.py`, `src/app/media_details_views.py`, `src/app/services/bulk_episode_tracking.py`, `src/app/services/tracking_hydration.py`, `src/app/tasks_bulk_plays.py`, `src/app/track_modal_views.py`.
- Behavior change for existing users: ABS podcast progress now imports where it previously did not. Users whose sync cursor has already advanced past their podcast history need a one-time `last_sync_ms` reset to backfill; ongoing syncs need nothing.
- No new settings, env vars, dependencies, or migrations.
