### PR TITLE
Fix genre/tag pills overlapping in media table view

### DIFF
--- a/src/templates/app/components/cells/media_genres_cell.html
+++ b/src/templates/app/components/cells/media_genres_cell.html
@@ -1,5 +1,5 @@
 {% if media.item.genres %}
-  <span class="block max-w-md truncate" title="{{ media.item.genres|join:', ' }}">
+  <span class="block max-w-xs truncate" title="{{ media.item.genres|join:', ' }}">
     {{ media.item.genres|join:", " }}
   </span>
 {% else %}

--- a/src/templates/app/components/cells/media_genres_cell.html
+++ b/src/templates/app/components/cells/media_genres_cell.html
@@ -1,7 +1,7 @@
 {% if media.item.genres %}
   <div class="flex flex-wrap gap-1">
     {% for genre in media.item.genres %}
-      <span class="inline-flex h-5 items-center rounded-full border border-violet-400/18 bg-violet-500/[0.07] px-2 text-xs font-medium text-violet-100">{{ genre }}</span>
+      <span class="inline-flex h-5 items-center whitespace-nowrap rounded-full border border-violet-400/18 bg-violet-500/[0.07] px-2 text-xs font-medium text-violet-100">{{ genre }}</span>
     {% endfor %}
   </div>
 {% else %}

--- a/src/templates/app/components/cells/media_genres_cell.html
+++ b/src/templates/app/components/cells/media_genres_cell.html
@@ -1,9 +1,7 @@
 {% if media.item.genres %}
-  <div class="flex flex-wrap gap-1">
-    {% for genre in media.item.genres %}
-      <span class="inline-flex h-5 items-center whitespace-nowrap rounded-full border border-violet-400/18 bg-violet-500/[0.07] px-2 text-xs font-medium text-violet-100">{{ genre }}</span>
-    {% endfor %}
-  </div>
+  <span class="block max-w-md truncate" title="{{ media.item.genres|join:', ' }}">
+    {{ media.item.genres|join:", " }}
+  </span>
 {% else %}
   <span class="text-gray-500">-</span>
 {% endif %}

--- a/src/templates/app/components/cells/media_tags_cell.html
+++ b/src/templates/app/components/cells/media_tags_cell.html
@@ -3,7 +3,7 @@
   {% if tag_names %}
     <div class="flex flex-wrap gap-1">
       {% for tag_name in tag_names %}
-        <span class="inline-flex h-5 items-center rounded-full border border-indigo-400/18 bg-indigo-500/[0.07] px-2 text-xs font-medium text-indigo-100">{{ tag_name }}</span>
+        <span class="inline-flex h-5 items-center whitespace-nowrap rounded-full border border-indigo-400/18 bg-indigo-500/[0.07] px-2 text-xs font-medium text-indigo-100">{{ tag_name }}</span>
       {% endfor %}
     </div>
   {% else %}

--- a/src/templates/app/components/cells/media_tags_cell.html
+++ b/src/templates/app/components/cells/media_tags_cell.html
@@ -1,11 +1,9 @@
 {% load app_tags %}
 {% with tag_names=media.item.item_tags.all|user_tag_names:user %}
   {% if tag_names %}
-    <div class="flex flex-wrap gap-1">
-      {% for tag_name in tag_names %}
-        <span class="inline-flex h-5 items-center whitespace-nowrap rounded-full border border-indigo-400/18 bg-indigo-500/[0.07] px-2 text-xs font-medium text-indigo-100">{{ tag_name }}</span>
-      {% endfor %}
-    </div>
+    <span class="block max-w-md truncate" title="{{ tag_names|join:', ' }}">
+      {{ tag_names|join:", " }}
+    </span>
   {% else %}
     <span class="text-gray-500">-</span>
   {% endif %}

--- a/src/templates/app/components/cells/media_tags_cell.html
+++ b/src/templates/app/components/cells/media_tags_cell.html
@@ -1,7 +1,7 @@
 {% load app_tags %}
 {% with tag_names=media.item.item_tags.all|user_tag_names:user %}
   {% if tag_names %}
-    <span class="block max-w-md truncate" title="{{ tag_names|join:', ' }}">
+    <span class="block max-w-xs truncate" title="{{ tag_names|join:', ' }}">
       {{ tag_names|join:", " }}
     </span>
   {% else %}


### PR DESCRIPTION
Pills had a fixed h-5 height with no whitespace-nowrap, so long
labels (e.g. "Turn-based strategy") wrapped internally at narrower
column widths and overflowed the pill, overlapping the one below.

Fixes #476