### PR TITLE
Keep season-level collection entries visible in the season modal

### DIFF
--- a/src/app/collection_views.py
+++ b/src/app/collection_views.py
@@ -795,7 +795,10 @@ def build_collection_modal_context(
     season_audit_entries = _build_collection_season_audit_entries(request.user, item)
     episode_audit_entries = _build_collection_episode_audit_entries(request.user, item)
     visible_existing_entries = list(existing_entries)
-    if season_audit_entries or episode_audit_entries:
+    if season_audit_entries:
+        # At show level an entry on the show Item cannot say which season it
+        # covers, so the per-season audit rows replace it. A season-level entry
+        # is unambiguous: keep it visible so it can still be seen and removed.
         visible_existing_entries = []
     form = CollectionEntryForm(
         user=request.user,

--- a/src/app/tests/views/test_collection.py
+++ b/src/app/tests/views/test_collection.py
@@ -727,15 +727,15 @@ class CollectionModalViewTest(TestCase):
         )
         self.assertEqual(
             response.context["season_audit_entries"][0]["display_title"],
-            "Season 1: 1/2 • 50%",
+            "Season 1: 2/2 • 100%",
         )
         self.assertEqual(
             response.context["season_audit_entries"][0]["progress_label"],
-            "Collected Episodes: 1/2 • 50%",
+            "Collected Episodes: 2/2 • 100%",
         )
         self.assertEqual(
             response.context["season_audit_entries"][0]["source_labels"],
-            ["Sonarr"],
+            ["Sonarr", "Plex"],
         )
         self.assertEqual(
             response.context["season_audit_entries"][0]["quality_label"],
@@ -750,8 +750,8 @@ class CollectionModalViewTest(TestCase):
             "Collected Episodes: 1/1 • 100%",
         )
         self.assertContains(response, "Collected Seasons")
-        self.assertContains(response, "Season 1: 1/2 • 50%")
-        self.assertNotContains(response, "Collected Episodes: 1/2 • 50%")
+        self.assertContains(response, "Season 1: 2/2 • 100%")
+        self.assertNotContains(response, "Collected Episodes: 2/2 • 100%")
         self.assertContains(response, "WebDL-1080p")
         self.assertContains(response, "Sonarr")
         self.assertContains(response, "Add Another Copy")
@@ -769,7 +769,9 @@ class CollectionModalViewTest(TestCase):
         self.assertContains(response, 'aria-label="Remove collection entry"', count=2)
         self.assertNotContains(response, "Existing Entries")
         self.assertNotContains(response, "Delete")
-        self.assertNotContains(response, "Plex")
+        # Season 1 now counts both of its collected episodes, so the Plex-sourced
+        # one contributes its label alongside Sonarr.
+        self.assertContains(response, "Sources: Sonarr • Plex")
         self.assertNotContains(response, "S01E03 - Third Episode")
 
     def test_collection_modal_season_limits_episode_audit_entries_to_the_season(self):


### PR DESCRIPTION
## Problem

Two collection modal tests fail on `latest`, deterministically and in isolation:

* `test_collection_modal_show_displays_season_audit_entries_with_sources`
* `test_collection_modal_season_keeps_manual_entries_visible_with_sonarr_audit_rows`

They passed when they were written. `git bisect` puts the break at `8ed8432b` ("Fix season/show collection cascade for partially-collected episodes", #396), which cascaded collection entries down to individual episodes. Tests could not run in CI at that point, so nothing flagged it. They have been failing on every PR since, including #443 and #393.

Refs #390

## Solution

Two separate things, and they are not the same kind of change.

### The counting assertions were stale

Season 1 in that fixture has two episodes and both have a `CollectionEntry`, so `2/2 • 100%` is the correct summary and both episodes' sources belong in the label. The old expectations of `1/2 • 50%` and `["Sonarr"]` described the pre-cascade behaviour. Updated to match, including the `assertNotContains(response, "Plex")` that only held while the Plex-sourced episode went uncounted.

### The visibility one is a real behaviour question

The modal hid an item's own entries whenever any audit row existed:

```python
if season_audit_entries or episode_audit_entries:
    visible_existing_entries = []
```

At **show** level that is right, and the other test asserts it: an entry on the show `Item` cannot say which season it covers, so the per-season audit rows replace it.

At **season** level it is not. A season-level entry is unambiguous, and blanket-hiding it meant a manually added entry could no longer be seen or removed from the modal, leaving it stranded. That also contradicts what the second test asserts by name.

The condition now covers only the show case. Both tests pass without weakening either.

I want to be explicit that this is a judgement rather than a mechanical fix. #396 set out to stop the ambiguous show/season entry being counted in stats and to let manually collected episodes be removed; it did not say it intended to hide season-level entries. Nothing in the test suite asserted the blanket behaviour, and the only test that spoke to it expected the opposite. If you intended season-level entries to disappear once episode rows exist, say so and I will invert this: update that test instead and leave the view as it was.

## Validation

* `python -m pytest src/app/tests/views/test_collection.py -q` gives `26 passed` (was 2 failing)
* The tests added by #396, `test_collection_season_cascade.py`, plus `test_collection_integration.py`: `18 passed`
* Full suite: `Ran 2664 tests`, `FAILED (failures=1, errors=2, skipped=1)`. The single remaining failure is `test_consumption_stats_aggregation`, which depends on a live provider API and is tagged in #450. The two errors are Playwright browser binaries missing locally, which CI installs.
* `ruff check src` gives `All checks passed!`; `ruff format --check src` gives `600 files already formatted`

With #450 and its companion workflow change, this should leave the suite green in CI.

## Screenshots

Not applicable: no template or styling changes. The visible effect is that a season-level collection entry reappears in the season modal's "Existing Entries" section, as it did before #396.

## AI Assistance

Generated with Claude Code (Claude Opus 5). Reviewed and tested manually.

## Notes

Refs #390.
