### PR TITLE
Retry transient network errors when backfilling completed-season episodes

### DIFF
--- a/src/integrations/imports/helpers.py
+++ b/src/integrations/imports/helpers.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import json
 import logging
+import time
 from collections import defaultdict
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -227,6 +228,32 @@ def _ordered_media_types(bulk_media_list):
     return ordered_types
 
 
+def _fetch_season_metadata_with_retry(season, max_retries=3, base_delay=0.5):
+    """Fetch season metadata, retrying transient network failures.
+
+    A single dropped connection is common when a bulk import fires off
+    metadata requests for many shows back-to-back; without a retry here
+    that one blip permanently strands the season at Completed with zero
+    episodes (see issue #471). Provider errors that aren't transient (e.g.
+    a 404 for a season TMDB doesn't have) are raised immediately since
+    retrying them cannot succeed.
+    """
+    attempt = 0
+    while True:
+        try:
+            return providers.services.get_media_metadata(
+                MediaTypes.SEASON.value,
+                season.item.media_id,
+                season.item.source,
+                [season.item.season_number],
+            )
+        except RequestException:
+            attempt += 1
+            if attempt >= max_retries:
+                raise
+            time.sleep(base_delay * attempt)
+
+
 def _backfill_completed_season_episodes(seasons):
     """Create the missing Episode rows for seasons bulk-created as Completed.
 
@@ -236,6 +263,9 @@ def _backfill_completed_season_episodes(seasons):
     Completed with no per-episode history (e.g. a rating-only import) would
     otherwise end up with zero Episode rows, making it invisible to
     exports/statistics that key off episode data.
+
+    Returns warning messages for seasons that could not be backfilled, so
+    the importer can surface them to the user instead of only logging.
     """
     completed_seasons = [
         season
@@ -243,7 +273,7 @@ def _backfill_completed_season_episodes(seasons):
         if season.pk is not None and season.status == Status.COMPLETED.value
     ]
     if not completed_seasons:
-        return
+        return []
 
     existing_season_ids = set(
         Episode.objects.filter(
@@ -253,17 +283,13 @@ def _backfill_completed_season_episodes(seasons):
         .distinct(),
     )
 
+    warnings = []
     episodes_to_create = []
     for season in completed_seasons:
         if season.pk in existing_season_ids:
             continue
         try:
-            season_metadata = providers.services.get_media_metadata(
-                MediaTypes.SEASON.value,
-                season.item.media_id,
-                season.item.source,
-                [season.item.season_number],
-            )
+            season_metadata = _fetch_season_metadata_with_retry(season)
             episodes_to_create.extend(season.get_remaining_eps(season_metadata))
         except (
             providers.services.ProviderAPIError,
@@ -278,9 +304,17 @@ def _backfill_completed_season_episodes(seasons):
                 season.item.season_number,
                 error,
             )
+            warnings.append(
+                f"{season.item.title} S{season.item.season_number}: imported as "
+                f"Completed but episode data could not be fetched ({error}). "
+                "Re-import in overwrite mode once the issue clears to fill in "
+                "the missing episodes.",
+            )
 
     if episodes_to_create:
         bulk_create_with_history(episodes_to_create, Episode, batch_size=500)
+
+    return warnings
 
 
 def _has_unique_user_item_constraint(model):
@@ -325,7 +359,11 @@ def _deduplicate_unique_user_item_rows(model, bulk_media):
 
 
 def bulk_create_media(bulk_media_list, user):
-    """Bulk create all media objects."""
+    """Bulk create all media objects.
+
+    Returns warning messages for any seasons whose Completed-status
+    episode backfill failed, for callers that want to surface them.
+    """
     for media_type in _ordered_media_types(bulk_media_list):
         bulk_media = bulk_media_list[media_type]
         if not bulk_media:
@@ -362,9 +400,10 @@ def bulk_create_media(bulk_media_list, user):
     # episodes" check below sees the importer's own episodes too.
     bulk_seasons = bulk_media_list.get(MediaTypes.SEASON.value)
     if bulk_seasons:
-        retry_on_lock(
+        return retry_on_lock(
             lambda: _backfill_completed_season_episodes(bulk_seasons),
         )
+    return []
 
 
 def create_import_schedule(

--- a/src/integrations/imports/mdblist.py
+++ b/src/integrations/imports/mdblist.py
@@ -185,7 +185,7 @@ class MDBListImporter(TraktMetadataResolverMixin):
         self.process_collection()
 
         helpers.cleanup_existing_media(self.to_delete, self.user)
-        helpers.bulk_create_media(self.bulk_media, self.user)
+        self.warnings.extend(helpers.bulk_create_media(self.bulk_media, self.user))
 
         if self.completed_seasons:
             bulk_update_with_history(

--- a/src/integrations/imports/yamtrack.py
+++ b/src/integrations/imports/yamtrack.py
@@ -196,7 +196,7 @@ class YamtrackImporter:
                 raise MediaImportUnexpectedError(error_msg) from error
 
         helpers.cleanup_existing_media(self.to_delete, self.user)
-        helpers.bulk_create_media(self.bulk_media, self.user)
+        self.warnings.extend(helpers.bulk_create_media(self.bulk_media, self.user))
         self._apply_status_overrides()
 
         for custom_list in self.smart_lists:

--- a/src/integrations/tests/imports/test_helpers.py
+++ b/src/integrations/tests/imports/test_helpers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import requests
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
@@ -154,6 +155,72 @@ class HelpersTest(TestCase):
             1,
         )
         self.assertEqual(Episode.objects.get().related_season_id, season.id)
+
+    def _make_completed_season(self, media_id="42"):
+        """Create a bulk-created Completed season with zero episodes."""
+        tv_item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test Show",
+            image="tv.jpg",
+        )
+        season_item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Test Show",
+            image="season.jpg",
+            season_number=1,
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+        )
+        return Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.COMPLETED.value,
+        )
+
+    def test_backfill_retries_transient_network_error(self):
+        """A single dropped connection should not strand a season at zero episodes."""
+        season = self._make_completed_season()
+        season_metadata = {
+            "episodes": [{"episode_number": 1, "still_path": None}],
+            "max_progress": 1,
+        }
+
+        with (
+            patch(
+                "app.providers.services.get_media_metadata",
+                side_effect=[requests.ConnectionError("boom"), season_metadata],
+            ),
+            patch("integrations.imports.helpers.time.sleep"),
+        ):
+            warnings = helpers._backfill_completed_season_episodes([season])
+
+        self.assertEqual(warnings, [])
+        self.assertEqual(Episode.objects.filter(related_season=season).count(), 1)
+
+    def test_backfill_surfaces_warning_after_exhausted_retries(self):
+        """A persistently failing fetch should be reported, not silently dropped."""
+        season = self._make_completed_season()
+
+        with (
+            patch(
+                "app.providers.services.get_media_metadata",
+                side_effect=requests.ConnectionError("still down"),
+            ),
+            patch("integrations.imports.helpers.time.sleep"),
+        ):
+            warnings = helpers._backfill_completed_season_episodes([season])
+
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("Test Show", warnings[0])
+        self.assertEqual(Episode.objects.filter(related_season=season).count(), 0)
 
     @patch("django.contrib.messages.error")
     def test_create_import_schedule(self, mock_messages):


### PR DESCRIPTION
Bulk imports (Yamtrack, MDBList) persist Season/TV rows via bulk_create,
bypassing the save() fan-out that normally creates episodes for a season
marked Completed. helpers._backfill_completed_season_episodes() already
compensates for this (#369), but a single dropped connection during a
large bulk migration hit an untried failure path (RequestException, not
an HTTP status code) and permanently stranded that season at
Completed/zero-episodes with only a server log line to show for it.

Retry the per-season metadata fetch a few times on transient network
errors, and surface any season that still fails as a warning in the
import summary instead of only logging it, so affected shows are
visible instead of silently broken.

Fixes #471