### PR TITLE
Fix custom metadata on manual episodes

### DIFF
--- a/src/api/fork_views_metadata.py
+++ b/src/api/fork_views_metadata.py
@@ -27,13 +27,25 @@ from .schema import MEDIA_TYPE_PARAM, MEDIA_TYPE_TV_ONLY_PARAM
 logger = logging.getLogger(__name__)
 
 
+def _owned_media_queryset(user, item):
+    """Return the user's tracked-media rows for an item.
+
+    Episode rows have no `user` column -- ownership is inherited from the
+    related season -- so filtering them by `user=` raises FieldError and turns
+    every episode metadata override into a 500.
+    """
+    media_model = apps.get_model("app", item.media_type)
+    if item.media_type == MediaTypes.EPISODE.value:
+        return media_model.objects.filter(related_season__user=user, item=item)
+    return media_model.objects.filter(user=user, item=item)
+
+
 def _get_owned_tracked_item(user, item_id):
     """Return the Item if the user tracks it, else None."""
     item = Item.objects.filter(id=item_id).first()
     if item is None:
         return None
-    media_model = apps.get_model("app", item.media_type)
-    if not media_model.objects.filter(user=user, item=item).exists():
+    if not _owned_media_queryset(user, item).exists():
         return None
     return item
 

--- a/src/api/tests/test_fork_metadata.py
+++ b/src/api/tests/test_fork_metadata.py
@@ -4,11 +4,13 @@ from http import HTTPStatus as HTTP  # noqa: N814
 from unittest.mock import patch
 
 from app.models import (
+    TV,
     Episode,
     Item,
     MediaTypes,
     MetadataProviderPreference,
     Movie,
+    Season,
     Sources,
 )
 
@@ -99,6 +101,101 @@ class ItemMetadataTests(FloppyApiTestCase):
             response.status_code,
             (HTTP.BAD_REQUEST, HTTP.OK),
         )
+
+
+class ManualEpisodeMetadataTests(FloppyApiTestCase):
+    """PATCH /metadata/items/{id} on a manual episode.
+
+    Episode rows have no ``user`` column -- ownership is inherited from the
+    related season -- so the ownership check has to join through it.
+    """
+
+    def setUp(self):
+        """Track a manual show with one season and one episode."""
+        super().setUp()
+        tv_item = Item.objects.create(
+            media_id="manual-tv-1",
+            source=Sources.MANUAL.value,
+            media_type=MediaTypes.TV.value,
+            title="Manual Show",
+        )
+        tv = TV.objects.create(item=tv_item, user=self.user1)
+        season_item = Item.objects.create(
+            media_id="manual-tv-1",
+            source=Sources.MANUAL.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Manual Show",
+            season_number=2026,
+        )
+        self.season = Season.objects.create(
+            item=season_item,
+            user=self.user1,
+            related_tv=tv,
+        )
+        self.episode_item = Item.objects.create(
+            media_id="manual-tv-1",
+            source=Sources.MANUAL.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Manual Show",
+            season_number=2026,
+            episode_number=1,
+        )
+        Episode.objects.create(item=self.episode_item, related_season=self.season)
+
+    def test_update_manual_episode_metadata(self):
+        """Episode overrides are stored instead of raising."""
+        response = self.call_api(
+            "patch",
+            "api_item_metadata",
+            args=(self.episode_item.id,),
+            payload={"episode_title": "A video about spinning things"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, HTTP.OK)
+        self.episode_item.refresh_from_db()
+        self.assertEqual(
+            self.episode_item.manual_metadata["episode_title"],
+            "A video about spinning things",
+        )
+
+    def test_other_users_episode_not_found(self):
+        """An episode in someone else's library still 404s."""
+        response = self.call_api(
+            "patch",
+            "api_item_metadata",
+            args=(self.episode_item.id,),
+            payload={"episode_title": "Nope"},
+            headers=self.auth_headers2,
+        )
+        self.assertEqual(response.status_code, HTTP.NOT_FOUND)
+
+    def test_watching_an_episode_with_a_string_runtime(self):
+        """Manual items store the runtime as a string; watching must survive it."""
+        season_metadata = {
+            "episodes": [
+                {
+                    "episode_number": 1,
+                    "title": "A video about spinning things",
+                    "image": "https://example.com/episode.jpg",
+                    "runtime": "12",
+                },
+            ],
+        }
+        with patch(
+            "app.providers.services.get_media_metadata",
+            return_value=season_metadata,
+        ):
+            self.season.watch(1, datetime.datetime.now(tz=datetime.UTC))
+
+        self.assertEqual(
+            Episode.objects.filter(
+                related_season=self.season,
+                item__episode_number=1,
+            ).count(),
+            2,
+        )
+        self.episode_item.refresh_from_db()
+        self.assertEqual(self.episode_item.runtime_minutes, 12)
 
 
 class ProviderPreferenceTests(FloppyApiTestCase):

--- a/src/app/metadata_sync_views.py
+++ b/src/app/metadata_sync_views.py
@@ -155,7 +155,13 @@ def update_manual_item_metadata(request, item_id):
     return_url = helpers.normalize_navigation_url(request.POST.get("return_url"))
     item = get_object_or_404(Item, id=item_id)
     media_model = apps.get_model("app", item.media_type)
-    if not media_model.objects.filter(user=request.user, item=item).exists():
+    # Episode rows have no `user` column -- ownership is inherited from the
+    # related season -- so filtering them by `user=` raises FieldError.
+    if item.media_type == MediaTypes.EPISODE.value:
+        owned = media_model.objects.filter(related_season__user=request.user, item=item)
+    else:
+        owned = media_model.objects.filter(user=request.user, item=item)
+    if not owned.exists():
         messages.error(request, "You can only update metadata for items in your library.")
         return helpers.redirect_back(request)
 

--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -24,6 +24,19 @@ from app.models.media import Media
 logger = logging.getLogger(__name__)
 
 
+def _runtime_minutes(value):
+    """Return a positive runtime in minutes, or None.
+
+    Providers disagree on the type: TMDB sends an int, manual items store the
+    string the custom-metadata form was filled in with.
+    """
+    try:
+        minutes = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return minutes if minutes > 0 else None
+
+
 class TV(Media):
     """Model for TV shows."""
 
@@ -1031,10 +1044,10 @@ class Season(Media):
                 matched_episode.get("image"),
             )
 
-            # Extract runtime from episode metadata (raw TMDB data has integer runtime in minutes)
-            if matched_episode.get("runtime") is not None:
-                # Runtime is an integer (minutes) from TMDB
-                runtime_minutes = int(matched_episode["runtime"]) if matched_episode["runtime"] > 0 else None
+            # Extract runtime from episode metadata. TMDB sends an integer
+            # number of minutes, manual items whatever the custom-metadata form
+            # stored (a string), so compare only after coercing.
+            runtime_minutes = _runtime_minutes(matched_episode.get("runtime"))
 
             # Extract release_datetime from episode air_date
             air_date = matched_episode.get("air_date")


### PR DESCRIPTION
Custom-metadata overrides on a manual **episode** never worked. Two separate bugs, both reachable from the web UI and the API.

### 1. Ownership check looks for a column Episode does not have

`api/fork_views_metadata.py::_get_owned_tracked_item` and `app/metadata_sync_views.py::update_manual_item_metadata` both do:

```python
media_model = apps.get_model("app", item.media_type)
media_model.objects.filter(user=user, item=item).exists()
```

`Episode` has no `user` field — ownership is inherited from `related_season` — so this raises `FieldError: Cannot resolve keyword 'user' into field`. Every episode override ends in a 500 on `PATCH /api/v1/metadata/items/<id>/`, and an error page in the web view. Episodes are listed in `MEDIA_TYPE_FIELD_ORDER`, so this path is meant to work.

Fixed by joining through `related_season__user` for episodes.

### 2. Episode runtime is compared before it is coerced

`app/models/tv.py::get_episode_item`:

```python
runtime_minutes = int(matched_episode["runtime"]) if matched_episode["runtime"] > 0 else None
```

TMDB sends an int, so this holds there. Manual items store whatever the custom-metadata form was filled in with, which comes back as a string, and `'12' > 0` raises `TypeError`. Consequence: once an episode has a custom runtime, **every** later watch of that episode 500s (`POST .../episodes/<n>/watch/`, and the same call from the web UI).

Fixed with a small `_runtime_minutes()` helper that coerces first and rejects non-positive or unparsable values.

### Tests

`api/tests/test_fork_metadata.py::ManualEpisodeMetadataTests` covers both. Each test fails on `latest` and passes with the fix.

### How I ran into this

Building a Kodi addon that logs watched YouTube/Mediathek videos into Floppy as manual episodes — one show per channel, one season per year. Recording the play works; giving the episode the video's title did not.