### PR TITLE
Fix light/dark toggle overlapping media type filter on mobile

### DIFF
--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -5115,6 +5115,11 @@
       -webkit-line-clamp: 2;
     }
   }
+  .lg\:block {
+    @media (width >= 64rem) {
+      display: block;
+    }
+  }
   .lg\:flex {
     @media (width >= 64rem) {
       display: flex;

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -459,13 +459,25 @@
                     </form>
                   </div>
                 {% endif %}
+
+                {# Mobile: theme toggle as a flex item so it can't overlap the search/media-type controls #}
+                {% if user.is_authenticated %}
+                  <button type="button"
+                          onclick="floppyToggleTheme()"
+                          class="lg:hidden shrink-0 p-2 rounded-md text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-hover-dim)] transition-colors duration-200 cursor-pointer"
+                          title="Toggle theme"
+                          aria-label="Toggle theme">
+                    {% include "app/icons/sun.svg" with classes="w-5 h-5 theme-toggle-icon-sun" %}
+                    {% include "app/icons/moon.svg" with classes="w-5 h-5 theme-toggle-icon-moon" %}
+                  </button>
+                {% endif %}
               </div>
             </div>
 
             {% if user.is_authenticated %}
               <button type="button"
                       onclick="floppyToggleTheme()"
-                      class="absolute right-4 top-1/2 -translate-y-1/2 shrink-0 p-2 rounded-md text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-hover-dim)] transition-colors duration-200 cursor-pointer"
+                      class="hidden lg:block absolute right-4 top-1/2 -translate-y-1/2 shrink-0 p-2 rounded-md text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-hover-dim)] transition-colors duration-200 cursor-pointer"
                       title="Toggle theme"
                       aria-label="Toggle theme">
                 {% include "app/icons/sun.svg" with classes="w-5 h-5 theme-toggle-icon-sun" %}


### PR DESCRIPTION
The theme toggle was absolutely positioned relative to the sticky top
bar, independent of the flex row containing search and the media type
dropdown. On mobile that row grows to fill the width, pushing the
dropdown under the toggle. Split into two buttons: the desktop one
keeps its original absolute position (now gated to lg: and up), and a
new mobile one is a normal flex item after the search form so it
reflows instead of overlapping.