### PR TITLE
Tag the tests that need a live provider API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,7 +341,12 @@ Notes:
 - Quick confidence: `ruff check src`
 - Migration sync confidence: `cd src && python manage.py check_migration_hygiene --strict`
 - Upstream sync replay: `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios`
-- Tag vocabulary: `slow` is the exclusion tag used by the fast suite; `benchmark` and `playwright` are sub-selectors (`scripts/test.sh --slow` runs only tagged tests). Any new benchmark/performance or Playwright test **must** be decorated with `@tag("slow", ...)`.
+- Tag vocabulary: `slow` and `network` are the exclusion tags used by the fast
+  suite. `network` marks tests that call a live provider API: they need keys and
+  internet, they are slow and flaky, and a fork PR cannot read repository secrets,
+  so CI excludes them. Run them with `scripts/test.sh --network`. If you add a test
+  that needs a real provider response, either mock it or tag it.
+- `slow` is the exclusion tag used by the fast suite; `benchmark` and `playwright` are sub-selectors (`scripts/test.sh --slow` runs only tagged tests). Any new benchmark/performance or Playwright test **must** be decorated with `@tag("slow", ...)`.
 - `playwright install` is only needed when actually running Playwright-tagged tests (`scripts/test.sh --full` / `--slow`); the fast suite excludes them.
 - `src/manage.py` sets `DJANGO_SETTINGS_MODULE=config.test_settings` for tests.
 - `config.test_settings` uses fakeredis and sets `CELERY_TASK_ALWAYS_EAGER=True`.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,9 @@
 #   scripts/test.sh --full                Full suite incl. slow tests (20+ min,
 #                                         needs `playwright install`)
 #   scripts/test.sh --slow                Only @tag("slow") tests
+#   scripts/test.sh --network             Only @tag("network") tests (needs API
+#                                         keys and internet; excluded by default
+#                                         because they are slow and flaky)
 #
 # Extra manage.py test flags (e.g. -v 2, --failfast) pass through after the mode.
 set -euo pipefail
@@ -26,8 +29,13 @@ case "${1:-}" in
     shift
     exec python src/manage.py test "${APPS[@]}" "${COMMON[@]}" --tag slow "$@"
     ;;
+  --network)
+    shift
+    exec python src/manage.py test "${APPS[@]}" "${COMMON[@]}" --tag network "$@"
+    ;;
   "")
-    exec python src/manage.py test "${APPS[@]}" "${COMMON[@]}" --exclude-tag slow
+    exec python src/manage.py test "${APPS[@]}" "${COMMON[@]}" \
+      --exclude-tag slow --exclude-tag network
     ;;
   *)
     exec python src/manage.py test "${COMMON[@]}" "$@"

--- a/src/app/tests/models/test_tv.py
+++ b/src/app/tests/models/test_tv.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from app.models import (
     TV,
@@ -137,6 +137,7 @@ class TVModel(TestCase):
             datetime(2023, 6, 5, 0, 0, tzinfo=UTC),
         )
 
+    @tag("network")
     def test_tv_save(self):
         """Test the custom save method of the TV model."""
         self.tv.status = Status.COMPLETED.value

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import requests
 from django.conf import settings
 from django.core.cache import cache
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 
 from app.credits import _normalize_credit_rows
 from app.models import Episode, Item, MediaTypes, Sources
@@ -62,6 +62,7 @@ class Metadata(TestCase):
         self.assertEqual(response["details"]["status"], "Finished")
         self.assertEqual(response["details"]["number_of_chapters"], 162)
 
+    @tag("network")
     def test_mangaupdates(self):
         """Test the metadata method for manga from mangaupdates."""
         response = mangaupdates.manga("72274276213")
@@ -69,6 +70,7 @@ class Metadata(TestCase):
         self.assertEqual(response["details"]["year"], "1994")
         self.assertEqual(response["details"]["format"], "Manga")
 
+    @tag("network")
     def test_tv(self):
         """Test the metadata method for TV shows."""
         response = tmdb.tv("1396")
@@ -1465,6 +1467,7 @@ class Metadata(TestCase):
         next_episode = tmdb.find_next_episode(5, episodes_metadata)
         self.assertIsNone(next_episode)
 
+    @tag("network")
     def test_movie(self):
         """Test the metadata method for movies."""
         response = tmdb.movie("10494")
@@ -1704,12 +1707,14 @@ class Metadata(TestCase):
         with self.assertRaises(ValueError, msg="IGDB game IDs must be numeric"):
             igdb.game("game-123")
 
+    @tag("network")
     def test_external_game_steam(self):
         """Test the external_game method for Steam games."""
         igdb_game_id = igdb.external_game("292030", igdb.ExternalGameSource.STEAM)
 
         self.assertEqual(igdb_game_id, 1942)
 
+    @tag("network")
     def test_external_game_not_found(self):
         """Test the external_game method with non-existent Steam ID."""
         igdb_game_id = igdb.external_game("999999999", igdb.ExternalGameSource.STEAM)

--- a/src/app/tests/providers/test_search.py
+++ b/src/app/tests/providers/test_search.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from app.models import MediaTypes, Sources
 from app.providers import (
@@ -43,6 +43,7 @@ class Search(TestCase):
 
         self.assertEqual(response["results"], [])
 
+    @tag("network")
     def test_mangaupdates(self):
         """Test the search method for manga.
 
@@ -54,12 +55,14 @@ class Search(TestCase):
         for manga in response["results"]:
             self.assertTrue(all(key in manga for key in required_keys))
 
+    @tag("network")
     def test_manga_not_found(self):
         """Test the search method for manga with no results."""
         response = mangaupdates.search("", 1)
 
         self.assertEqual(response["results"], [])
 
+    @tag("network")
     def test_tv(self):
         """Test the search method for TV shows.
 
@@ -71,6 +74,7 @@ class Search(TestCase):
         for tv in response["results"]:
             self.assertTrue(all(key in tv for key in required_keys))
 
+    @tag("network")
     def test_games(self):
         """Test the search method for games.
 
@@ -168,6 +172,7 @@ class Search(TestCase):
         for book in response["results"]:
             self.assertTrue(all(key in book for key in required_keys))
 
+    @tag("network")
     def test_comics(self):
         """Test the search method for comics.
 

--- a/src/app/tests/test_statistics.py
+++ b/src/app/tests/test_statistics.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -1340,6 +1340,7 @@ class ConsumptionStatisticsTests(TestCase):
             end_date=now - datetime.timedelta(hours=6),
         )
 
+    @tag("network")
     def test_consumption_stats_aggregation(self):
         """TV/movie consumption helpers should return expected totals and chart data."""
         with patch(

--- a/src/app/tests/views/test_crud.py
+++ b/src/app/tests/views/test_crud.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -65,6 +65,7 @@ class CreateMedia(TestCase):
             True,
         )
 
+    @tag("network")
     @override_settings(MEDIA_ROOT=("create_media"))
     def test_create_tv(self):
         """Test the creation of a TV object through views."""
@@ -382,6 +383,7 @@ class CreateMedia(TestCase):
             self.assertEqual(item.genres, expected_genres)
             self.assertTrue(model.objects.filter(item=item, user=self.user).exists())
 
+    @tag("network")
     def test_create_season(self):
         """Test the creation of a Season through views."""
         Item.objects.create(
@@ -471,6 +473,7 @@ class CreateMedia(TestCase):
             1,
         )
 
+    @tag("network")
     def test_create_episodes(self):
         """Test the creation of Episode through views."""
         self.client.post(
@@ -662,6 +665,7 @@ class CreateMedia(TestCase):
             2,
         )
 
+    @tag("network")
     @patch("app.views.ensure_item_metadata")
     def test_create_game_htmx_returns_activity_subtitle_update(
         self, ensure_item_metadata_mock
@@ -1254,6 +1258,7 @@ class EditMedia(TestCase):
         game.refresh_from_db()
         self.assertIsNone(game.start_date)
 
+    @tag("network")
     @patch("app.views.ensure_item_metadata")
     def test_create_movie_htmx_inserts_score_chip_slot(self, ensure_item_metadata_mock):
         """HTMX tracker creation should insert the score chip into the page."""

--- a/src/integrations/tests/imports/test_imdb.py
+++ b/src/integrations/tests/imports/test_imdb.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.utils import timezone
 
 from app.models import (
@@ -32,6 +32,7 @@ class ImportIMDB(TestCase):
         with Path(mock_path / "import_imdb.csv").open("rb") as file:
             self.import_results = imdb.importer(file, self.user, "new")
 
+    @tag("network")
     def test_import_imdb_csv(self):
         """Test importing movies and TV shows from IMDB CSV."""
         imported_counts, warnings = self.import_results
@@ -128,6 +129,7 @@ class ImportIMDB(TestCase):
 
         self.assertIsNone(result)
 
+    @tag("network")
     def test_duplicate_handling(self):
         """Test handling of duplicate IMDB entries that map to same TMDB ID."""
         imported_counts, warnings = self.import_results

--- a/src/integrations/tests/imports/test_mal.py
+++ b/src/integrations/tests/imports/test_mal.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import requests
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from app.models import (
     Anime,
@@ -92,6 +92,7 @@ class ImportMAL(TestCase):
         self.assertEqual(erased_item.localized_title, "Erased")
         self.assertEqual(erased_item.original_title, "Boku dake ga Inai Machi")
 
+    @tag("network")
     def test_user_not_found(self):
         """Test that an error is raised if the user is not found."""
         self.assertRaises(

--- a/src/integrations/tests/imports/test_simkl.py
+++ b/src/integrations/tests/imports/test_simkl.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -47,6 +47,7 @@ class ImportSimkl(TestCase):
             "new",
         )
 
+    @tag("network")
     @patch("integrations.imports.simkl.SimklImporter._get_user_list")
     def test_importer(
         self,

--- a/src/integrations/tests/imports/test_trakt_export.py
+++ b/src/integrations/tests/imports/test_trakt_export.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import requests
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.urls import reverse
 
 from app.models import (
@@ -305,6 +305,7 @@ class ImportTraktExport(TestCase):
         )
         self.assertEqual(watched, [1, 2])
 
+    @tag("network")
     @patch("integrations.imports.trakt.TraktImporter._get_metadata")
     def test_ratings_watchlist_and_comments(self, mock_get_metadata):
         """Ratings keep the raw 1-10 score; watchlist plans; comments become notes."""

--- a/src/integrations/tests/imports/test_yamtrack.py
+++ b/src/integrations/tests/imports/test_yamtrack.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pathlib import Path
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from app.models import (
     TV,
@@ -84,6 +84,7 @@ class ImportYamtrack(TestCase):
             datetime(2024, 2, 9, 12, 0, 0, tzinfo=UTC),
         )
 
+    @tag("network")
     def test_missing_metadata_handling(self):
         """Test _handle_missing_metadata method directly."""
         test_rows = [
@@ -136,6 +137,7 @@ class ImportYamtrack(TestCase):
             self.assertNotEqual(row["image"], original_row["image"])
 
 
+@tag("network")
 class ImportYamtrackPartials(TestCase):
     """Test importing yamtrack media with no ID."""
 
@@ -329,6 +331,7 @@ class ImportSampleTemplate(TestCase):
         file = BytesIO(content.encode("utf-8"))
         self.import_results, self.warnings = yamtrack.importer(file, self.user, "new")
 
+    @tag("network")
     def test_no_warnings(self):
         """The sample template should import without any warnings."""
         self.assertEqual(self.warnings, "")

--- a/src/integrations/tests/test_anime_mappings.py
+++ b/src/integrations/tests/test_anime_mappings.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, tag
 from django.urls import reverse
 
 from integrations.webhooks import anime_mappings
@@ -25,6 +25,7 @@ class AnimeMappingsTests(TestCase):
             [{"tvdb_id": "74796", "season_number": 17, "episode_offset": 13}],
         )
 
+    @tag("network")
     def test_fetch_mapping_data_downloads_mapping_data(self):
         """Test mapping data downloads from AniBridge."""
         mapping_data = anime_mappings.fetch_mapping_data()
@@ -32,6 +33,7 @@ class AnimeMappingsTests(TestCase):
         self.assertIn("tvdb_show:74796:s17", mapping_data)
         self.assertIn("anidb:3651:R", mapping_data)
 
+    @tag("network")
     def test_bleach_thousand_year_blood_war_part_two(self):
         """Test Bleach S17E14 maps to Thousand-Year Blood War part two."""
         mal_id, episode_number = anime_mappings.get_mal_id_from_tvdb(
@@ -44,6 +46,7 @@ class AnimeMappingsTests(TestCase):
         self.assertEqual(mal_id, 53998)
         self.assertEqual(episode_number, 1)
 
+    @tag("network")
     def test_bleach_season_one_maps_directly(self):
         """Test Bleach S01E09 maps directly to original Bleach progress."""
         mal_id, episode_number = anime_mappings.get_mal_id_from_tvdb(

--- a/src/integrations/tests/test_generic_scrobble_processor.py
+++ b/src/integrations/tests/test_generic_scrobble_processor.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from app.models import TV, Episode, Item, MediaTypes, Movie, Season, Sources, Status
 from integrations.webhooks.generic_scrobble import GenericScrobbleProcessor
@@ -98,6 +98,7 @@ class GenericScrobbleProcessPayloadTests(TestCase):
         )
         self.assertFalse(Movie.objects.filter(user=self.user).exists())
 
+    @tag("network")
     def test_movie_stop_marks_completed(self):
         """A completed movie stop event creates a completed Movie instance."""
         self.processor.process_payload(

--- a/src/integrations/tests/test_webhooks_emby.py
+++ b/src/integrations/tests/test_webhooks_emby.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, tag
 from django.urls import reverse
 
 from app.models import TV, Anime, Episode, Item, MediaTypes, Movie, Season, Status
@@ -25,6 +25,7 @@ class EmbyWebhookTests(TestCase):
         response = self.client.post(url, data={}, content_type="application/json")
         self.assertEqual(response.status_code, 401)
 
+    @tag("network")
     def test_tv_episode_mark_played(self):
         """Test webhook handles TV episode mark played event."""
         payload = {
@@ -150,6 +151,7 @@ class EmbyWebhookTests(TestCase):
         self.assertEqual(anime.status, Status.IN_PROGRESS.value)
         self.assertEqual(anime.progress, 1)
 
+    @tag("network")
     def test_movie_mark_played(self):
         """Test webhook handles movie mark played event."""
         payload = {
@@ -191,6 +193,7 @@ class EmbyWebhookTests(TestCase):
         self.assertEqual(movie.status, Status.COMPLETED.value)
         self.assertEqual(movie.progress, 1)
 
+    @tag("network")
     def test_anime_movie_mark_played(self):
         """Test webhook handles movie mark played event."""
         payload = {
@@ -324,6 +327,7 @@ class EmbyWebhookTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Movie.objects.count(), 0)
 
+    @tag("network")
     def test_repeated_watch(self):
         """Test webhook handles repeated watches."""
         payload = {

--- a/src/integrations/tests/test_webhooks_jellyfin.py
+++ b/src/integrations/tests/test_webhooks_jellyfin.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, tag
 from django.urls import reverse
 
 from app import live_playback
@@ -41,6 +41,7 @@ class JellyfinWebhookTests(TestCase):
         response = self.client.post(url, data={}, content_type="application/json")
         self.assertEqual(response.status_code, 401)
 
+    @tag("network")
     def test_tv_episode_mark_played(self):
         """Test webhook handles TV episode mark played event."""
         payload = {
@@ -87,6 +88,7 @@ class JellyfinWebhookTests(TestCase):
         )
         self.assertIsNotNone(episode.end_date)
 
+    @tag("network")
     def test_movie_mark_played(self):
         """Test webhook handles movie mark played event."""
         payload = {
@@ -116,6 +118,7 @@ class JellyfinWebhookTests(TestCase):
         self.assertEqual(movie.status, Status.COMPLETED.value)
         self.assertEqual(movie.progress, 1)
 
+    @tag("network")
     @patch("app.providers.mal.anime")
     @patch("app.providers.tmdb.find")
     def test_anime_movie_mark_played(self, mock_tmdb_find, mock_mal_anime):
@@ -432,6 +435,7 @@ class JellyfinWebhookTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Movie.objects.count(), 0)
 
+    @tag("network")
     def test_mark_unplayed(self):
         """Test webhook handles not finished events."""
         payload = {
@@ -511,6 +515,7 @@ class JellyfinWebhookTests(TestCase):
         self.assertEqual(movie.status, Status.COMPLETED.value)
         self.assertEqual(movie.progress, 1)
 
+    @tag("network")
     def test_mark_unplayed_event_ignored_when_disabled(self):
         """Test MarkUnplayed events are ignored unless opted in by the user."""
         self.assertFalse(self.user.jellyfin_mark_unplayed_enabled)
@@ -622,6 +627,7 @@ class JellyfinWebhookTests(TestCase):
             ).exists(),
         )
 
+    @tag("network")
     @patch("app.providers.tmdb.tv_with_seasons")
     @patch("app.providers.tmdb.find")
     def test_tv_episode_uses_existing_tvdb_tracked_item(
@@ -1075,6 +1081,7 @@ class JellyfinWebhookTests(TestCase):
         )
         self.assertIsNotNone(episode.end_date)
 
+    @tag("network")
     def test_repeated_watch(self):
         """Test webhook handles repeated watches."""
         payload = {

--- a/src/integrations/tests/test_webhooks_kodi.py
+++ b/src/integrations/tests/test_webhooks_kodi.py
@@ -1,7 +1,7 @@
 import json
 
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, tag
 from django.urls import reverse
 
 from app.models import TV, Episode, Item, MediaTypes, Movie, Season, Status
@@ -90,6 +90,7 @@ class KodiWebhookMovieTests(TestCase):
             content_type="application/json",
         )
 
+    @tag("network")
     def test_movie_end_event_marks_completed(self):
         payload = {**MOVIE_PAYLOAD, "event": "end"}
         response = self._post(payload)
@@ -119,6 +120,7 @@ class KodiWebhookMovieTests(TestCase):
         movie = Movie.objects.get(item__media_id="603", user=self.user)
         self.assertEqual(movie.status, Status.IN_PROGRESS.value)
 
+    @tag("network")
     def test_movie_start_event_creates_in_progress(self):
         payload = {
             **MOVIE_PAYLOAD,
@@ -130,6 +132,7 @@ class KodiWebhookMovieTests(TestCase):
         movie = Movie.objects.get(item__media_id="603", user=self.user)
         self.assertEqual(movie.status, Status.IN_PROGRESS.value)
 
+    @tag("network")
     def test_movie_repeated_watches_tracked(self):
         payload = {**MOVIE_PAYLOAD, "event": "end"}
         self._post(payload)
@@ -141,6 +144,7 @@ class KodiWebhookMovieTests(TestCase):
         self.assertTrue(all(m.status == Status.COMPLETED.value for m in movies))
 
 
+@tag("network")
 class KodiWebhookTVTests(TestCase):
     """Tests for Kodi TV episode webhook processing."""
 

--- a/src/integrations/tests/test_webhooks_stremio.py
+++ b/src/integrations/tests/test_webhooks_stremio.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.test import Client, TestCase
+from django.test import Client, TestCase, tag
 from django.urls import reverse
 
 from app.models import (
@@ -108,6 +108,7 @@ class StremioWebhookProcessorTests(TestCase):
             f"/stremio-addon/test-token/subtitles/{media_type}/{media_id}.json",
         )
 
+    @tag("network")
     def test_movie_start_marks_in_progress(self):
         """A movie playback start marks the movie in progress."""
         response = self._get("movie", "tt0133093")
@@ -144,6 +145,7 @@ class StremioWebhookProcessorTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(Movie.objects.filter(user=self.user).exists())
 
+    @tag("network")
     @patch("integrations.webhooks.stremio.live_playback.apply_playback_event")
     def test_movie_start_updates_live_playback(self, mock_apply_event):
         """A movie playback start updates the Now Playing card."""


### PR DESCRIPTION
## Problem

The test suite calls real provider APIs. Blocking outbound sockets and running the suite showed roughly 2,500 outbound connection attempts, and 47 tests genuinely depend on a live response rather than a mock.

Three consequences:

* **CI is slow.** App Tests takes around 30 minutes.
* **CI is flaky.** The run on #393 failed with `ProviderAPIError: Could not reach MyAnimeList (ReadTimeout)`. Which provider times out varies run to run.
* **Fork pull requests always fail.** GitHub does not expose repository secrets to PRs from forks, so `TMDB_API`, `MAL_API` and the rest arrive empty. #443 from @ict failed for the same reason, with a nearly identical failure list to #393: 15 failures in common.

None of that is any one contributor's change. It is the suite reaching the public internet.

Refs #390

## Solution

Mark the tests that need a live provider `@tag("network")`, matching the `@tag("slow")` convention this repo already uses for benchmarks and Playwright.

* 47 tests across 16 files, tagged where they sit rather than moved
* `scripts/test.sh` excludes them by default, and gains `--network` to run only them
* `AGENTS.md` documents the tag and says what to do when adding a test that needs a provider: mock it, or tag it

I identified them by measurement rather than by reading: a temporary socket guard in the test settings, then a run per app to see which tests actually failed when the network was unavailable.

## What this does and does not buy

Excluding them takes the suite from 3 failures to 2. One of the long-standing failures, `test_consumption_stats_aggregation`, turned out to be a live-API dependency rather than a real defect. The two that remain, both `test_collection_modal_*`, reproduce on `latest` unchanged and are untouched here.

Being straight about the trade: these tests do catch real provider contract changes, and excluding them means a provider altering its response shape will not be noticed until it shows up in production. The current situation is worse, because the signal is unreliable enough that nobody can act on it. Mocking them properly, so the coverage is kept without the network, is the better end state and is worth its own piece of work.

I also tried adding a permanent socket guard so new unmocked calls would fail loudly. I left it out: `services.py:212` mounts `HTTPAdapter(max_retries=3)`, so every blocked call retries three times, and the broad `except Exception` handlers around provider calls swallow the result. The guard made the suite slower without making it more honest. Worth revisiting alongside the mocking work.

## Validation

* Default suite, network tests excluded: `Ran 2614 tests`, `FAILED (failures=2, errors=2, skipped=1)`. The two errors are Playwright browser binaries missing locally, which CI installs.
* The same suite before this change: `failures=3`.
* Tagged tests still run on demand: `scripts/test.sh --network`, and individually under pytest.
* `ruff check src` gives `All checks passed!`; `ruff format --check src` gives `600 files already formatted`.

CI still runs everything until the companion workflow change lands, so this PR on its own will not show green here. That change has to ship separately, since the workflow's own `check-workflow-changes` job fails any PR touching `.github/workflows/**` alongside other files.

## Screenshots

Not applicable, test configuration only.

## AI Assistance

Generated with Claude Code (Claude Opus 5). Reviewed and tested manually.

## Notes

Refs #390. Companion workflow change to follow.
