### PR TITLE
Allow recording collection data per comic issue (#444)

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -419,6 +419,7 @@ COLLECTION_FIELD_BY_TYPE = {
     MediaTypes.BOOK.value: COLLECTION_FIELD_CONFIG["books"],
     MediaTypes.MANGA.value: COLLECTION_FIELD_CONFIG["books"],
     MediaTypes.COMIC.value: COLLECTION_FIELD_CONFIG["books"],
+    MediaTypes.COMIC_ISSUE.value: COLLECTION_FIELD_CONFIG["books"],
     MediaTypes.GAME.value: COLLECTION_FIELD_CONFIG["games"],
     MediaTypes.BOARDGAME.value: COLLECTION_FIELD_CONFIG["boardgames"],
 }

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -1822,7 +1822,7 @@ def media_details(
     item_id_for_polling = None
 
     if (
-        render_secondary_only
+        (render_secondary_only or media_type == MediaTypes.COMIC_ISSUE.value)
         and not public_view
         and media_type != MediaTypes.PODCAST.value
     ):

--- a/src/app/tests/test_collection_integration.py
+++ b/src/app/tests/test_collection_integration.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from app import config
 from app.helpers import is_item_collected
 from app.models import (
     TV,
@@ -131,6 +132,34 @@ class CollectionIntegrationTest(TestCase):
         self.assertTrue(
             CollectionEntry.objects.filter(user=self.user, item=item).exists()
         )
+
+    def test_collection_entry_comic_issue(self):
+        """Test creating collection entry for a ComicIssue, independent of its Comic."""
+        volume_item = Item.objects.create(
+            media_id="comic1",
+            source=Sources.COMICVINE.value,
+            media_type=MediaTypes.COMIC.value,
+            title="Test Comic",
+            image="http://example.com/comic.jpg",
+        )
+        issue_item = Item.objects.create(
+            media_id="issue1",
+            source=Sources.COMICVINE.value,
+            media_type=MediaTypes.COMIC_ISSUE.value,
+            title="Test Comic #1",
+            image="http://example.com/issue.jpg",
+        )
+
+        issue_entry = CollectionEntry.objects.create(user=self.user, item=issue_item)
+        self.assertTrue(
+            CollectionEntry.objects.filter(user=self.user, item=issue_item).exists()
+        )
+        self.assertFalse(
+            CollectionEntry.objects.filter(user=self.user, item=volume_item).exists()
+        )
+
+        config_fields = config.get_collection_field_config(MediaTypes.COMIC_ISSUE.value)
+        self.assertEqual(config_fields, config.COLLECTION_FIELD_CONFIG["books"])
 
     def test_collection_entry_music(self):
         """Test creating collection entry for Music."""

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -631,6 +631,102 @@ class MediaDetailsViewTests(TestCase):
         )
 
     @patch("app.providers.services.get_media_metadata")
+    def test_comic_issue_details_renders_collection_section(self, mock_get_metadata):
+        """The comic issue detail page should expose collection add/summary UI."""
+        mock_get_metadata.return_value = {
+            "media_id": "114214",
+            "title": "Tracked Issue",
+            "media_type": MediaTypes.COMIC_ISSUE.value,
+            "source": Sources.COMICVINE.value,
+            "image": "http://example.com/issue.jpg",
+            "max_progress": 1,
+            "details": {
+                "volume_id": "500",
+                "volume_name": "Test Volume",
+                "issue_number": "1",
+            },
+        }
+
+        issue_item = Item.objects.create(
+            media_id="114214",
+            source=Sources.COMICVINE.value,
+            media_type=MediaTypes.COMIC_ISSUE.value,
+            title="Tracked Issue",
+            image="http://example.com/issue.jpg",
+        )
+        CollectionEntry.objects.create(
+            user=self.user,
+            item=issue_item,
+            media_type="physical",
+            purchase_price=4.99,
+        )
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.COMICVINE.value,
+                    "media_type": MediaTypes.COMIC_ISSUE.value,
+                    "media_id": "114214",
+                    "title": "tracked-issue",
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "app/comic_issue_details.html")
+        self.assertTrue(response.context["has_collection_data"])
+        self.assertIsNotNone(response.context["collection_entry"])
+        self.assertContains(response, "COLLECTION")
+        self.assertContains(
+            response,
+            reverse(
+                "collection_modal",
+                args=[
+                    Sources.COMICVINE.value,
+                    MediaTypes.COMIC_ISSUE.value,
+                    "114214",
+                ],
+            ),
+        )
+        self.assertNotContains(response, "No collection data available")
+
+    @patch("app.providers.services.get_media_metadata")
+    def test_comic_issue_details_renders_collection_empty_state(
+        self, mock_get_metadata
+    ):
+        """An untracked-for-collection comic issue shows the empty state, not stats fields."""
+        mock_get_metadata.return_value = {
+            "media_id": "114215",
+            "title": "Untracked Issue",
+            "media_type": MediaTypes.COMIC_ISSUE.value,
+            "source": Sources.COMICVINE.value,
+            "image": "http://example.com/issue2.jpg",
+            "max_progress": 1,
+            "details": {
+                "volume_id": "500",
+                "volume_name": "Test Volume",
+                "issue_number": "2",
+            },
+        }
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.COMICVINE.value,
+                    "media_type": MediaTypes.COMIC_ISSUE.value,
+                    "media_id": "114215",
+                    "title": "untracked-issue",
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["has_collection_data"])
+        self.assertContains(response, "No collection data available")
+
+    @patch("app.providers.services.get_media_metadata")
     def test_media_details_related_sections_use_mobile_card_grid_preferences(
         self, mock_get_metadata
     ):

--- a/src/templates/app/comic_issue_details.html
+++ b/src/templates/app/comic_issue_details.html
@@ -260,6 +260,43 @@
         </div>
       </div>
     {% endif %}
+
+    {# Collection #}
+    {% if not public_view|default:False %}
+      <div class="flex items-center justify-between mb-2 mt-6">
+        <h3 class="text-sm font-semibold text-gray-400 tracking-wide">COLLECTION</h3>
+        <div x-data="{ collectionOpen: false }">
+          <button class="p-1.5 text-white rounded-md bg-indigo-600 hover:bg-indigo-700 transition-colors cursor-pointer"
+                  hx-get="{% media_view_url 'collection_modal' media %}"
+                  hx-vals='{"return_url": "{{ detail_return_url|urlencode }}"}'
+                  hx-target="#{% component_id 'collection' media %}"
+                  @click="collectionOpen = true"
+                  title="Add collection data">{% include "app/icons/plus.svg" with classes="w-3.5 h-3.5" %}</button>
+
+          <div x-show="collectionOpen"
+               @keydown.escape.window="collectionOpen = false"
+               class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"
+                 @click.outside="collectionOpen = false">
+              <div id="{% component_id 'collection' media %}"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% if collection_entries %}
+        <div>
+          {% for owned_entry in collection_entries %}
+            {% include "app/components/collection_entry_summary.html" with collection_entry=owned_entry media_type=media_type user=user source_style_game_meta=True flat_list=True is_last=forloop.last entry_quality_label="" %}
+          {% endfor %}
+        </div>
+      {% elif collection_entry %}
+        <div>
+          {% include "app/components/collection_entry_summary.html" with collection_entry=collection_entry media_type=media_type user=user source_style_game_meta=True flat_list=True is_last=True entry_quality_label="" %}
+        </div>
+      {% else %}
+        <p class="text-gray-400 text-sm">No collection data available</p>
+      {% endif %}
+    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
Collection info could previously only be attached to a comic series,
not to an individual issue, since the comic issue detail page never
computed or rendered the collection context and the field-config
mapping for comic issues was missing (silently falling back to
video-style fields). CollectionEntry already supports any Item, so no
schema change is needed: this wires up the existing collection modal
and summary components on comic_issue_details.html.