### PR TITLE
Fix anonymous users being redirected to login on episode detail pages

### DIFF
--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -4956,6 +4956,49 @@ class MediaDetailsViewTests(TestCase):
 
     @patch("app.providers.services.get_media_metadata")
     @patch("app.providers.tmdb.process_episodes")
+    def test_episode_details_view_anonymous_public(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+    ):
+        """Anonymous users viewing a public list should reach the episode page, not login."""
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Test TV Show",
+            "media_id": "1668",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Season 1",
+                "season_title": "Season 1",
+                "media_id": "1668",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TMDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [],
+            },
+        }
+        mock_process_episodes.return_value = []
+
+        self.client.logout()
+        response = self.client.get(
+            reverse(
+                "episode_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "test-tv-show",
+                    "season_number": 1,
+                    "episode_number": 1,
+                },
+            ),
+            {"public_view": "1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
     def test_season_details_secondary_fragment_renders_episodes(
         self,
         mock_process_episodes,

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -746,6 +746,7 @@ def progress_edit(request, media_type, instance_id):
     )
 
 
+@login_not_required
 @never_cache
 @require_GET
 def episode_details(


### PR DESCRIPTION
episode_details was missing the @login_not_required decorator that its
sibling detail views (media_details, season_details) already have, even
though its body already had public-view handling for anonymous users.
This caused clicking a TV episode from a public list as an anonymous
user to redirect to the login page instead of showing the episode.

Fixes #463