### PR TITLE
Fix game list Platform column falling back to arbitrary IGDB platform

### DIFF
--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -293,7 +293,7 @@ def _extract_item_platforms_with_collection(item, collection_platforms_by_item_i
 def _resolve_display_platform(
     item, collection_platforms_by_item_id, active_platform_filter
 ):
-    """Resolve a single display platform: collection data > active filter > first IGDB platform."""
+    """Resolve a single display platform: collection data > active filter > sole IGDB platform."""
     if not item:
         return ""
     if collection_platforms_by_item_id:
@@ -306,7 +306,9 @@ def _resolve_display_platform(
         for platform in item_platforms:
             if _normalize_filter_value(platform) == normalized_filter:
                 return platform
-    return item_platforms[0] if item_platforms else ""
+    if len(item_platforms) == 1:
+        return item_platforms[0]
+    return ""
 
 
 def build_filter_data_from_items(

--- a/src/app/tests/views/test_media_list.py
+++ b/src/app/tests/views/test_media_list.py
@@ -2330,11 +2330,11 @@ class MediaListViewTests(TestCase):
             image="http://example.com/game.jpg",
             platforms=["Xbox Series X|S", "PlayStation 5"],
         )
-        fallback_item = Item.objects.create(
-            media_id="game-platform-sort-fallback",
+        ambiguous_item = Item.objects.create(
+            media_id="game-platform-sort-ambiguous",
             source=Sources.IGDB.value,
             media_type=MediaTypes.GAME.value,
-            title="Fallback Platform",
+            title="Ambiguous Platform",
             image="http://example.com/game.jpg",
             platforms=["Nintendo Switch", "PlayStation 5"],
         )
@@ -2342,7 +2342,7 @@ class MediaListViewTests(TestCase):
             item=collection_item, user=self.user, status=Status.PLANNING.value
         )
         Game.objects.create(
-            item=fallback_item, user=self.user, status=Status.PLANNING.value
+            item=ambiguous_item, user=self.user, status=Status.PLANNING.value
         )
         CollectionEntry.objects.create(
             user=self.user,
@@ -2357,12 +2357,15 @@ class MediaListViewTests(TestCase):
 
         self.assertEqual(response.context["current_sort"], "platform")
         self.assertEqual(response.context["current_direction"], "asc")
+        # The collection-resolved platform sorts first; the multi-platform
+        # game with no collection entry has no unambiguous platform to show,
+        # so it sorts last instead of guessing an arbitrary IGDB platform.
         self.assertEqual(
             [
                 media.item.title
                 for media in response.context["media_list"].object_list[:2]
             ],
-            ["Fallback Platform", "Collection Platform"],
+            ["Collection Platform", "Ambiguous Platform"],
         )
         self.assertContains(response, "Nintendo Switch")
         self.assertContains(response, "PlayStation 5")

--- a/src/lists/views.py
+++ b/src/lists/views.py
@@ -29,6 +29,7 @@ from lists.models import CustomList, CustomListItem
 from lists.views_helpers import (
     _adapt_list_items_for_table,
     _attach_media_with_aggregation,
+    _build_collection_platforms_by_item_id,
     _build_list_url_template,
     _build_media_type_breakdown,
     _date_sort_value,
@@ -319,11 +320,14 @@ def list_detail(request, list_reference):
             "reverse": params["direction"] == "desc",
         },
         "platform": {
-            "key": lambda item: _platform_sort_value(item),
+            "key": lambda item: _platform_sort_value(
+                item, collection_platforms_by_item_id
+            ),
             "reverse": params["direction"] == "desc",
         },
     }
 
+    collection_platforms_by_item_id = {}
     sort_config = media_sort_config.get(params["sort_by"])
     if sort_config:
         all_items = list(
@@ -335,6 +339,11 @@ def list_detail(request, list_reference):
             ),
         )
         _attach_media_with_aggregation(all_items, media_user)
+
+        if params["sort_by"] == "platform":
+            collection_platforms_by_item_id = _build_collection_platforms_by_item_id(
+                media_user, [item.id for item in all_items]
+            )
 
         all_items = sorted(
             all_items,
@@ -361,7 +370,11 @@ def list_detail(request, list_reference):
     prefill_display_release_years(items_page)
 
     if layout == "table":
-        _adapt_list_items_for_table(items_page)
+        if not collection_platforms_by_item_id:
+            collection_platforms_by_item_id = _build_collection_platforms_by_item_id(
+                media_user, [item.id for item in items_page.object_list]
+            )
+        _adapt_list_items_for_table(items_page, collection_platforms_by_item_id)
 
     # Get recommendation count for owners/collaborators
     recommendation_count = 0

--- a/src/lists/views_helpers.py
+++ b/src/lists/views_helpers.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.db.models import Count, F, Q
 from django.urls import reverse
 
-from app.models import Item, MediaManager, MediaTypes, Status
+from app.models import CollectionEntry, Item, MediaManager, MediaTypes, Status
 from app.providers import services
 from integrations.imports import helpers as import_helpers
 from integrations.models import TraktAccount
@@ -475,7 +475,7 @@ def _extract_list_search_results(media_type, data):
 class _ListTableRowAdapter:
     """Expose list items through the shared media-table row contract."""
 
-    def __init__(self, list_item):
+    def __init__(self, list_item, collection_platforms_by_item_id=None):
         self._list_item = list_item
         self._source_media = getattr(list_item, "media", None)
         self.item = list_item
@@ -483,7 +483,9 @@ class _ListTableRowAdapter:
         self.track_media_id = self.id
         self.created_at = getattr(list_item, "list_date_added", None)
         self.repeats = getattr(self._source_media, "repeats", 1) or 1
-        self.display_platform = _extract_display_platform(list_item)
+        self.display_platform = _extract_display_platform(
+            list_item, collection_platforms_by_item_id
+        )
 
     def __getattr__(self, attr):
         if self._source_media is not None and hasattr(self._source_media, attr):
@@ -491,12 +493,29 @@ class _ListTableRowAdapter:
         return getattr(self._list_item, attr)
 
 
-def _adapt_list_items_for_table(items_page):
+def _adapt_list_items_for_table(items_page, collection_platforms_by_item_id=None):
     """Replace page rows with adapters that satisfy shared media-table cells."""
     items_page.object_list = [
-        _ListTableRowAdapter(item) for item in items_page.object_list
+        _ListTableRowAdapter(item, collection_platforms_by_item_id)
+        for item in items_page.object_list
     ]
     return items_page
+
+
+def _build_collection_platforms_by_item_id(user, item_ids):
+    """Return {item_id: {platform, ...}} from the user's game collection entries."""
+    platforms_by_item_id = {}
+    if not user or not getattr(user, "is_authenticated", False) or not item_ids:
+        return platforms_by_item_id
+    for item_id, resolution in CollectionEntry.objects.filter(
+        user=user,
+        item_id__in=item_ids,
+        item__media_type=MediaTypes.GAME.value,
+    ).values_list("item_id", "resolution"):
+        platform_value = str(resolution or "").strip()
+        if platform_value:
+            platforms_by_item_id.setdefault(item_id, set()).add(platform_value)
+    return platforms_by_item_id
 
 
 def _resolve_list_table_media_type(selected_media_types, filtered_media_types):
@@ -650,20 +669,27 @@ def _status_value(media):
     return _STATUS_SORT_ORDER.get(status, len(_STATUS_SORT_ORDER))
 
 
-def _extract_display_platform(item):
-    """Best-effort single platform label (only games populate Item.platforms)."""
+def _extract_display_platform(item, collection_platforms_by_item_id=None):
+    """Resolve a single display platform: collection data > sole IGDB platform."""
+    if not item:
+        return ""
+    if collection_platforms_by_item_id:
+        collected = collection_platforms_by_item_id.get(item.id, set())
+        if collected:
+            return sorted(collected, key=lambda value: value.lower())[0]
     platforms = getattr(item, "platforms", None)
     if not platforms:
         return ""
     if isinstance(platforms, str):
         return platforms.strip()
     if isinstance(platforms, list):
-        return next((str(p).strip() for p in platforms if str(p).strip()), "")
+        normalized = [str(p).strip() for p in platforms if str(p).strip()]
+        return normalized[0] if len(normalized) == 1 else ""
     return ""
 
 
-def _platform_sort_value(item):
-    platform = _extract_display_platform(item)
+def _platform_sort_value(item, collection_platforms_by_item_id=None):
+    platform = _extract_display_platform(item, collection_platforms_by_item_id)
     return platform.lower() if platform else "￿"
 
 

--- a/src/lists/views_smart_list.py
+++ b/src/lists/views_smart_list.py
@@ -30,6 +30,7 @@ from lists.models import CustomListItem
 from lists.views_helpers import (
     _adapt_list_items_for_table,
     _attach_media_with_aggregation,
+    _build_collection_platforms_by_item_id,
     _build_list_url_template,
     _build_media_type_breakdown,
     _date_sort_value,
@@ -247,11 +248,14 @@ def _smart_list_detail_response(
             "reverse": direction == "desc",
         },
         ListDetailSortChoices.PLATFORM: {
-            "key": lambda item: _platform_sort_value(item),
+            "key": lambda item: _platform_sort_value(
+                item, collection_platforms_by_item_id
+            ),
             "reverse": direction == "desc",
         },
     }
 
+    collection_platforms_by_item_id = {}
     sort_config = media_sort_config.get(sort_by)
     if sort_config:
         all_items = list(
@@ -262,6 +266,10 @@ def _smart_list_detail_response(
             )
         )
         _attach_media_with_aggregation(all_items, media_user)
+        if sort_by == ListDetailSortChoices.PLATFORM:
+            collection_platforms_by_item_id = _build_collection_platforms_by_item_id(
+                media_user, [item.id for item in all_items]
+            )
         all_items = sorted(
             all_items,
             key=sort_config["key"],
@@ -282,7 +290,11 @@ def _smart_list_detail_response(
     prefill_display_release_years(items_page)
 
     if layout == "table":
-        _adapt_list_items_for_table(items_page)
+        if not collection_platforms_by_item_id:
+            collection_platforms_by_item_id = _build_collection_platforms_by_item_id(
+                media_user, [item.id for item in items_page.object_list]
+            )
+        _adapt_list_items_for_table(items_page, collection_platforms_by_item_id)
 
     status_choices = [
         ("all", "All"),


### PR DESCRIPTION
Media-list and list/smart-list Platform columns now match the priority
already used by the game stats view: collection-chosen platform first,
then the item's sole IGDB platform if unambiguous, otherwise blank
instead of guessing the first platform in arbitrary metadata order.

Fixes #473

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QX71YRF5SpsMXPrsXUH5Ki