### PR TITLE
Use GITHUB_TOKEN for GHCR login so new packages auto-link

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,8 +80,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: dannyvfilms
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
The floppy package was being pushed with a PAT (GHCR_TOKEN), which
does not get auto-linked to the source repo by GHCR and defaults to
private/unlisted - matching the 404 reported in #446. Switching to
the workflow's built-in GITHUB_TOKEN lets GHCR link future pushes to
this repo automatically, same as GitHub's documented behavior for
Actions-authenticated package pushes.

Fixes #446