### PR TITLE
Fix Discover add-to-planning not creating Music/Podcast trackers

### DIFF
--- a/src/app/discover_views.py
+++ b/src/app/discover_views.py
@@ -13,10 +13,12 @@ from app import discover
 from app.discover import tab_cache as discover_tab_cache
 from app.models import (
     TV,
+    AlbumTracker,
     DiscoverFeedback,
     DiscoverFeedbackType,
     Item,
     MediaTypes,
+    PodcastShowTracker,
     Season,
     Status,
 )
@@ -272,18 +274,42 @@ def _get_or_create_discover_item(media_type, media_id, source, season_number, se
     return item
 
 
-def _discover_model_for_media_type(
+def _discover_media_model_for_type(
     media_type: str,
     *,
     source: str | None = None,
     identity_media_type: str | None = None,
 ):
+    """Return the per-item trackable Media model for a Discover media type."""
     model_name = metadata_resolution.get_tracking_media_type(
         media_type,
         source=source,
         identity_media_type=identity_media_type,
     )
     return apps.get_model(app_label="app", model_name=model_name)
+
+
+def _discover_model_for_media_type(
+    media_type: str,
+    *,
+    source: str | None = None,
+    identity_media_type: str | None = None,
+):
+    """Return the model used to persist Discover planning/dismiss state.
+
+    Music and podcasts are tracked at the album/show level (AlbumTracker /
+    PodcastShowTracker), not the per-item Music/Podcast model, so category
+    listing pages and the item detail page see the planning status.
+    """
+    if media_type == MediaTypes.MUSIC.value:
+        return AlbumTracker
+    if media_type == MediaTypes.PODCAST.value:
+        return PodcastShowTracker
+    return _discover_media_model_for_type(
+        media_type,
+        source=source,
+        identity_media_type=identity_media_type,
+    )
 
 
 def _discover_planning_instance(
@@ -293,12 +319,22 @@ def _discover_planning_instance(
     *,
     source: str | None = None,
     identity_media_type: str | None = None,
+    album=None,
+    show=None,
 ):
     model = _discover_model_for_media_type(
         media_type,
         source=source or item.source,
         identity_media_type=identity_media_type or item.media_type,
     )
+    if model is AlbumTracker:
+        if album is None:
+            return None
+        return model.objects.filter(user=user, album=album).select_related("album").first()
+    if model is PodcastShowTracker:
+        if show is None:
+            return None
+        return model.objects.filter(user=user, show=show).select_related("show").first()
     return model.objects.filter(user=user, item=item).select_related("item").first()
 
 
@@ -474,11 +510,15 @@ def discover_action(request):
         side_effect = snapshot.get("side_effect") or {}
         side_effect_kind = side_effect.get("kind")
         if side_effect_kind == "planning" and side_effect.get("instance_id"):
-            model = _discover_model_for_media_type(
-                side_effect.get("media_type"),
-                source=side_effect.get("source"),
-                identity_media_type=side_effect.get("identity_media_type"),
-            )
+            model_label = side_effect.get("model_label")
+            if model_label:
+                model = apps.get_model(model_label)
+            else:
+                model = _discover_model_for_media_type(
+                    side_effect.get("media_type"),
+                    source=side_effect.get("source"),
+                    identity_media_type=side_effect.get("identity_media_type"),
+                )
             instance = model.objects.filter(
                 id=side_effect["instance_id"],
                 user=request.user,
@@ -624,6 +664,8 @@ def discover_action(request):
             hydrated.item,
             source=source,
             identity_media_type=identity_media_type,
+            album=hydrated.album,
+            show=hydrated.podcast_show,
         )
         if existing_instance:
             DiscoverFeedback.objects.filter(
@@ -651,27 +693,53 @@ def discover_action(request):
                 source=source,
                 identity_media_type=identity_media_type,
             )
-            instance_kwargs = {
-                "item": hydrated.item,
-                "user": request.user,
-                "status": Status.PLANNING.value,
-                "score": None,
-                "notes": "",
-            }
-            if model not in {TV, Season}:
-                instance_kwargs["progress"] = 0
-                instance_kwargs["start_date"] = None
-                instance_kwargs["end_date"] = None
-            instance = model(**instance_kwargs)
-            if candidate_media_type == MediaTypes.MUSIC.value:
-                instance.artist = hydrated.artist
-                instance.album = hydrated.album
-                instance.track = hydrated.track
-            if (
-                candidate_media_type == MediaTypes.PODCAST.value
-                and hydrated.podcast_show is not None
-            ):
-                instance.show = hydrated.podcast_show
+            if model is AlbumTracker and hydrated.album is not None:
+                instance = AlbumTracker(
+                    user=request.user,
+                    album=hydrated.album,
+                    status=Status.PLANNING.value,
+                    score=None,
+                    notes="",
+                    start_date=None,
+                    end_date=None,
+                )
+            elif model is PodcastShowTracker and hydrated.podcast_show is not None:
+                instance = PodcastShowTracker(
+                    user=request.user,
+                    show=hydrated.podcast_show,
+                    status=Status.PLANNING.value,
+                    score=None,
+                    notes="",
+                    start_date=None,
+                    end_date=None,
+                )
+            else:
+                fallback_model = _discover_media_model_for_type(
+                    candidate_media_type,
+                    source=source,
+                    identity_media_type=identity_media_type,
+                )
+                instance_kwargs = {
+                    "item": hydrated.item,
+                    "user": request.user,
+                    "status": Status.PLANNING.value,
+                    "score": None,
+                    "notes": "",
+                }
+                if fallback_model not in {TV, Season}:
+                    instance_kwargs["progress"] = 0
+                    instance_kwargs["start_date"] = None
+                    instance_kwargs["end_date"] = None
+                instance = fallback_model(**instance_kwargs)
+                if candidate_media_type == MediaTypes.MUSIC.value:
+                    instance.artist = hydrated.artist
+                    instance.album = hydrated.album
+                    instance.track = hydrated.track
+                if (
+                    candidate_media_type == MediaTypes.PODCAST.value
+                    and hydrated.podcast_show is not None
+                ):
+                    instance.show = hydrated.podcast_show
             with suppress_media_cache_change_signals():
                 instance.save()
             view_barrel._invalidate_discover_after_action(
@@ -690,6 +758,9 @@ def discover_action(request):
                         "source": source,
                         "identity_media_type": identity_media_type,
                         "instance_id": instance.id,
+                        "model_label": (
+                            f"{instance._meta.app_label}.{instance._meta.model_name}"
+                        ),
                     },
                 )
             message = f'Added "{hydrated.item.title}" to Planning.'

--- a/src/app/tests/discover/test_views.py
+++ b/src/app/tests/discover/test_views.py
@@ -9,11 +9,17 @@ from django.urls import reverse
 from app.discover.schemas import CandidateItem, RowResult
 from app.models import (
     TV,
+    Album,
+    AlbumTracker,
     DiscoverFeedback,
     DiscoverFeedbackType,
     Item,
     MediaTypes,
     Movie,
+    Music,
+    Podcast,
+    PodcastShow,
+    PodcastShowTracker,
     Sources,
     Status,
 )
@@ -86,6 +92,24 @@ class DiscoverViewTests(TestCase):
             media_type=MediaTypes.MOVIE.value,
             title=title,
             image="https://example.com/movie.jpg",
+        )
+
+    def _music_item(self, media_id="album-9001", title="Great Album"):
+        return Item.objects.create(
+            media_id=media_id,
+            source=Sources.MUSICBRAINZ.value,
+            media_type=MediaTypes.MUSIC.value,
+            title=title,
+            image="https://example.com/album.jpg",
+        )
+
+    def _podcast_item(self, media_id="show-9001", title="Great Show"):
+        return Item.objects.create(
+            media_id=media_id,
+            source=Sources.POCKETCASTS.value,
+            media_type=MediaTypes.PODCAST.value,
+            title=title,
+            image="https://example.com/show.jpg",
         )
 
     @patch("app.views._invalidate_discover_after_action")
@@ -673,6 +697,203 @@ class DiscoverViewTests(TestCase):
             self.user.id,
             MediaTypes.TV.value,
         )
+
+    @patch("app.views.discover_tab_cache.invalidate_for_media_change")
+    @patch("app.views.discover_tab_cache.update_undo_snapshot")
+    @patch("app.views.discover_tab_cache.apply_cached_action")
+    @patch("app.views.discover_tab_cache.store_undo_snapshot", return_value="undo-music")
+    @patch("app.views.ensure_item_metadata")
+    def test_discover_action_planning_music_creates_album_tracker(
+        self,
+        mock_ensure_item_metadata,
+        _mock_store_undo_snapshot,
+        mock_apply_cached_action,
+        mock_update_undo_snapshot,
+        _mock_invalidate_for_media_change,
+    ):
+        item = self._music_item()
+        album = Album.objects.create(title="Great Album")
+        mock_ensure_item_metadata.return_value = HydratedItemResult(
+            item=item,
+            metadata={},
+            created=False,
+            album=album,
+        )
+        mock_apply_cached_action.return_value = [self._row(title="Updated Album")]
+
+        response = self.client.post(
+            reverse("discover_action"),
+            {
+                "action": "planning",
+                "candidate_media_type": MediaTypes.MUSIC.value,
+                "source": Sources.MUSICBRAINZ.value,
+                "media_id": item.media_id,
+                "active_media_type": MediaTypes.MUSIC.value,
+                "show_more": "0",
+                "row_key": "top_picks_for_you",
+                "title": item.title,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            AlbumTracker.objects.filter(
+                user=self.user,
+                album=album,
+                status=Status.PLANNING.value,
+            ).exists(),
+        )
+        self.assertFalse(Music.objects.filter(user=self.user, item=item).exists())
+        mock_update_undo_snapshot.assert_called_once()
+        _, snapshot_kwargs = mock_update_undo_snapshot.call_args
+        self.assertEqual(
+            snapshot_kwargs["side_effect"]["model_label"],
+            "app.albumtracker",
+        )
+
+    @patch("app.views.discover_tab_cache.invalidate_for_media_change")
+    @patch("app.views.discover_tab_cache.update_undo_snapshot")
+    @patch("app.views.discover_tab_cache.apply_cached_action")
+    @patch(
+        "app.views.discover_tab_cache.store_undo_snapshot", return_value="undo-podcast"
+    )
+    @patch("app.views.ensure_item_metadata")
+    def test_discover_action_planning_podcast_creates_show_tracker(
+        self,
+        mock_ensure_item_metadata,
+        _mock_store_undo_snapshot,
+        mock_apply_cached_action,
+        mock_update_undo_snapshot,
+        _mock_invalidate_for_media_change,
+    ):
+        item = self._podcast_item()
+        show = PodcastShow.objects.create(
+            podcast_uuid="show-uuid-9001",
+            title="Great Show",
+        )
+        mock_ensure_item_metadata.return_value = HydratedItemResult(
+            item=item,
+            metadata={},
+            created=False,
+            podcast_show=show,
+        )
+        mock_apply_cached_action.return_value = [self._row(title="Updated Show")]
+
+        response = self.client.post(
+            reverse("discover_action"),
+            {
+                "action": "planning",
+                "candidate_media_type": MediaTypes.PODCAST.value,
+                "source": Sources.POCKETCASTS.value,
+                "media_id": item.media_id,
+                "active_media_type": MediaTypes.PODCAST.value,
+                "show_more": "0",
+                "row_key": "top_picks_for_you",
+                "title": item.title,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            PodcastShowTracker.objects.filter(
+                user=self.user,
+                show=show,
+                status=Status.PLANNING.value,
+            ).exists(),
+        )
+        self.assertFalse(Podcast.objects.filter(user=self.user, item=item).exists())
+        mock_update_undo_snapshot.assert_called_once()
+
+    @patch("app.views.discover_tab_cache.invalidate_for_feedback_change")
+    @patch("app.views.ensure_item_metadata")
+    def test_discover_action_planning_music_already_in_library(
+        self,
+        mock_ensure_item_metadata,
+        mock_invalidate_for_feedback_change,
+    ):
+        item = self._music_item(media_id="album-9002", title="Existing Album")
+        album = Album.objects.create(title="Existing Album")
+        AlbumTracker.objects.create(
+            user=self.user,
+            album=album,
+            status=Status.PLANNING.value,
+        )
+        mock_ensure_item_metadata.return_value = HydratedItemResult(
+            item=item,
+            metadata={},
+            created=False,
+            album=album,
+        )
+
+        response = self.client.post(
+            reverse("discover_action"),
+            {
+                "action": "planning",
+                "candidate_media_type": MediaTypes.MUSIC.value,
+                "source": Sources.MUSICBRAINZ.value,
+                "media_id": item.media_id,
+                "active_media_type": MediaTypes.MUSIC.value,
+                "show_more": "0",
+                "row_key": "top_picks_for_you",
+                "title": item.title,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            AlbumTracker.objects.filter(user=self.user, album=album).count(),
+            1,
+        )
+        mock_invalidate_for_feedback_change.assert_called_once_with(
+            self.user.id,
+            MediaTypes.MUSIC.value,
+        )
+
+    @patch("app.views.discover_tab_cache.invalidate_for_media_change")
+    @patch("app.views.discover_tab_cache.restore_undo_snapshot")
+    @patch("app.views.discover_tab_cache.get_undo_snapshot")
+    def test_discover_action_undo_deletes_album_tracker(
+        self,
+        mock_get_undo_snapshot,
+        mock_restore_undo_snapshot,
+        _mock_invalidate_for_media_change,
+    ):
+        album = Album.objects.create(title="Undo Album")
+        tracker = AlbumTracker.objects.create(
+            user=self.user,
+            album=album,
+            status=Status.PLANNING.value,
+        )
+        mock_get_undo_snapshot.return_value = {
+            "side_effect": {
+                "kind": "planning",
+                "media_type": MediaTypes.MUSIC.value,
+                "source": Sources.MUSICBRAINZ.value,
+                "identity_media_type": None,
+                "instance_id": tracker.id,
+                "model_label": "app.albumtracker",
+            },
+        }
+        mock_restore_undo_snapshot.return_value = {
+            "rows": [self._row(title="Restored Album")]
+        }
+
+        response = self.client.post(
+            reverse("discover_action"),
+            {
+                "action": "undo",
+                "undo_token": "undo-music",
+                "active_media_type": MediaTypes.MUSIC.value,
+                "show_more": "0",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(AlbumTracker.objects.filter(id=tracker.id).exists())
 
     @patch("app.views.discover_tab_cache.update_undo_snapshot")
     @patch("app.views.discover_tab_cache.apply_cached_action")


### PR DESCRIPTION
The Discover page's "add to planning" quick action created a Music/Podcast
row (the per-item trackable unit) for music and podcast candidates instead
of an AlbumTracker/PodcastShowTracker row (the per-album/per-show tracker
that category listing pages and item detail pages actually read). Items
added this way never appeared in their category and couldn't be un-planned
from the UI.

Fixes #472

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013C9qDLgWu4pJuDc73629Kk