### PR TITLE
Use Audiobookshelf publication data so books stop re-repairing

### DIFF
--- a/src/integrations/imports/audiobookshelf.py
+++ b/src/integrations/imports/audiobookshelf.py
@@ -37,6 +37,13 @@ BOOK_METADATA_PROVIDER_ORDER = (
     Sources.OPENLIBRARY.value,
 )
 TITLE_MATCH_THRESHOLD = 0.72
+# (strptime format, characters to feed it) pairs, most specific first.
+PUBLISHED_DATE_FORMATS = (
+    ("%Y-%m-%d", 10),
+    ("%d-%b-%Y", 11),
+    ("%Y-%m", 7),
+    ("%Y", 4),
+)
 
 
 class AudiobookshelfClientError(Exception):
@@ -261,6 +268,8 @@ class AudiobookshelfImporter:
         should_enrich = (
             self._should_prefer_provider_cover(image)
             or not authors_list
+            or not publishers
+            or not genres
         )
         provider_metadata = (
             self._resolve_provider_metadata(
@@ -294,6 +303,8 @@ class AudiobookshelfImporter:
             if isinstance(provider_metadata, dict)
             else None
         )
+        if release_datetime is None:
+            release_datetime = self._extract_published_datetime(metadata)
         if not series_name:
             series_name = provider_metadata.get("series_name") if isinstance(provider_metadata, dict) else None
         if series_position is None:
@@ -891,11 +902,13 @@ class AudiobookshelfImporter:
             return True
 
         image = item.image or ""
+        # A missing ISBN is not a defect for audiobooks: ABS carries an ASIN for
+        # most audio editions and no ISBN at all, so requiring one here marked
+        # those items unhealthy forever and re-repaired them on every sync.
         return any(
             (
                 self._is_stale_abs_cover(image),
                 not item.authors,
-                not item.isbn,
                 not item.publishers,
                 not item.genres,
                 item.release_datetime is None,
@@ -984,6 +997,26 @@ class AudiobookshelfImporter:
         if len(candidate) in (10, 13):
             return candidate
         return ""
+
+    def _extract_published_datetime(self, metadata: dict[str, Any]):
+        """Build a release datetime from the ABS publication fields.
+
+        ABS exposes publishedDate ("2022-08-26") and publishedYear, which is
+        usually a bare year but sometimes carries a full date ("26-Aug-2022").
+        Used as a fallback when provider enrichment supplies no release date,
+        so books keep a release date even without a provider match.
+        """
+        for raw in (metadata.get("publishedDate"), metadata.get("publishedYear")):
+            if not raw:
+                continue
+            value = str(raw).strip()
+            for fmt, length in PUBLISHED_DATE_FORMATS:
+                try:
+                    parsed = datetime.strptime(value[:length], fmt)  # noqa: DTZ007
+                except ValueError:
+                    continue
+                return parsed.replace(tzinfo=UTC)
+        return None
 
     def _extract_publisher(self, metadata: dict[str, Any]):
         raw = metadata.get("publisher") or metadata.get("publishers")

--- a/src/integrations/tests/imports/test_audiobookshelf.py
+++ b/src/integrations/tests/imports/test_audiobookshelf.py
@@ -1103,3 +1103,130 @@ class AudiobookshelfImporterTests(TestCase):
         self.assertEqual(counts, {})
         self.assertEqual(warnings, "")
         mock_item.assert_not_called()
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_release_date_falls_back_to_abs_published_year(
+        self,
+        mock_me,
+        mock_item,
+    ):
+        """ABS publishedYear should set the release date without a provider."""
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "year-item",
+                    "currentTime": 600,
+                    "duration": 7_200,
+                    "lastUpdate": 1_000,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {
+                "duration": 7_200,
+                "metadata": {
+                    "title": "Zeitbruch",
+                    "authors": [{"name": "Tom Hillenbrand"}],
+                    "publisher": "Ronin Hörverlag",
+                    "genres": ["Science Fiction"],
+                    "publishedYear": "2021",
+                },
+            },
+            "coverPath": "https://covers.example/zeitbruch.jpg",
+        }
+
+        importer = AudiobookshelfImporter(self.user)
+        importer.import_data()
+
+        item = Book.objects.get(user=self.user).item
+        self.assertEqual(item.release_datetime, datetime(2021, 1, 1, tzinfo=UTC))
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_release_date_parses_day_month_year_published_year(
+        self,
+        mock_me,
+        mock_item,
+    ):
+        """ABS sometimes puts a full date in publishedYear."""
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "date-item",
+                    "currentTime": 600,
+                    "duration": 7_200,
+                    "lastUpdate": 1_000,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {
+                "duration": 7_200,
+                "metadata": {
+                    "title": "Freiheitsgeld",
+                    "authors": [{"name": "Andreas Eschbach"}],
+                    "publisher": "BASTEI LÜBBE",
+                    "genres": ["Thriller"],
+                    "publishedYear": "26-Aug-2022",
+                },
+            },
+            "coverPath": "https://covers.example/freiheitsgeld.jpg",
+        }
+
+        importer = AudiobookshelfImporter(self.user)
+        importer.import_data()
+
+        item = Book.objects.get(user=self.user).item
+        self.assertEqual(item.release_datetime, datetime(2022, 8, 26, tzinfo=UTC))
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_does_not_repair_hydrated_book_without_isbn(self, mock_me, mock_item):
+        """Audiobooks without an ISBN are healthy and must not be re-repaired."""
+        account = self.user.audiobookshelf_account
+        account.last_sync_ms = 2_000
+        account.save(update_fields=["last_sync_ms", "updated_at"])
+
+        importer = AudiobookshelfImporter(self.user)
+        media_id = importer._stable_media_id(account.base_url, "no-isbn-item")
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.AUDIOBOOKSHELF.value,
+            media_type=MediaTypes.BOOK.value,
+            title="Der Heimweg",
+            original_title="Der Heimweg",
+            localized_title="Der Heimweg",
+            image="https://covers.example/heimweg.jpg",
+            authors=["Sebastian Fitzek"],
+            isbn=[],
+            publishers="Audible Studios",
+            genres=["Psychothriller"],
+            release_datetime=datetime(2020, 1, 1, tzinfo=UTC),
+            format="audiobook",
+            metadata_fetched_at=timezone.now(),
+        )
+        Book.objects.create(
+            user=self.user,
+            item=item,
+            status=Status.IN_PROGRESS.value,
+            progress=60,
+        )
+
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "no-isbn-item",
+                    "currentTime": 3_600,
+                    "duration": 12_000,
+                    "lastUpdate": 1_500,
+                },
+            ],
+        }
+
+        importer = AudiobookshelfImporter(self.user)
+        counts, warnings = importer.import_data()
+
+        self.assertEqual(counts, {})
+        self.assertEqual(warnings, "")
+        mock_item.assert_not_called()


### PR DESCRIPTION
## Problem

Audiobookshelf books are selected as repair candidates on every sync and never become healthy, so the importer re-fetches them forever.

Two conditions in `_needs_book_repair` can't be satisfied by the data the importer collects:

- **`release_datetime`** is only read from provider enrichment (`_upsert_book`), never from ABS — even though ABS supplies `publishedYear` (and sometimes `publishedDate`) for practically every library item.
- **`not item.isbn`** treats a missing ISBN as a defect, but audiobook editions routinely have no ISBN. ABS carries an ASIN instead (`isbn=None, asin=B0BCWLNPYB`).

There's a third, related gap: `should_enrich` only fires when the cover is provider-preferred or authors are empty, so the `publishers`/`genres` provider fallbacks below it are unreachable for items that have an ABS cover and authors — exactly the items whose publisher is missing.

Measured on a real 31-book library: 18 items permanently unhealthy (12 missing release date, 10 missing ISBN, 6 missing publisher), each costing an ABS library-item fetch plus a provider lookup every two hours, with every scheduled run logging `Imported 18 Books` when nothing changed.

## Solution

- Add `_extract_published_datetime`, parsing ABS `publishedDate`/`publishedYear` (`2021`, `2022-08-26`, and the `26-Aug-2022` form ABS also emits), used as a fallback when provider enrichment yields no release date.
- Drop `not item.isbn` from the repair check, with a comment explaining why an ISBN-less audiobook is healthy.
- Extend `should_enrich` to also fire on a missing publisher or genre list, so those fields can actually be filled rather than re-detected on every pass.

Net effect: repairs now converge instead of running indefinitely.

## Validation

```
SECRET=… python -m pytest integrations/tests/imports/test_audiobookshelf.py -q
28 passed, 5 warnings in 40.75s
```

Three new tests: `publishedYear` → release date, `26-Aug-2022` form → release date, and a hydrated ISBN-less book that must not trigger a repair lookup (`mock_item.assert_not_called()`).

`ruff check` on both touched files reports the same 27 pre-existing findings as on `latest` — no new ones.

Source data confirmed against a live ABS instance: all 31 items in the test library had `publishedYear` populated.

## Screenshots

N/A — importer-only change, no template, CSS, or UI surface touched.

## AI Assistance

Generated with Claude Code (claude-opus-4-5). Diagnosed from production import logs, reviewed and tested manually.