### PR TITLE
Exclude live-provider tests from CI

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -154,7 +154,12 @@ jobs:
 
       - name: Run Tests
         run: |
-          coverage run src/manage.py test app users integrations lists events --parallel
+          # Tests tagged "network" call live provider APIs. They are slow and
+          # flaky, and a pull request from a fork cannot read repository secrets,
+          # so they fail there regardless of the change. Run them deliberately
+          # with scripts/test.sh --network.
+          coverage run src/manage.py test app users integrations lists events \
+            --parallel --exclude-tag network
 
       - name: Build Coverage Report
         run: |


### PR DESCRIPTION
## Problem

#450 tagged the 47 tests that call live provider APIs, but CI still runs everything, so nothing has changed yet in practice: App Tests keeps hitting the network, staying slow, and failing for anyone without API keys.

That last part is the one that matters. GitHub does not expose repository secrets to pull requests from forks, so `TMDB_API`, `MAL_API` and the rest arrive empty on every fork PR. #443 from @ict and #393 failed with near-identical provider errors for exactly this reason, 15 failures in common, neither caused by the change under review.

Refs #390

## Solution

Add `--exclude-tag network` to the CI test step, so it runs the deterministic part of the suite.

This is the companion to #450 and has to ship on its own: the workflow's own `check-workflow-changes` job fails any PR that touches `.github/workflows/**` alongside other files.

The excluded tests are still there and still runnable, deliberately, with `scripts/test.sh --network`.

## Validation

Measured locally against the same tag:

* With the tag excluded: `Ran 2614 tests`, `FAILED (failures=2, errors=2, skipped=1)`
* Without it: `failures=3`

The difference is `test_consumption_stats_aggregation`, which turned out to be a live-API dependency rather than a real defect. The two remaining failures are the collection modal ones, fixed separately in #453. Both errors are Playwright browser binaries missing locally, which CI installs.

So with #450 merged, this change, and #453, CI should be green for fork pull requests for the first time.

`python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow cleanly.

## What this trades away

Worth being straight about: these tests do catch real provider contract changes, and excluding them means a provider altering its response shape will not surface until it shows up in production. The status quo is worse, because the signal is unreliable enough that nobody acts on it, but this is a stopgap rather than the end state. Mocking those calls so the coverage survives without the network is the better answer and deserves its own piece of work.

## Screenshots

Not applicable, CI configuration only.

## AI Assistance

Generated with Claude Code (Claude Opus 5). Reviewed and tested manually.

## Notes

Refs #390. Companion to #450.
