### PR TITLE
fix: mcp server search and track

### DIFF
--- a/mcp_server/floppy_mcp/server.py
+++ b/mcp_server/floppy_mcp/server.py
@@ -78,7 +78,7 @@ async def search_media(media_type: str, query: str, page: int = 1) -> Any:
     return await _call(
         "get",
         f"search/{media_type}",
-        params={"q": query, "page": page},
+        params={"search": query, "page": page},
     )
 
 
@@ -186,8 +186,19 @@ async def track_media(
         "notes": notes,
     }
     body = {k: v for k, v in body.items() if v is not None}
+    # media/{type}/{source}/{id} resolves provider metadata for ANY known
+    # item, tracked or not — it 200s even when nothing is tracked yet (it
+    # returns {"tracked": False, "id": None, ...} in that case). Checking
+    # only "did the GET error" therefore always looked truthy and this
+    # always PATCHed, even for brand-new items, which the API 404s on.
+    # The correct signal for "does a consumption record already exist" is
+    # the `tracked` flag (or a non-null `id`), not just GET success.
     existing = await _call("get", f"media/{media_type}/{source}/{media_id}")
-    if isinstance(existing, dict) and not existing.get("error"):
+    if (
+        isinstance(existing, dict)
+        and not existing.get("error")
+        and existing.get("tracked")
+    ):
         return await _call(
             "patch",
             f"media/{media_type}/{source}/{media_id}",


### PR DESCRIPTION
## Summary
Update search parameters and logic for existing media checks. The search used the wrong parameter and was therefore broken. The tracking error logic was always returning 200.

## Validation
Tried to do various searches using the mcp server which failed before and are working now.

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)
- [x] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [x] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

## Notes
- Link relevant issues (for example: `Refs #101`).
