### PR TITLE
Stop iOS serving stale HTML, and size icons from their wrapper

### DIFF
--- a/src/app/middleware.py
+++ b/src/app/middleware.py
@@ -50,6 +50,40 @@ class AutoLoginMiddleware:
         return self.get_response(request)
 
 
+class NoStoreHtmlMiddleware:
+    """Stop browsers heuristically caching rendered HTML.
+
+    Django sends no Cache-Control on ordinary HTML responses, which leaves the
+    document heuristically cacheable. iOS Safari (and the installed PWA, which
+    shares Safari's HTTP cache) takes that as licence to keep serving markup it
+    fetched days ago, so template fixes never reach the device until the user
+    deletes and re-adds the PWA. That is what made #442 look unfixable.
+
+    Static assets are excluded: they are cache-busted by mtime and are the one
+    thing that *should* stay in the cache.
+    """
+
+    def __init__(self, get_response):
+        """Store the next middleware in the chain."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Mark HTML responses as uncacheable."""
+        response = self.get_response(request)
+
+        if request.path_info.startswith(("/static/", "/media/")):
+            return response
+
+        if response.has_header("Cache-Control"):
+            return response
+
+        content_type = response.headers.get("Content-Type", "")
+        if content_type.startswith("text/html"):
+            response.headers["Cache-Control"] = "no-store, must-revalidate"
+
+        return response
+
+
 class HtmxAuthRedirectMiddleware:
     """Turn login redirects into HX-Redirect for htmx requests.
 

--- a/src/app/tests/test_css_assets.py
+++ b/src/app/tests/test_css_assets.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from django.conf import settings
@@ -45,3 +46,60 @@ class StaticCssContractTests(SimpleTestCase):
                 content,
                 f"{relative_path} should not reference css/tailwind.css.",
             )
+
+
+class IconSizingContractTests(SimpleTestCase):
+    """Keep inline icons from rendering at container size (#442).
+
+    WebKit stretches an <svg> that only carries a viewBox to fill its parent
+    rather than falling back to a fixed intrinsic box, so an icon with no size
+    renders enormous on iOS while looking merely wrong elsewhere.
+    """
+
+    SVG_TAG = re.compile(r"<svg\b[^>]*>", re.DOTALL)
+    SIZE_CLASS = re.compile(r'class="[^"]*\b(?:w-|h-|size-)')
+
+    def setUp(self):
+        """Resolve the template tree scanned by the checks below."""
+        self.templates_dir = Path(settings.BASE_DIR) / "templates"
+
+    def test_icon_templates_declare_an_intrinsic_size_fallback(self):
+        """Every icon partial keeps its width/height="1em" fallback."""
+        for path in sorted((self.templates_dir / "app" / "icons").rglob("*.svg")):
+            content = path.read_text(encoding="utf-8")
+            relative_path = path.relative_to(settings.BASE_DIR).as_posix()
+
+            self.assertIn(
+                'width="1em"',
+                content,
+                f'{relative_path} must keep width="1em" so a call site that '
+                "omits a size utility still renders a text-sized icon.",
+            )
+            self.assertIn('height="1em"', content, f"{relative_path} needs height.")
+            self.assertIn(
+                'class="{{ classes }}"',
+                content,
+                f"{relative_path} must expose a classes hook so call sites can "
+                "size it.",
+            )
+
+    def test_inline_svgs_are_sized(self):
+        """Inline <svg> markup carries either a size attribute or a size class."""
+        unsized = []
+        for path in sorted(self.templates_dir.rglob("*.html")):
+            content = path.read_text(encoding="utf-8")
+            for match in self.SVG_TAG.finditer(content):
+                tag = match.group(0)
+                if "width=" in tag or self.SIZE_CLASS.search(tag):
+                    continue
+                line = content[: match.start()].count("\n") + 1
+                unsized.append(
+                    f"{path.relative_to(settings.BASE_DIR).as_posix()}:{line}"
+                )
+
+        self.assertEqual(
+            unsized,
+            [],
+            "Inline <svg> needs a width/height attribute or a w-/h-/size- "
+            f"class or it fills its container on iOS: {unsized}",
+        )

--- a/src/app/tests/test_middleware.py
+++ b/src/app/tests/test_middleware.py
@@ -1,10 +1,11 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
 from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
-from app.middleware import AutoLoginMiddleware
+from app.middleware import AutoLoginMiddleware, NoStoreHtmlMiddleware
 
 UserModel = get_user_model()
 
@@ -137,3 +138,59 @@ class SessionDurabilityTest(TestCase):
         cache.clear()
 
         self.assertEqual(self.client.get("/").status_code, 200)
+
+
+class NoStoreHtmlMiddlewareTest(TestCase):
+    """HTML must not be heuristically cacheable by iOS Safari (#442)."""
+
+    def setUp(self):
+        """Create a logged-in client and a bare request factory."""
+        self.factory = RequestFactory()
+        self.user = UserModel.objects.create_user(
+            username="no_store_user",
+            password="no_store_password",
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def _apply(self, response, path="/"):
+        middleware = NoStoreHtmlMiddleware(lambda _request: response)
+        return middleware(self.factory.get(path))
+
+    def test_html_response_is_marked_no_store(self):
+        """A rendered page tells the browser never to reuse the markup."""
+        response = self._apply(HttpResponse("<html></html>"))
+
+        self.assertEqual(response["Cache-Control"], "no-store, must-revalidate")
+
+    def test_static_assets_keep_their_cache_headers(self):
+        """Cache-busted static files stay cacheable."""
+        response = self._apply(
+            HttpResponse("<html></html>"),
+            path="/static/css/main.css",
+        )
+
+        self.assertFalse(response.has_header("Cache-Control"))
+
+    def test_non_html_responses_are_untouched(self):
+        """JSON API responses are left alone."""
+        response = self._apply(HttpResponse("{}", content_type="application/json"))
+
+        self.assertFalse(response.has_header("Cache-Control"))
+
+    def test_existing_cache_control_is_preserved(self):
+        """A view that set its own policy wins."""
+        existing = HttpResponse("<html></html>")
+        existing.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+
+        self.assertEqual(
+            self._apply(existing)["Cache-Control"],
+            "no-cache, no-store, must-revalidate",
+        )
+
+    def test_rendered_page_is_no_store_end_to_end(self):
+        """The header survives the real middleware stack."""
+        response = self.client.get(reverse("home"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Cache-Control"], "no-store, must-revalidate")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -236,6 +236,9 @@ PERF_LOG_QUERY_COUNT_THRESHOLD = config(
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    # Keep rendered HTML out of the browser's heuristic cache so template fixes
+    # actually reach iOS Safari and the installed PWA (#442)
+    "app.middleware.NoStoreHtmlMiddleware",
     "app.middleware.RequestPerformanceLoggingMiddleware",
     "app.middleware.DatabaseRetryMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/src/templates/app/components/_scrollable_row.html
+++ b/src/templates/app/components/_scrollable_row.html
@@ -116,7 +116,7 @@
               :aria-expanded="open.toString()"
               aria-label="Toggle section">
         <div class="w-4 h-4 transition-transform duration-200" :class="{ 'rotate-180': open }">
-          {% include "app/icons/chevron-down.svg" %}
+          {% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}
         </div>
       </button>
       {% endif %}

--- a/src/templates/app/components/album_list_grid_items.html
+++ b/src/templates/app/components/album_list_grid_items.html
@@ -25,15 +25,15 @@
         {% with status_value=tracker.status %}
           <div class="w-4 h-4 {{ status_value|status_color }}">
             {% if status_value == Status.COMPLETED.value %}
-              {% include "app/icons/states/completed.svg" %}
+              {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.IN_PROGRESS.value %}
-              {% include "app/icons/states/in-progress.svg" %}
+              {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.PAUSED.value %}
-              {% include "app/icons/states/paused.svg" %}
+              {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.PLANNING.value %}
-              {% include "app/icons/states/planning.svg" %}
+              {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.DROPPED.value %}
-              {% include "app/icons/states/dropped.svg" %}
+              {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
             {% endif %}
           </div>
         {% endwith %}

--- a/src/templates/app/components/artist_grid_items.html
+++ b/src/templates/app/components/artist_grid_items.html
@@ -26,15 +26,15 @@
         {% with status_value=tracker.status %}
           <div class="w-4 h-4 {{ status_value|status_color }}">
             {% if status_value == Status.COMPLETED.value %}
-              {% include "app/icons/states/completed.svg" %}
+              {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.IN_PROGRESS.value %}
-              {% include "app/icons/states/in-progress.svg" %}
+              {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.PAUSED.value %}
-              {% include "app/icons/states/paused.svg" %}
+              {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.PLANNING.value %}
-              {% include "app/icons/states/planning.svg" %}
+              {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.DROPPED.value %}
-              {% include "app/icons/states/dropped.svg" %}
+              {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
             {% endif %}
           </div>
         {% endwith %}

--- a/src/templates/app/components/artist_relation_grid.html
+++ b/src/templates/app/components/artist_relation_grid.html
@@ -24,15 +24,15 @@
             {% with status_value=relation.tracker.status %}
               <div class="w-4 h-4 {{ status_value|status_color }}">
                 {% if status_value == Status.COMPLETED.value %}
-                  {% include "app/icons/states/completed.svg" %}
+                  {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
                 {% elif status_value == Status.IN_PROGRESS.value %}
-                  {% include "app/icons/states/in-progress.svg" %}
+                  {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
                 {% elif status_value == Status.PAUSED.value %}
-                  {% include "app/icons/states/paused.svg" %}
+                  {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
                 {% elif status_value == Status.PLANNING.value %}
-                  {% include "app/icons/states/planning.svg" %}
+                  {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
                 {% elif status_value == Status.DROPPED.value %}
-                  {% include "app/icons/states/dropped.svg" %}
+                  {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
                 {% endif %}
               </div>
             {% endwith %}

--- a/src/templates/app/components/detail_secondary_content.html
+++ b/src/templates/app/components/detail_secondary_content.html
@@ -20,7 +20,7 @@
             <button @click="showRepeats = !showRepeats"
                     class="group flex items-center justify-center w-full px-3 py-2 text-sm text-white bg-gray-600 hover:bg-gray-700 transition-all duration-200 rounded-lg tracking-wide cursor-pointer">
               <div class="lucide lucide-chevron-down w-4 h-4 mr-2 transition-transform"
-                   :class="{ 'rotate-180': showRepeats }">{% include "app/icons/chevron-down.svg" %}</div>
+                   :class="{ 'rotate-180': showRepeats }">{% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}</div>
               {% if media_type == MediaTypes.GAME.value or media_type == MediaTypes.BOARDGAME.value %}Show Sessions{% else %}Show Repeats{% endif %} ({{ user_medias|length|add:"-1" }})
             </button>
 

--- a/src/templates/app/components/history_card.html
+++ b/src/templates/app/components/history_card.html
@@ -24,15 +24,15 @@
         {% with status_value=entry.status %}
           <div class="w-4 h-4 {{ status_value|status_color }}">
             {% if status_value == "Completed" %}
-              {% include "app/icons/states/completed.svg" %}
+              {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
             {% elif status_value == "In progress" %}
-              {% include "app/icons/states/in-progress.svg" %}
+              {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
             {% elif status_value == "Paused" %}
-              {% include "app/icons/states/paused.svg" %}
+              {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
             {% elif status_value == "Planning" %}
-              {% include "app/icons/states/planning.svg" %}
+              {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
             {% elif status_value == "Dropped" %}
-              {% include "app/icons/states/dropped.svg" %}
+              {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
             {% endif %}
           </div>
         {% endwith %}

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -63,15 +63,15 @@
                         {% with status_value=media.aggregated_status %}
                           <div class="w-4 h-4 {{ status_value|status_color }}">
                             {% if status_value == Status.COMPLETED.value %}
-                              {% include "app/icons/states/completed.svg" %}
+                              {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.IN_PROGRESS.value %}
-                              {% include "app/icons/states/in-progress.svg" %}
+                              {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.PAUSED.value %}
-                              {% include "app/icons/states/paused.svg" %}
+                              {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.PLANNING.value %}
-                              {% include "app/icons/states/planning.svg" %}
+                              {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.DROPPED.value %}
-                              {% include "app/icons/states/dropped.svg" %}
+                              {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
                             {% endif %}
                           </div>
                         {% endwith %}
@@ -79,15 +79,15 @@
                         {% with status_value=media.status %}
                           <div class="w-4 h-4 {{ status_value|status_color }}">
                             {% if status_value == Status.COMPLETED.value %}
-                              {% include "app/icons/states/completed.svg" %}
+                              {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.IN_PROGRESS.value %}
-                              {% include "app/icons/states/in-progress.svg" %}
+                              {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.PAUSED.value %}
-                              {% include "app/icons/states/paused.svg" %}
+                              {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.PLANNING.value %}
-                              {% include "app/icons/states/planning.svg" %}
+                              {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
                             {% elif status_value == Status.DROPPED.value %}
-                              {% include "app/icons/states/dropped.svg" %}
+                              {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
                             {% endif %}
                           </div>
                         {% endwith %}

--- a/src/templates/app/components/podcast_show_grid_items.html
+++ b/src/templates/app/components/podcast_show_grid_items.html
@@ -25,15 +25,15 @@
         {% with status_value=tracker.status %}
           <div class="w-4 h-4 {{ status_value|status_color }} {% if tracker.end_date or tracker.start_date %}mr-1.5{% endif %}">
             {% if status_value == Status.COMPLETED.value %}
-              {% include "app/icons/states/completed.svg" %}
+              {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.IN_PROGRESS.value %}
-              {% include "app/icons/states/in-progress.svg" %}
+              {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.PAUSED.value %}
-              {% include "app/icons/states/paused.svg" %}
+              {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.PLANNING.value %}
-              {% include "app/icons/states/planning.svg" %}
+              {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
             {% elif status_value == Status.DROPPED.value %}
-              {% include "app/icons/states/dropped.svg" %}
+              {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
             {% endif %}
           </div>
         {% endwith %}

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -77,7 +77,7 @@
               <button @click="open = !open"
                       class="flex w-full items-center justify-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer md:w-auto md:justify-start">
                 <span class="text-sm font-medium">{{ episode.display_episode_number|default:episode_number }}. {{ episode_title }}</span>
-                <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" %}</div>
+                <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}</div>
               </button>
               <div x-show="open"
                    x-transition:enter="transition ease-out duration-200"
@@ -264,7 +264,7 @@
                 :aria-expanded="castOpen.toString()"
                 aria-label="Toggle cast section">
           <div class="w-4 h-4 transition-transform duration-200" :class="{ 'rotate-180': castOpen }">
-            {% include "app/icons/chevron-down.svg" %}
+            {% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}
           </div>
         </button>
       </div>
@@ -333,7 +333,7 @@
                 :aria-expanded="crewOpen.toString()"
                 aria-label="Toggle crew section">
           <div class="w-4 h-4 transition-transform duration-200" :class="{ 'rotate-180': crewOpen }">
-            {% include "app/icons/chevron-down.svg" %}
+            {% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}
           </div>
         </button>
       </div>

--- a/src/templates/app/icons/camera.svg
+++ b/src/templates/app/icons/camera.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      width="1em"
      height="1em"
-     width="24"
-     height="24"
      viewBox="0 0 24 24"
      fill="none"
      stroke="currentColor"

--- a/src/templates/app/icons/week.svg
+++ b/src/templates/app/icons/week.svg
@@ -1,12 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg"
-     width="24"
-     height="24"
+     width="1em"
+     height="1em"
      viewBox="0 0 24 24"
      fill="none"
      stroke="currentColor"
      stroke-width="2"
      stroke-linecap="round"
-     stroke-linejoin="round">
+     stroke-linejoin="round"
+     class="{{ classes }}">
   <rect width="18" height="18" x="3" y="4" rx="2" ry="2"></rect>
   <line x1="16" x2="16" y1="2" y2="6"></line>
   <line x1="8" x2="8" y1="2" y2="6"></line>

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -123,7 +123,7 @@
                 <button @click="open = !open"
                         class="flex w-full items-center justify-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer md:w-auto md:justify-start">
                   <span class="text-sm font-medium">{{ media.season_header_title|default:media.title }}</span>
-                  <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" %}</div>
+                  <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}</div>
                 </button>
                 <div x-show="open"
                      x-transition:enter="transition ease-out duration-200"

--- a/src/templates/app/search.html
+++ b/src/templates/app/search.html
@@ -97,15 +97,15 @@
                       {% with status_value=tracker.status %}
                         <div class="w-4 h-4 {{ status_value|status_color }}">
                           {% if status_value == Status.COMPLETED.value %}
-                            {% include "app/icons/states/completed.svg" %}
+                            {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
                           {% elif status_value == Status.IN_PROGRESS.value %}
-                            {% include "app/icons/states/in-progress.svg" %}
+                            {% include "app/icons/states/in-progress.svg" with classes="w-full h-full" %}
                           {% elif status_value == Status.PAUSED.value %}
-                            {% include "app/icons/states/paused.svg" %}
+                            {% include "app/icons/states/paused.svg" with classes="w-full h-full" %}
                           {% elif status_value == Status.PLANNING.value %}
-                            {% include "app/icons/states/planning.svg" %}
+                            {% include "app/icons/states/planning.svg" with classes="w-full h-full" %}
                           {% elif status_value == Status.DROPPED.value %}
-                            {% include "app/icons/states/dropped.svg" %}
+                            {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
                           {% endif %}
                         </div>
                       {% endwith %}


### PR DESCRIPTION
The oversized icons on iOS were never a CSS-loading failure. Sampling the
reported screenshot shows the page background is #212529 and the search
placeholder is the right gray, so main.css was applying; the photo is
zoomed in on a single SVG rendering at container size.

Measured in Chromium against the real main.css:

  - status badge inside its w-4 h-4 wrapper, no attrs -> 16px
  - same badge with width="1em" (the previous attempt) -> 12px
  - icon with no size class and no sized wrapper      -> 131px

The status badges the previous attempt targeted were already constrained
by their wrapper, so the 1em fallback fixed nothing there and shrank them
from 16px to 12px. WebKit stretches a viewBox-only <svg> to fill its
parent instead of falling back to a fixed box, which is why the unsized
case presents as iOS-only.

The reason markup fixes never reached the device is that Django sends no
Cache-Control on HTML at all, leaving the document heuristically
cacheable. iOS Safari and the installed PWA share that cache, so they kept
rendering markup fetched days earlier - hence "delete and re-add the PWA"
being the only thing that ever helped.

- Add NoStoreHtmlMiddleware, marking HTML no-store while leaving
  /static/ and /media/ (mtime cache-busted) alone and never overriding a
  view's own policy
- Pass explicit w-full h-full at the 46 wrapper-based icon call sites so
  size comes from the wrapper rather than inherited font-size
- Give week.svg the classes hook it was missing entirely, so call sites
  can size it, and drop the duplicate width/height left in camera.svg
- Cover both halves with regression tests

bfcache is disabled by no-store, which costs nothing here: base.html
already sets historyCacheSize = 0 and refreshOnHistoryMiss = true.

Fixes #442

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RdER7woUV9p3d9XLFZxc7V