### PR TITLE
Keep detail pages alive when a mapped TMDB ID 404s

### DIFF
--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -1903,12 +1903,25 @@ def media_details(
                 on_deferred=_mark_detail_persistence_deferred,
             )
             if tmdb_media_id:
-                tmdb_metadata = services.get_media_metadata(
-                    media_type,
-                    tmdb_media_id,
-                    Sources.TMDB.value,
-                )
-                watch_provider_payload = tmdb_metadata.get("providers")
+                try:
+                    tmdb_metadata = services.get_media_metadata(
+                        media_type,
+                        tmdb_media_id,
+                        Sources.TMDB.value,
+                    )
+                except services.ProviderAPIError:
+                    # Watch providers are TMDB-only enrichment. A dead TMDB
+                    # mapping must not take down a page the tracking provider
+                    # can render on its own.
+                    logger.warning(
+                        "Skipping watch providers for %s media_id=%s: mapped TMDB "
+                        "ID %s could not be fetched",
+                        source,
+                        media_id,
+                        tmdb_media_id,
+                    )
+                else:
+                    watch_provider_payload = tmdb_metadata.get("providers")
 
         watch_providers = (
             tmdb.filter_providers(

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -32,6 +32,7 @@ from app.models import (
     Game,
     Item,
     ItemPersonCredit,
+    ItemProviderLink,
     ItemStudioCredit,
     ItemTag,
     Manga,
@@ -52,7 +53,7 @@ from app.models import (
     Tag,
     Track,
 )
-from app.providers import tmdb
+from app.providers import services, tmdb
 from app.services import game_lengths as game_length_services
 from app.services.metadata_resolution import MetadataResolutionResult
 from integrations.models import PlexAccount
@@ -1955,6 +1956,82 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(item.title, "Sword Art Online")
         self.assertEqual(item.original_title, "ソードアート・オンライン")
         self.assertEqual(item.localized_title, "Sword Art Online")
+
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
+    @patch("app.providers.services.get_media_metadata")
+    def test_media_details_renders_tvdb_show_when_mapped_tmdb_id_is_gone(
+        self,
+        mock_get_metadata,
+    ):
+        """A TVDB title must still render when its TMDB mapping 404s."""
+        item = Item.objects.create(
+            media_id="467589",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Ask Hank Anything",
+            image="https://example.com/cover.jpg",
+        )
+        # TVDB advertises a TMDB remote ID that TMDB has since deleted.
+        ItemProviderLink.objects.create(
+            item=item,
+            provider=Sources.TMDB.value,
+            provider_media_id="281366",
+            provider_media_type=MediaTypes.TV.value,
+        )
+        tvdb_metadata = {
+            "media_id": "467589",
+            "title": "Ask Hank Anything",
+            "media_type": MediaTypes.TV.value,
+            "source": Sources.TVDB.value,
+            "image": "https://example.com/cover.jpg",
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+
+        def metadata_side_effect(
+            media_type,
+            media_id,
+            source,
+            season_numbers=None,
+            episode_number=None,
+        ):
+            del media_type, media_id, season_numbers, episode_number
+            if source == Sources.TMDB.value:
+                tmdb_response = requests.Response()
+                tmdb_response.status_code = requests.codes.not_found
+                raise services.ProviderAPIError(
+                    Sources.TMDB.value,
+                    requests.exceptions.HTTPError(response=tmdb_response),
+                )
+            return {
+                **tvdb_metadata,
+                "details": dict(tvdb_metadata["details"]),
+                "related": dict(tvdb_metadata["related"]),
+                "cast": list(tvdb_metadata["cast"]),
+                "crew": list(tvdb_metadata["crew"]),
+                "studios_full": list(tvdb_metadata["studios_full"]),
+            }
+
+        mock_get_metadata.side_effect = metadata_side_effect
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.TVDB.value,
+                    "media_type": MediaTypes.TV.value,
+                    "media_id": "467589",
+                    "title": "ask-hank-anything",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["watch_providers"])
 
     @patch("app.providers.services.get_media_metadata")
     def test_media_details_persists_movie_recommendation_metadata(


### PR DESCRIPTION
## Problem

A TVDB-tracked show whose stored TMDB mapping points at a **deleted** TMDB entry returns a 500 on its detail page:

```
app.providers.services.ProviderAPIError: There was an error contacting The Movie Database (HTTP 404).
  File "app/media_details_views.py", line 1726, in media_details
    tmdb_metadata = services.get_media_metadata(
```

The failing request is `GET /details/tvdb/tv/467589/ask-hank-anything?fragment=secondary`.

Watch providers are TMDB-only enrichment, so for a TVDB route the view resolves the item's mapped TMDB ID purely to fill the streaming row. TVDB publishes a TMDB ID in its `remoteIds`, we persist it, and normally that works fine. For this title the TMDB record has since been deleted — `api.themoviedb.org/3/tv/281366` returns `status_code 34` — and the unhandled `ProviderAPIError` took down the **entire** secondary fragment: details, collection, cast, seasons, links. A page TVDB could render on its own returned a 500 because an optional extra was unavailable.

This is a per-title data problem, not a TVDB-wide one. Checking one affected library: of 118 TVDB-tracked shows with a stored TMDB mapping, 117 resolve and 1 is dead. TMDB deletes and merges entries continuously, so this recurs on a different title over time.

## Change

Guard the lookup and log a warning instead of propagating, matching the degradation already used twice in this view for specials enrichment (line ~1450) and season-card enrichment (line ~1477).

Behaviour change: when a mapped TMDB ID cannot be fetched, the page renders from the tracking provider with the streaming row absent, rather than 500ing. No other path changes; nothing is written or deleted.

## Files

- `src/app/media_details_views.py` — guard the watch-provider lookup
- `src/app/tests/views/test_media_details.py` — regression test for a TVDB show whose TMDB mapping 404s

## Validation

- New test fails on the parent commit (500 != 200) and passes with the fix.
- Fast suite on this commit vs parent `23c0d929`, same container and flags: **no regressions**. 14 pre-existing failures are identical across both runs; the 2 extra on this run (`test_books`, `test_process_ratings_tmdb_401_raises_clean_import_error`) are live-network tests that pass on re-run in isolation.
- `ruff check` clean on both changed files.
- Built and running against a live instance.

## Remaining risk / not addressed here

- The dead ID is still re-imported from TVDB `remoteIds` on each render, so the page costs one wasted TMDB 404 per secondary-fragment load. Suppressing that at the ingest point is a larger change and deliberately out of scope.
- The external-links panel still renders a `themoviedb.org/tv/<dead id>` link from the same `remoteIds` entry. Cosmetic, separate fix.
- The same unguarded `ProviderAPIError` shape exists in `metadata_resolution.resolve_detail_metadata`'s overlay fetch, reachable when an item's display provider is switched to TMDB. Happy to send that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
