### PR TITLE
Fix container serving 502s: logs directory is root-owned so gunicorn can't start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,9 +56,15 @@ usermod -o -u "$PUID" abc
 
 chown abc:abc /floppy
 
+# "logs" holds the rotating file handler every process configures at import time
+# (settings.LOG_FILE). settings.py creates the directory, so whichever process
+# imports settings first as root leaves it root-owned and every abc-owned
+# process then dies with "Unable to configure handler 'file'" -- taking gunicorn
+# with it, so the container serves 502s while reporting healthy.
+#
 # Bound each recursive chown: a stalled bind mount (e.g. network storage)
 # must degrade to a warning instead of hanging the boot silently (issue #341).
-for dir in db staticfiles /var/log/nginx /var/lib/nginx; do
+for dir in db logs staticfiles /var/log/nginx /var/lib/nginx; do
     timeout 600 chown -R abc:abc "$dir" || \
         echo "[entrypoint] WARNING: chown of ${dir} failed or timed out (stalled mount?); continuing" >&2
 done


### PR DESCRIPTION
## Summary

A container built from current `latest` serves **502 on every request** because
gunicorn never starts.

`config/settings.py` creates `LOG_DIR` at import time and every process attaches
a `RotatingFileHandler` to `settings.LOG_FILE`. `entrypoint.sh` chowns `db`,
`staticfiles`, `/var/log/nginx` and `/var/lib/nginx` to `abc` — but not `logs`.
So whichever process imports settings first while still root leaves
`/floppy/logs` owned by `root:root 755`, and every supervised `abc`-owned
process then dies at startup with:

```
ValueError: Unable to configure handler 'file'
  File "/usr/local/lib/python3.12/logging/config.py", line 615, in configure
    raise ValueError('Unable to configure handler ')
```

nginx has no upstream left, so every request 502s:

```
[error] connect() failed (111: Connection refused) while connecting to upstream,
  upstream: "http://127.0.0.1:8001/..."
```

This should affect any deployment using the default `LOG_DIR`.

## The fix

Add `logs` to the chown loop that already exists a few lines below. The loop
keeps its `timeout 600` guard, so a stalled bind mount still degrades to a
warning rather than hanging the boot (#341).

## Verification

Reproduced and fixed on a live instance (SQLite, PUID/PGID 1000):

- Before: `/floppy/logs` `root:root`, no gunicorn process, `curl` → 502.
- After `--force-recreate` with this change: `/floppy/logs` `abc:abc`,
  3 gunicorn processes, `curl` → 200, zero `Unable to configure handler`
  lines in the container log.

Recovery without a rebuild, for anyone hitting this now:
`docker exec <container> chown -R abc:abc /floppy/logs` then restart the
container. Note the image ships no `supervisorctl` section, so `supervisorctl
restart` is not available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
