### PR TITLE
Add sanitized log download feature for bug reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ db-dev/
 # Local dev DB
 db/
 
+# Runtime log file (see LOG_DIR in config/settings.py)
+src/logs/
+
 # Retired Tailwind output path; main.css is the canonical compiled asset.
 src/static/css/tailwind.css
 docs/upstream-review.md

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -4,11 +4,59 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import re
 from collections.abc import Iterable, Mapping
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
+
+# Query/form/header param names that commonly carry secrets across Floppy's
+# integrations (Plex, Jellyfin, Trakt, TMDB, Last.fm, Koito, Pocket Casts,
+# gpodder, Stremio). Matches "name=value" (URL/form encoded) up to the next
+# delimiter, or "Name: value" (header style) to end of line.
+_SECRET_PARAM_NAMES = (
+    "token",
+    "access_token",
+    "refresh_token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "client_id",
+    "password",
+    "passwd",
+    "secret",
+    "x-plex-token",
+)
+
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"(?i)\bBearer\s+[A-Za-z0-9\-_.~+/]+=*"),
+        "Bearer [REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)\b(" + "|".join(_SECRET_PARAM_NAMES) + r")\s*[=:]\s*[^&\s\"'<>]+"
+        ),
+        r"\1=[REDACTED]",
+    ),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Strip common secret/token patterns out of raw log text.
+
+    Unlike the structured helpers below, this scrubs text that may already
+    contain a raw token (e.g. logged before a call site adopted these
+    conventions, or from a third-party library's own log lines).
+    """
+    if not text:
+        return ""
+
+    redacted = text
+    for pattern, replacement in _SECRET_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
 
 
 def exception_summary(exc: BaseException | None) -> str:

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -1,6 +1,12 @@
 from django.test import SimpleTestCase
 
-from app.log_safety import exception_summary, presence_map, safe_url, stable_hmac
+from app.log_safety import (
+    exception_summary,
+    presence_map,
+    redact_secrets,
+    safe_url,
+    stable_hmac,
+)
 
 
 class LogSafetyTests(SimpleTestCase):
@@ -30,3 +36,28 @@ class LogSafetyTests(SimpleTestCase):
 
         self.assertEqual(digest, stable_hmac("value", namespace="discover"))
         self.assertNotEqual(digest, stable_hmac("value", namespace="history"))
+
+    def test_redact_secrets_strips_bearer_tokens(self):
+        line = "[INFO] Authorization: Bearer abc123.def-456_ghi== sent to trakt"
+
+        self.assertEqual(
+            redact_secrets(line),
+            "[INFO] Authorization: Bearer [REDACTED] sent to trakt",
+        )
+
+    def test_redact_secrets_strips_named_params(self):
+        line = (
+            "GET https://plex.example/library?X-Plex-Token=abcDEF123&size=10 "
+            "api_key=deadbeef password: hunter2"
+        )
+
+        result = redact_secrets(line)
+
+        self.assertNotIn("abcDEF123", result)
+        self.assertNotIn("deadbeef", result)
+        self.assertNotIn("hunter2", result)
+        self.assertIn("size=10", result)
+
+    def test_redact_secrets_handles_empty_input(self):
+        self.assertEqual(redact_secrets(""), "")
+        self.assertEqual(redact_secrets(None), "")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -468,6 +468,13 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Logging
 # https://docs.djangoproject.com/en/stable/topics/logging/
+
+# Recent logs are also kept on disk (in addition to stdout) so the app can
+# offer a sanitized log download from Settings > Advanced (#510).
+LOG_DIR = config("LOG_DIR", default=str(BASE_DIR / "logs"))
+Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
+LOG_FILE = str(Path(LOG_DIR) / "floppy.log")
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -496,8 +503,16 @@ LOGGING = {
             "formatter": "verbose",
             "level": "DEBUG" if DEBUG else "INFO",
         },
+        "file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": LOG_FILE,
+            "maxBytes": 5 * 1024 * 1024,
+            "backupCount": 3,
+            "formatter": "verbose",
+            "level": "DEBUG" if DEBUG else "INFO",
+        },
     },
-    "root": {"handlers": ["console"], "level": "DEBUG" if DEBUG else "INFO"},
+    "root": {"handlers": ["console", "file"], "level": "DEBUG" if DEBUG else "INFO"},
 }
 
 # Internationalization

--- a/src/templates/users/advanced.html
+++ b/src/templates/users/advanced.html
@@ -70,6 +70,33 @@
           </button>
         </form>
       </div>
+
+      <div class="bg-[var(--color-surface-strong)] p-5 rounded-lg mt-6">
+        <div class="flex items-center mb-3">
+          {% include "app/icons/vertical-sliders.svg" with classes="w-5 h-5 text-indigo-400 mr-2" %}
+          <h3 class="text-base font-medium">Logs &amp; Bug Reports</h3>
+        </div>
+        <p class="text-[var(--color-text-muted)] mb-4 text-sm">
+          Download recent application logs with tokens, passwords, and API keys automatically
+          redacted &mdash; safe to attach to a bug report.
+          <br>
+          If this Floppy instance is shared with other users, the logs may still include their
+          activity, just not their secrets.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <a href="{% url 'export_logs' %}"
+             class="flex items-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors text-sm">
+            {% include "app/icons/vertical-sliders.svg" with classes="w-4 h-4 mr-2" %}
+            Download Sanitized Logs
+          </a>
+          <a href="https://github.com/dannyvfilms/Floppy/issues/new?title={{ bug_report_title|urlencode }}&body={{ bug_report_body|urlencode }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="flex items-center px-4 py-2 bg-[var(--color-surface)] border border-gray-600 rounded-md hover:border-indigo-500 transition-colors text-sm">
+            File a Bug Report
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
     ),
     path("settings/export", views.export_data, name="export_data"),
     path("settings/advanced", views.advanced, name="advanced"),
+    path("settings/advanced/logs", views.export_logs, name="export_logs"),
     path("settings/about", views.about, name="about"),
     path(
         "delete_import_schedule",

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -1365,8 +1365,41 @@ def export_data(request):
 @require_GET
 def advanced(request):
     """Render the advanced settings page."""
-    context = {"tmdb_proxy_configured": bool(request.user.tmdb_proxy_url)}
+    bug_report_body = (
+        f"**Floppy version:** {settings.VERSION}\n\n"
+        "**Describe the issue:**\n\n\n"
+        "**Steps to reproduce:**\n\n\n"
+        "**Logs:** attach the file downloaded from Settings > Advanced > "
+        "Download Sanitized Logs"
+    )
+    context = {
+        "tmdb_proxy_configured": bool(request.user.tmdb_proxy_url),
+        "bug_report_title": "[BUG] ",
+        "bug_report_body": bug_report_body,
+    }
     return render(request, "users/advanced.html", context)
+
+
+@require_GET
+def export_logs(request):
+    """Return recent application logs, with secrets redacted, as a text file."""
+    from pathlib import Path
+
+    from app.log_safety import redact_secrets
+
+    log_path = Path(settings.LOG_FILE)
+    raw_logs = (
+        log_path.read_text(encoding="utf-8", errors="replace")
+        if log_path.exists()
+        else ""
+    )
+
+    sanitized_logs = redact_secrets(raw_logs)
+
+    filename = f"floppy-logs-{timezone.localtime():%Y%m%d-%H%M%S}.txt"
+    response = HttpResponse(sanitized_logs, content_type="text/plain")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
 
 
 @require_GET


### PR DESCRIPTION
## Summary

This PR adds a new feature to download application logs with secrets automatically redacted, making it safe for users to attach logs to bug reports. The changes include:

- **New `redact_secrets()` function** in `app/log_safety.py` that strips common secret/token patterns (Bearer tokens, API keys, passwords, etc.) from raw log text using regex patterns
- **Log file persistence** via a new `RotatingFileHandler` in Django logging configuration that writes to `logs/floppy.log` with rotation (5MB max, 3 backups)
- **New `export_logs` view** in `users/views.py` that serves sanitized logs as a downloadable text file with timestamped filename
- **Updated advanced settings page** with a new "Logs & Bug Reports" section featuring:
  - "Download Sanitized Logs" button linked to the export endpoint
  - "File a Bug Report" button that pre-fills a GitHub issue template with version info and log attachment instructions
- **Comprehensive test coverage** for the `redact_secrets()` function covering Bearer tokens, named parameters, and edge cases

## Validation

- Added unit tests in `test_log_safety.py` covering:
  - Bearer token redaction
  - Named parameter redaction (case-insensitive, various delimiters)
  - Empty/None input handling
- Logging configuration updated to write to both console and rotating file handler
- Template updated with proper URL routing and user-friendly UI

## Notes

Refs #510 - Sanitized log download for bug reports

The redaction patterns cover secrets from integrated services: Plex, Jellyfin, Trakt, TMDB, Last.fm, Koito, Pocket Casts, gpodder, and Stremio. The feature is designed to be safe for shared instances (logs may include other users' activity but not their secrets).

https://claude.ai/code/session_01Lxasp51iEQjv6kS6Hm7DMf