### PR TITLE
Fix FK IntegrityError when re-importing Trakt seasons in overwrite mode

### DIFF
--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -705,10 +705,15 @@ class TraktImporter(TraktMetadataResolverMixin):
 
         season_key = f"{tmdb_id}:{season_number}"
         if season_key not in self.media_instances[MediaTypes.SEASON.value]:
-            season_obj = app.models.Season.objects.filter(
-                user=self.user,
-                item=season_item,
-            ).first()
+            tv_marked_for_deletion = (
+                tmdb_id in self.to_delete[MediaTypes.TV.value][Sources.TMDB.value]
+            )
+            season_obj = None
+            if not tv_marked_for_deletion:
+                season_obj = app.models.Season.objects.filter(
+                    user=self.user,
+                    item=season_item,
+                ).first()
             if season_obj is None:
                 season_obj = app.models.Season(
                     item=season_item,

--- a/src/integrations/tests/imports/test_trakt.py
+++ b/src/integrations/tests/imports/test_trakt.py
@@ -250,6 +250,91 @@ class ImportTrakt(TestCase):
             Episode.objects.filter(related_season=season).exists(),
         )
 
+    @patch("integrations.imports.trakt.TraktImporter._get_metadata")
+    def test_process_watched_episode_overwrite_mode_existing_season(
+        self,
+        mock_get_metadata,
+    ):
+        """Overwrite-mode re-import must not reference a deleted Season row (#531)."""
+        tv_item = Item.objects.get_or_create(
+            media_id="12345",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            defaults={"title": "Test Show"},
+        )[0]
+        old_tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.get_or_create(
+            media_id="12345",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            defaults={"title": "Season 1"},
+        )[0]
+        old_season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=old_tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.get_or_create(
+            media_id="12345",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            defaults={"title": "Pilot"},
+        )[0]
+        Episode.objects.create(item=episode_item, related_season=old_season)
+
+        episode_entry = {
+            "type": "episode",
+            "episode": {"season": 1, "number": 1, "title": "Pilot"},
+            "show": {"title": "Test Show", "ids": {"tmdb": 12345}},
+            "watched_at": "2023-01-01T00:00:00.000Z",
+        }
+
+        def mock_metadata_side_effect(media_type, _, __, ___=None):
+            if media_type == MediaTypes.TV.value:
+                return {
+                    "title": "Test Show",
+                    "image": "tv_image.jpg",
+                    "last_episode_season": 1,
+                    "max_progress": 1,
+                }
+            if media_type == MediaTypes.SEASON.value:
+                return {
+                    "title": "Season 1",
+                    "image": "season_image.jpg",
+                    "episodes": [{"episode_number": 1, "still_path": "/still.jpg"}],
+                    "max_progress": 1,
+                }
+            return None
+
+        mock_get_metadata.side_effect = mock_metadata_side_effect
+
+        trakt_importer = TraktImporter("testuser", self.user, "overwrite")
+        trakt_importer.process_watched_episode(episode_entry)
+
+        self.assertEqual(len(trakt_importer.bulk_media[MediaTypes.TV.value]), 1)
+        self.assertEqual(len(trakt_importer.bulk_media[MediaTypes.SEASON.value]), 1)
+
+        # Exercise the actual delete-then-create sequence used by import_data().
+        # This must not raise IntegrityError from a stale (soon-to-be-deleted)
+        # Season row being referenced by the new Episode.
+        helpers.cleanup_existing_media(trakt_importer.to_delete, trakt_importer.user)
+        helpers.bulk_create_media(trakt_importer.bulk_media, trakt_importer.user)
+
+        new_tv = TV.objects.get(user=self.user, item__media_id="12345")
+        new_season = Season.objects.get(user=self.user, related_tv=new_tv)
+        self.assertNotEqual(new_season.pk, old_season.pk)
+        self.assertTrue(
+            Episode.objects.filter(related_season=new_season).exists(),
+        )
+
     @patch("integrations.imports.trakt.TraktImporter._make_api_request")
     @patch("integrations.imports.trakt.TraktImporter._get_metadata")
     def test_process_watchlist(self, mock_get_metadata, mock_make_request):


### PR DESCRIPTION
process_watched_episode already rebuilds a fresh TV instance when the
existing show is queued for delete+recreate (fixed in #419), but the
Season lookup right below it had no equivalent check: it would reuse
the old Season row (still present in the DB until cleanup_existing_media
runs), which was about to be cascade-deleted along with the old TV row.
Episodes built afterward captured that stale Season PK, causing
"FOREIGN KEY constraint failed" once the old rows were deleted and the
new Episode rows were inserted.

Fixes #531