### PR TITLE
Fix Trakt export duplicate media bulk import

### DIFF
--- a/src/integrations/imports/helpers.py
+++ b/src/integrations/imports/helpers.py
@@ -9,7 +9,6 @@ from cryptography.fernet import Fernet, InvalidToken
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
-from django.db.utils import OperationalError
 from django.utils import timezone
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
 from requests import RequestException
@@ -17,12 +16,7 @@ from simple_history.utils import bulk_create_with_history
 
 import app
 from app import providers
-from app.db_retry import (
-    is_disk_io_error,
-    is_lock_error,
-    is_retryable_error,
-    run_retryable_db_operation,
-)
+from app.db_retry import run_retryable_db_operation
 from app.models import Episode, MediaTypes, Status
 
 logger = logging.getLogger(__name__)
@@ -281,6 +275,47 @@ def _backfill_completed_season_episodes(seasons):
         bulk_create_with_history(episodes_to_create, Episode, batch_size=500)
 
 
+def _has_unique_user_item_constraint(model):
+    """Return whether model enforces one row per user/item pair."""
+    return any(
+        tuple(getattr(constraint, "fields", ())) == ("user", "item")
+        for constraint in model._meta.constraints
+    )
+
+
+def _merge_duplicate_media_row(existing, duplicate):
+    """Fold non-empty imported values from duplicate into the kept row."""
+    for field in duplicate._meta.fields:
+        if field.primary_key or field.name in {"created_at", "item", "user"}:
+            continue
+        value = getattr(duplicate, field.name)
+        if value not in (None, ""):
+            setattr(existing, field.name, value)
+
+    if hasattr(duplicate, "_history_date"):
+        existing._history_date = duplicate._history_date
+
+
+def _deduplicate_unique_user_item_rows(model, bulk_media):
+    """Remove duplicate unsaved rows that would violate a user/item import key."""
+    if not _has_unique_user_item_constraint(model):
+        return bulk_media
+
+    deduplicated = []
+    by_user_item = {}
+    for media_obj in bulk_media:
+        key = (media_obj.user_id, media_obj.item_id)
+        existing = by_user_item.get(key)
+        if existing is None:
+            by_user_item[key] = media_obj
+            deduplicated.append(media_obj)
+            continue
+
+        _merge_duplicate_media_row(existing, media_obj)
+
+    return deduplicated
+
+
 def bulk_create_media(bulk_media_list, user):
     """Bulk create all media objects."""
     for media_type in _ordered_media_types(bulk_media_list):
@@ -289,6 +324,7 @@ def bulk_create_media(bulk_media_list, user):
             continue
 
         model = apps.get_model(app_label="app", model_name=media_type)
+        bulk_media = _deduplicate_unique_user_item_rows(model, bulk_media)
 
         logger.info("Bulk importing %s", media_type)
 

--- a/src/integrations/tests/imports/test_trakt_export.py
+++ b/src/integrations/tests/imports/test_trakt_export.py
@@ -13,12 +13,15 @@ from app.models import (
     TV,
     CollectionEntry,
     Episode,
+    Item,
     MediaTypes,
     Movie,
     Season,
+    Sources,
     Status,
 )
 from app.providers import services
+from integrations.imports import helpers
 from integrations.imports.helpers import MediaImportError
 from integrations.imports.trakt_export import TraktExportArchive, importer
 from lists.models import CustomList, CustomListItem
@@ -194,6 +197,32 @@ class ImportTraktExport(TestCase):
         """Create user for the tests."""
         credentials = {"username": "test", "password": "12345"}
         self.user = get_user_model().objects.create_user(**credentials)
+
+    def test_duplicate_show_rows_are_deduplicated_before_bulk_create(self):
+        """Duplicate in-memory rows must not abort a large export import."""
+        item = Item.objects.create(
+            media_id="12345",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Duplicate Show",
+            image="",
+        )
+
+        helpers.bulk_create_media(
+            {
+                MediaTypes.TV.value: [
+                    TV(item=item, user=self.user, status=Status.IN_PROGRESS.value),
+                    TV(item=item, user=self.user, status=Status.COMPLETED.value),
+                ],
+            },
+            self.user,
+        )
+
+        self.assertEqual(TV.objects.filter(user=self.user, item=item).count(), 1)
+        self.assertEqual(
+            TV.objects.get(user=self.user, item=item).status,
+            Status.COMPLETED.value,
+        )
 
     @patch("integrations.imports.trakt.TraktImporter._get_metadata")
     def test_history_creates_movie_and_episodes(self, mock_get_metadata):


### PR DESCRIPTION
## Summary
- Fixes Trakt export imports aborting when the in-memory import batch contains duplicate rows for a model that enforces one row per user/item.
- Keeps the first queued row and folds non-empty values from later duplicates before `bulk_create_with_history` runs.
- Fixes #435.

## Validation
- RED: `SECRET=*** DATABASE_URL=sqlite:///$(pwd)/src/db/test.sqlite3 scripts/test.sh integrations.tests.imports.test_trakt_export.ImportTraktExport.test_duplicate_show_rows_are_deduplicated_before_bulk_create` failed with `django.db.utils.IntegrityError: UNIQUE constraint failed: app_tv.user_id, app_tv.item_id`.
- GREEN: same targeted test passed: `Ran 1 test ... OK`.
- GREEN: `SECRET=*** DATABASE_URL=sqlite:///$(pwd)/src/db/test.sqlite3 scripts/test.sh integrations.tests.imports.test_trakt_export` passed: `Ran 23 tests ... OK`.
- GREEN: `ruff check src/integrations/imports/helpers.py src/integrations/tests/imports/test_trakt_export.py` passed: `All checks passed!`.
- GREEN: `python -m py_compile src/integrations/imports/helpers.py src/integrations/tests/imports/test_trakt_export.py` passed.
- GREEN: `git diff --check` passed.

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)
- [ ] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [ ] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

Not a `dev` -> `latest` sync PR; migration sync gate is not applicable.

## Screenshots
Backend import-path change only; no UI/templates/CSS touched, so screenshots are not applicable.

## AI Assistance
Generated with Hermes Agent (OpenAI Codex provider). Reviewed via focused regression tests and lint locally.

## Notes
- Duplicate preflight: issue #435 is open/unassigned with no contributor comments; open PR list only showed unrelated ruff backlog PR #393.
