### PR TITLE
Replace grid/table toggle with a settings gear menu, add Share View

### DIFF
--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -2145,6 +2145,73 @@ class SmartRulesUpdateViewTest(TestCase):
         self.assertEqual(response.status_code, 400)
 
 
+class ShareViewTest(TestCase):
+    """Tests for the Share View endpoint."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = get_user_model().objects.create_user(
+            username="owner",
+            password="12345",
+        )
+        self.client.login(username="owner", password="12345")
+
+    def test_share_view_creates_public_smart_list(self):
+        response = self.client.post(
+            reverse("list_share_view"),
+            {"media_type": MediaTypes.TV.value, "status": "In progress"},
+        )
+        self.assertEqual(response.status_code, 200)
+        custom_list = CustomList.objects.get()
+        self.assertTrue(custom_list.is_smart)
+        self.assertEqual(custom_list.visibility, "public")
+        self.assertEqual(custom_list.owner, self.user)
+        self.assertEqual(custom_list.smart_media_types, [MediaTypes.TV.value])
+        self.assertEqual(custom_list.smart_filters["status"], ["In progress"])
+        self.assertEqual(
+            response.json()["url"],
+            custom_list.get_absolute_url(),
+        )
+
+    def test_share_view_reuses_existing_matching_list(self):
+        first = self.client.post(
+            reverse("list_share_view"),
+            {"media_type": MediaTypes.TV.value, "status": "In progress"},
+        ).json()
+        second = self.client.post(
+            reverse("list_share_view"),
+            {"media_type": MediaTypes.TV.value, "status": "In progress"},
+        ).json()
+        self.assertEqual(first["url"], second["url"])
+        self.assertEqual(CustomList.objects.count(), 1)
+
+    def test_share_view_different_filters_create_different_lists(self):
+        self.client.post(
+            reverse("list_share_view"),
+            {"media_type": MediaTypes.TV.value, "status": "In progress"},
+        )
+        self.client.post(
+            reverse("list_share_view"),
+            {"media_type": MediaTypes.TV.value, "status": "Completed"},
+        )
+        self.assertEqual(CustomList.objects.count(), 2)
+
+    def test_share_view_rejects_invalid_media_type(self):
+        response = self.client.post(
+            reverse("list_share_view"),
+            {"media_type": "not-a-real-type"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_share_view_requires_login(self):
+        self.client.logout()
+        response = self.client.post(
+            reverse("list_share_view"),
+            {"media_type": MediaTypes.TV.value},
+        )
+        self.assertEqual(response.status_code, 302)
+
+
 class EditListViewTest(TestCase):
     """Test case for the edit list view."""
 

--- a/src/lists/urls.py
+++ b/src/lists/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
         name="list_smart_rules_update",
     ),
     path("list/create", views_list_actions.create, name="list_create"),
+    path("list/share-view", views_list_actions.share_view, name="list_share_view"),
     path("list/edit", views_list_actions.edit, name="list_edit"),
     path("list/delete", views_list_actions.delete, name="list_delete"),
     path("list/import-csv", views_list_actions.import_list_csv, name="list_import_csv"),

--- a/src/lists/views_list_actions.py
+++ b/src/lists/views_list_actions.py
@@ -7,6 +7,7 @@ small fragments. The read-heavy detail views live in views_list_detail.py and
 views_smart_list.py; the browse views live in views_list_browse.py.
 """
 
+import contextlib
 import json
 import logging
 
@@ -21,9 +22,10 @@ from django.views.decorators.http import require_GET, require_POST
 from app import helpers
 from app.columns import sanitize_column_prefs
 from app.discover import tab_cache as discover_tab_cache
-from app.models import Item, MediaTypes
+from app.models import Item, MediaTypes, Status
 from app.providers import services
 from app.services import metadata_resolution
+from app.templatetags.app_tags import media_type_readable_plural
 from lists import smart_rules
 from lists import tasks as list_tasks
 from lists.forms import CustomListForm
@@ -37,7 +39,7 @@ from lists.views_helpers import (
     _list_item_title_fields_from_metadata,
     _maybe_backfill_episode_title,
 )
-from users.models import ListDetailSortChoices
+from users.models import ListDetailSortChoices, MediaSortChoices
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +134,66 @@ def create(request):
         logger.error(form.errors.as_json())
         helpers.form_error_messages(form, request)
     return helpers.redirect_back(request)
+
+
+def _build_share_view_name(media_type, normalized_rules):
+    """Build a short, human-readable name for a Share View smart list."""
+    parts = [media_type_readable_plural(media_type)]
+
+    statuses = normalized_rules.get("status") or []
+    if statuses:
+        parts.append(", ".join(Status(value).label for value in statuses))
+
+    sort_value = normalized_rules.get("sort")
+    if sort_value:
+        with contextlib.suppress(ValueError):
+            parts.append(f"sorted by {MediaSortChoices(sort_value).label}")
+
+    return " — ".join(parts)
+
+
+@login_required
+@require_POST
+def share_view(request):
+    """Create (or reuse) a public smart list snapshotting the current view."""
+    media_type = request.POST.get("media_type", "")
+    if media_type not in MediaTypes.values:
+        return HttpResponseBadRequest("Invalid media type")
+
+    normalized = smart_rules.normalize_rule_payload(request.POST, request.user)
+    smart_media_types = [media_type]
+    smart_filters = {
+        key: normalized.get(key, smart_rules.SMART_FILTER_DEFAULTS[key])
+        for key in smart_rules.SMART_FILTER_KEYS
+    }
+
+    existing = CustomList.objects.filter(
+        owner=request.user,
+        is_smart=True,
+        visibility="public",
+        smart_media_types=smart_media_types,
+        smart_filters=smart_filters,
+    ).first()
+
+    if existing:
+        custom_list = existing
+    else:
+        custom_list = CustomList.objects.create(
+            name=_build_share_view_name(media_type, normalized),
+            owner=request.user,
+            visibility="public",
+            is_smart=True,
+            smart_media_types=smart_media_types,
+            smart_filters=smart_filters,
+        )
+        ListActivity.objects.create(
+            custom_list=custom_list,
+            user=request.user,
+            activity_type=ListActivityType.LIST_CREATED,
+        )
+        list_tasks.sync_smart_list_task.delay(custom_list.id)
+
+    return JsonResponse({"url": custom_list.get_absolute_url()})
 
 
 @login_required

--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -1030,13 +1030,8 @@ html.light .theme-toggle-icon-moon {
     display: none;
   }
 
-  .media-filter-toolbar .layout-toggle {
-    margin-left: 0 !important;
-    justify-self: end;
-  }
-
-  .filter-toolbar .layout-toggle {
-    justify-self: end;
+  .media-settings-menu-desktop {
+    display: none !important;
   }
 
   .lists-filter-toolbar {
@@ -1124,6 +1119,10 @@ html.light .theme-toggle-icon-moon {
   .result-count-desktop {
     display: inline-flex;
     align-items: center;
+  }
+
+  .media-settings-menu-mobile {
+    display: none !important;
   }
 }
 

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -4255,6 +4255,11 @@
       cursor: not-allowed;
     }
   }
+  .disabled\:cursor-wait {
+    &:disabled {
+      cursor: wait;
+    }
+  }
   .disabled\:border-gray-700 {
     &:disabled {
       border-color: var(--color-gray-700);
@@ -6116,12 +6121,8 @@ html.light .theme-toggle-icon-moon {
   .result-count-desktop {
     display: none;
   }
-  .media-filter-toolbar .layout-toggle {
-    margin-left: 0 !important;
-    justify-self: end;
-  }
-  .filter-toolbar .layout-toggle {
-    justify-self: end;
+  .media-settings-menu-desktop {
+    display: none !important;
   }
   .lists-filter-toolbar {
     width: 100%;
@@ -6194,6 +6195,9 @@ html.light .theme-toggle-icon-moon {
   .result-count-desktop {
     display: inline-flex;
     align-items: center;
+  }
+  .media-settings-menu-mobile {
+    display: none !important;
   }
 }
 .select2-container--tailwindcss-4 {

--- a/src/templates/app/components/filter_toolbar.html
+++ b/src/templates/app/components/filter_toolbar.html
@@ -1185,21 +1185,7 @@
         {% url 'medialist_columns' media_type as media_list_columns_url %}
         {% include "app/components/table_column_menu.html" with table_column_update_url=media_list_columns_url table_refresh_url=filter_hx_endpoint table_refresh_target=".media-table" table_refresh_include_selector="#filter-form" table_loading_indicator="#loading-indicator" table_type=table_type|default:'media' %}
 
-        <!-- Layout Toggle -->
-        <div class="flex rounded-md overflow-hidden border border-gray-700 layout-toggle">
-          <a :href="layoutHref('grid')"
-             class="p-2 cursor-pointer"
-             :class="layout === 'grid' ? 'bg-indigo-600 text-white' : 'bg-[var(--color-surface-strong)] hover:bg-[var(--color-surface-hover)]'"
-             title="Grid View"
-             @click="layout = 'grid'">
-            {% include "app/icons/four-square.svg" with classes="w-5 h-5" %}
-          </a>
-          <a :href="layoutHref('table')"
-             class="p-2 cursor-pointer"
-             :class="layout === 'table' ? 'bg-indigo-600 text-white' : 'bg-[var(--color-surface-strong)] hover:bg-[var(--color-surface-hover)]'"
-             title="Table View"
-             @click="layout = 'table'">{% include "app/icons/table.svg" with classes="w-5 h-5" %}</a>
-        </div>
+        {% include "app/components/media_settings_menu.html" with menu_class="media-settings-menu-desktop" %}
       </div>
     {% endif %}
   </div>

--- a/src/templates/app/components/media_settings_menu.html
+++ b/src/templates/app/components/media_settings_menu.html
@@ -1,0 +1,32 @@
+<div class="relative filter-control {{ menu_class|default:'' }}"
+     x-data="{ open: false, sharing: false }"
+     @click.outside="open = false">
+  <button class="p-2 rounded-md border border-gray-700 bg-[var(--color-surface-strong)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-secondary)] transition-colors cursor-pointer"
+          title="View settings"
+          @click="open = !open"
+          type="button">{% include "app/icons/settings.svg" with classes="w-5 h-5" %}</button>
+  <div class="absolute right-0 z-40 mt-2 w-56 bg-[var(--color-surface-strong)] rounded-md shadow-lg overflow-hidden border border-gray-700"
+       x-cloak
+       x-show="open"
+       x-transition:enter="transition ease-out duration-100"
+       x-transition:enter-start="transform opacity-0 scale-95"
+       x-transition:enter-end="transform opacity-100 scale-100"
+       x-transition:leave="transition ease-in duration-75"
+       x-transition:leave-start="transform opacity-100 scale-100"
+       x-transition:leave-end="transform opacity-0 scale-95">
+    <a :href="layoutHref(layout === 'grid' ? 'table' : 'grid')"
+       class="flex items-center gap-2 w-full px-3 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] transition-colors cursor-pointer"
+       @click="layout = layout === 'grid' ? 'table' : 'grid'; open = false">
+      <span x-show="layout === 'grid'">{% include "app/icons/table.svg" with classes="w-4 h-4" %}</span>
+      <span x-show="layout !== 'grid'">{% include "app/icons/four-square.svg" with classes="w-4 h-4" %}</span>
+      <span x-text="layout === 'grid' ? 'Table View' : 'Grid View'"></span>
+    </a>
+    <button class="flex items-center gap-2 w-full px-3 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait"
+            type="button"
+            :disabled="sharing"
+            @click="open = false; sharing = true; shareView().finally(() => { sharing = false; })">
+      {% include "app/icons/link.svg" with classes="w-4 h-4" %}
+      <span x-text="sharing ? 'Sharing…' : 'Share View'"></span>
+    </button>
+  </div>
+</div>

--- a/src/templates/app/media_list.html
+++ b/src/templates/app/media_list.html
@@ -7,17 +7,6 @@
 {% endblock title %}
 
 {% block content %}
-  <div class="flex items-center gap-3 mb-6">
-    <h1 class="text-3xl font-bold">{{ media_type|media_type_readable_plural }}</h1>
-    <div data-result-count class="result-count-badge result-count-mobile px-4 py-2 bg-[var(--color-surface)] rounded-md text-[var(--color-text-secondary)] text-sm font-semibold">
-      {% if media_list.paginator %}
-        {{ media_list.paginator.count }}
-      {% else %}
-        {{ media_list|length }}
-      {% endif %}
-    </div>
-  </div>
-
   {% include "app/components/filter_toolbar_scripts.html" %}
 
   <div x-data="{
@@ -218,8 +207,48 @@
       this.provider = '';
       this.selectedTags = [];
       this.tagMode = 'or';
+    },
+    shareView() {
+      // Open the tab synchronously (within the click handler) so browsers
+      // don't treat it as a blocked popup once the fetch resolves later.
+      const shareWindow = window.open('', '_blank');
+      const form = document.getElementById('filter-form');
+      const params = buildMediaListFilterParams(form);
+      params.set('media_type', '{{ media_type|escapejs }}');
+      return fetch('{% url "list_share_view" %}', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': '{{ csrf_token }}' },
+        body: params,
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          if (data.url && shareWindow) {
+            shareWindow.location.href = data.url;
+          } else if (data.url) {
+            window.open(data.url, '_blank');
+          } else if (shareWindow) {
+            shareWindow.close();
+          }
+        })
+        .catch(() => {
+          if (shareWindow) {
+            shareWindow.close();
+          }
+        });
     }
   }">
+
+    <div class="flex items-center gap-3 mb-6">
+      <h1 class="text-3xl font-bold">{{ media_type|media_type_readable_plural }}</h1>
+      <div data-result-count class="result-count-badge result-count-mobile px-4 py-2 bg-[var(--color-surface)] rounded-md text-[var(--color-text-secondary)] text-sm font-semibold">
+        {% if media_list.paginator %}
+          {{ media_list.paginator.count }}
+        {% else %}
+          {{ media_list|length }}
+        {% endif %}
+      </div>
+      {% include "app/components/media_settings_menu.html" with menu_class="ml-auto media-settings-menu-mobile" %}
+    </div>
 
     {% include "app/components/filter_form.html" %}
 


### PR DESCRIPTION
The gear menu consolidates the grid/table view toggle and adds a Share
View action that publishes the current filtered view as a public smart
list and opens it in a new tab. On mobile the gear button moves onto
the title line so the filter row has more room; desktop placement is
unchanged. Repeated Share View clicks with identical filters reuse the
existing public list instead of creating duplicates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WSzaLAc1KihexuWcPwE88e