### PR TITLE
Fix Sonarr import crash from Item rows split across library buckets

### DIFF
--- a/src/app/migrations/0148_merge_duplicate_item_buckets.py
+++ b/src/app/migrations/0148_merge_duplicate_item_buckets.py
@@ -1,0 +1,239 @@
+"""Merge Item rows that differ only by their library_media_type bucket.
+
+0118 added ``library_media_type`` to all three Item uniqueness constraints, so
+the same media identity became storable twice - once in the bucket the tracking
+pages use (e.g. 'tv' for a show's episodes) and once in the default bucket
+('episode'). Callers keyed on the identity fields alone, notably the Sonarr
+importer, then created that second row instead of finding the first. The split
+left collection ownership attached to a row the rest of the app never looks at,
+and once both rows existed the next import crashed with MultipleObjectsReturned.
+
+0125 cleaned up one flavour of this (stray ('episode','season') rows). This
+migration handles the general case: any identity carrying more than one row is
+folded onto a single survivor, everything referencing the losers is repointed,
+and the losers are deleted. Rebuildable provider metadata (person credits,
+backfill state) that would collide on the survivor is dropped rather than
+merged, since it regenerates.
+
+The surviving bucket is chosen per title rather than per row. A per-row choice
+keeps one episode of a season on 'tv' and the next on 'episode' purely because
+of insertion order, which is the same split this migration exists to undo.
+
+Only duplicated identities are touched. Single rows sitting in a non-canonical
+bucket are left alone: they resolve fine today, and re-bucketing them would
+move rows the app currently finds.
+"""
+
+from collections import defaultdict
+
+from django.db import migrations, transaction
+from django.db.models import Count
+from django.db.utils import IntegrityError
+
+IDENTITY_FIELDS = (
+    "media_id",
+    "source",
+    "media_type",
+    "season_number",
+    "episode_number",
+)
+
+MIN_GROUP_SIZE = 2
+
+# Rows recording that the user tracks this item. These decide which bucket
+# survives: they are what the tracking pages, statistics and exports resolve.
+TRACKING_MODELS = {
+    ("app", "basicmedia"),
+    ("app", "manga"),
+    ("app", "anime"),
+    ("app", "movie"),
+    ("app", "game"),
+    ("app", "boardgame"),
+    ("app", "book"),
+    ("app", "comic"),
+    ("app", "comicissue"),
+    ("app", "music"),
+    ("app", "podcast"),
+    ("app", "tv"),
+    ("app", "season"),
+    ("app", "episode"),
+}
+
+# Other things a user created or chose, as opposed to provider metadata the app
+# can refetch. These break ties and move onto the survivor either way.
+OWNED_MODELS = {
+    ("app", "collectionentry"),
+    ("app", "itemtag"),
+    ("app", "playbackprogress"),
+    ("app", "discoverfeedback"),
+    ("integrations", "collectionsourcestate"),
+    ("integrations", "plexwatchlistsyncitem"),
+    ("events", "event"),
+    ("lists", "customlist"),
+    ("lists", "customlistitem"),
+}
+
+
+def _relation_key(relation):
+    """Return the (app_label, model_name) of a relation's model."""
+    meta = relation.related_model._meta
+    return (meta.app_label, meta.model_name)
+
+
+def _count(item, relations):
+    """Count rows on this item across the given reverse relations."""
+    total = 0
+    for relation in relations:
+        total += (
+            relation.related_model._base_manager.filter(
+                **{relation.field.name: item},
+            ).count()
+        )
+    return total
+
+
+def _repoint(item_model, loser, keeper):
+    """Move everything referencing loser onto keeper."""
+    for relation in item_model._meta.related_objects:
+        field = relation.field
+        related_manager = relation.related_model._base_manager
+
+        if relation.many_to_many:
+            # 0125 predates the m2m relations on Item and did not handle them.
+            for related in related_manager.filter(**{field.name: loser}):
+                getattr(related, field.name).add(keeper)
+                getattr(related, field.name).remove(loser)
+            continue
+
+        # Materialised, not an iterator: the save below changes the column the
+        # queryset filters on, which can make a streaming cursor skip rows.
+        for related in list(related_manager.filter(**{field.name: loser})):
+            setattr(related, field.name, keeper)
+            try:
+                # A savepoint keeps a collision from poisoning the surrounding
+                # transaction, so the rest of the group can still be merged.
+                with transaction.atomic():
+                    related.save(update_fields=[field.attname])
+            except IntegrityError:
+                # The keeper already has the equivalent row; the loser's copy
+                # is redundant provider metadata.
+                related.delete()
+
+
+def merge_duplicate_item_buckets(apps, schema_editor):
+    """Fold every duplicated Item identity onto a single row."""
+    del schema_editor
+    Item = apps.get_model("app", "Item")
+
+    tracking_relations = [
+        relation
+        for relation in Item._meta.related_objects
+        if _relation_key(relation) in TRACKING_MODELS
+    ]
+    owned_relations = [
+        relation
+        for relation in Item._meta.related_objects
+        if _relation_key(relation) in OWNED_MODELS
+    ]
+
+    duplicate_groups = _duplicate_groups(Item)
+    if not duplicate_groups:
+        return
+
+    weights = _bucket_weights(duplicate_groups, tracking_relations, owned_relations)
+
+    for items in duplicate_groups:
+        scope = (items[0].media_id, items[0].source, items[0].media_type)
+        keeper = _pick_keeper(
+            items,
+            weights.get(scope),
+            tracking_relations,
+            owned_relations,
+        )
+        for loser in items:
+            if loser.pk == keeper.pk:
+                continue
+            _repoint(Item, loser, keeper)
+            loser.delete()
+
+
+def _duplicate_groups(item_model):
+    """Return the Item rows of every identity that has more than one row.
+
+    Two queries rather than a full materialisation of the table: the aggregate
+    finds the duplicated identities, then one fetch pulls back only the rows
+    belonging to them.
+    """
+    duplicate_keys = {
+        tuple(row[field] for field in IDENTITY_FIELDS)
+        for row in item_model.objects.values(*IDENTITY_FIELDS)
+        .annotate(row_count=Count("id"))
+        .filter(row_count__gte=MIN_GROUP_SIZE)
+    }
+    if not duplicate_keys:
+        return []
+
+    groups = defaultdict(list)
+    media_ids = {key[0] for key in duplicate_keys}
+    for item in item_model.objects.filter(media_id__in=media_ids).order_by("id"):
+        key = tuple(getattr(item, field) for field in IDENTITY_FIELDS)
+        if key in duplicate_keys:
+            groups[key].append(item)
+
+    return list(groups.values())
+
+
+def _bucket_weights(duplicate_groups, tracking_relations, owned_relations):
+    """Return the winning bucket per title, or None where nothing decides it."""
+    tallies = defaultdict(lambda: defaultdict(lambda: [0, 0]))
+    for items in duplicate_groups:
+        for item in items:
+            scope = (item.media_id, item.source, item.media_type)
+            tally = tallies[scope][item.library_media_type]
+            tally[0] += _count(item, tracking_relations)
+            tally[1] += _count(item, owned_relations)
+
+    preferred = {}
+    for scope, buckets in tallies.items():
+        if not any(any(tally) for tally in buckets.values()):
+            # Nothing to go on; leave the choice to the per-group fallback.
+            continue
+        preferred[scope] = max(buckets, key=lambda bucket: buckets[bucket])
+    return preferred
+
+
+def _pick_keeper(items, preferred_bucket, tracking_relations, owned_relations):
+    """Return the row the rest of the group should collapse onto."""
+    candidates = [
+        item for item in items if item.library_media_type == preferred_bucket
+    ]
+    # Prefer the title's tracked bucket, but never at the cost of losing a row's
+    # own tracking history to a bucket that has none in this group.
+    if candidates and not any(
+        _count(item, tracking_relations)
+        for item in items
+        if item.pk not in {candidate.pk for candidate in candidates}
+    ):
+        items = candidates
+
+    return max(
+        items,
+        key=lambda item: (
+            _count(item, tracking_relations),
+            _count(item, owned_relations),
+            -item.pk,
+        ),
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0146_backfill_reconcile_state"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            merge_duplicate_item_buckets,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/src/app/tests/migrations/test_0148_merge_duplicate_item_buckets.py
+++ b/src/app/tests/migrations/test_0148_merge_duplicate_item_buckets.py
@@ -1,0 +1,144 @@
+import importlib
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import (
+    TV,
+    CollectionEntry,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+from integrations.models import CollectionSourceState
+
+migration = importlib.import_module(
+    "app.migrations.0148_merge_duplicate_item_buckets",
+)
+
+
+class _RealAppsRegistry:
+    """Minimal stand-in for the historical `apps` migrations pass in."""
+
+    def get_model(self, app_label, model_name):
+        del app_label
+        return {"Item": Item}[model_name]
+
+
+class MergeDuplicateItemBucketsMigration(TestCase):
+    """Test the corrective data migration for split library buckets."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",
+        )
+        show_item = Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Severance",
+        )
+        season_item = Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Severance Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=show_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+
+    def _episode_item(self, episode_number, bucket):
+        return Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=bucket,
+            title=f"Severance S1E{episode_number}",
+            season_number=1,
+            episode_number=episode_number,
+        )
+
+    def _run(self):
+        migration.merge_duplicate_item_buckets(_RealAppsRegistry(), None)
+
+    def test_keeps_the_row_carrying_watch_history(self):
+        """The tracked row survives and the stray importer row is deleted."""
+        tracked = self._episode_item(1, MediaTypes.TV.value)
+        stray = self._episode_item(1, MediaTypes.EPISODE.value)
+        Episode.objects.create(item=tracked, related_season=self.season)
+
+        self._run()
+
+        self.assertTrue(Item.objects.filter(pk=tracked.pk).exists())
+        self.assertFalse(Item.objects.filter(pk=stray.pk).exists())
+
+    def test_moves_collection_state_onto_the_survivor(self):
+        """Ownership recorded against the stray row follows it to the keeper."""
+        tracked = self._episode_item(1, MediaTypes.TV.value)
+        stray = self._episode_item(1, MediaTypes.EPISODE.value)
+        Episode.objects.create(item=tracked, related_season=self.season)
+        entry = CollectionEntry.objects.create(
+            user=self.user,
+            item=stray,
+            media_type="digital",
+        )
+        state = CollectionSourceState.objects.create(
+            user=self.user,
+            item=stray,
+            source="sonarr",
+        )
+
+        self._run()
+
+        entry.refresh_from_db()
+        state.refresh_from_db()
+        self.assertEqual(entry.item_id, tracked.pk)
+        self.assertEqual(state.item_id, tracked.pk)
+
+    def test_collapses_a_whole_season_to_one_bucket(self):
+        """Episodes of one title share a bucket regardless of insertion order.
+
+        Only the first episode carries history here, and the second episode's
+        rows were inserted in the opposite order. Choosing per row would keep
+        E1 on 'tv' and E2 on 'episode' - the very split being undone.
+        """
+        tracked = self._episode_item(1, MediaTypes.TV.value)
+        self._episode_item(1, MediaTypes.EPISODE.value)
+        Episode.objects.create(item=tracked, related_season=self.season)
+
+        self._episode_item(2, MediaTypes.EPISODE.value)
+        self._episode_item(2, MediaTypes.TV.value)
+
+        self._run()
+
+        survivors = Item.objects.filter(
+            media_id="95396",
+            media_type=MediaTypes.EPISODE.value,
+        ).order_by("episode_number")
+        self.assertEqual(
+            [(item.episode_number, item.library_media_type) for item in survivors],
+            [(1, MediaTypes.TV.value), (2, MediaTypes.TV.value)],
+        )
+
+    def test_leaves_single_rows_in_odd_buckets_alone(self):
+        """A lone row in a non-canonical bucket is not a duplicate."""
+        lone = self._episode_item(3, MediaTypes.TV.value)
+
+        self._run()
+
+        lone.refresh_from_db()
+        self.assertEqual(lone.library_media_type, MediaTypes.TV.value)

--- a/src/integrations/imports/helpers.py
+++ b/src/integrations/imports/helpers.py
@@ -45,6 +45,28 @@ def retry_on_lock(func, max_retries=5, base_delay=0.1, backoff=2.0):
     return outcome.value
 
 
+def find_item_across_buckets(preferred_bucket=None, **identity):
+    """Return an existing Item for an identity, preferring one library bucket.
+
+    Every Item uniqueness constraint includes ``library_media_type``, and the
+    same media identity can legitimately live in more than one bucket (grouped
+    anime is stored on TV rows, and episodes auto-created for a tracked season
+    inherit the show's bucket rather than the default 'episode' one). A
+    ``get``/``get_or_create`` keyed only on the identity fields therefore raises
+    ``MultipleObjectsReturned`` as soon as two buckets exist. Reuse an existing
+    row instead of failing or creating a third, divergent one - preferring the
+    caller's bucket, then the oldest row so repeat runs stay stable.
+    """
+    candidates = list(app.models.Item.objects.filter(**identity).order_by("id"))
+    if not candidates:
+        return None
+    if preferred_bucket:
+        for item in candidates:
+            if item.library_media_type == preferred_bucket:
+                return item
+    return candidates[0]
+
+
 def get_existing_media(user):
     """Get all existing media for the user to check against during import."""
     excluded_types = [MediaTypes.SEASON.value, MediaTypes.EPISODE.value]

--- a/src/integrations/imports/radarr.py
+++ b/src/integrations/imports/radarr.py
@@ -11,7 +11,11 @@ from django.utils import timezone
 from app.models import Item, MediaTypes, Sources
 from app.providers import services
 from integrations import import_progress
-from integrations.imports.helpers import MediaImportError, decrypt_or_raise
+from integrations.imports.helpers import (
+    MediaImportError,
+    decrypt_or_raise,
+    find_item_across_buckets,
+)
 from integrations.models import RadarrAccount
 from integrations.source_sync import upsert_collection_source_state
 
@@ -141,11 +145,11 @@ class RadarrImporter:
         imdb_id = row.get("imdbId")
 
         if tmdb_id:
-            existing = Item.objects.filter(
+            existing = find_item_across_buckets(
                 media_id=str(tmdb_id),
                 source=Sources.TMDB.value,
                 media_type=MediaTypes.MOVIE.value,
-            ).first()
+            )
             if existing:
                 return existing
 
@@ -181,11 +185,11 @@ class RadarrImporter:
             return item
 
         if imdb_id:
-            return Item.objects.filter(
+            return find_item_across_buckets(
                 media_id=str(imdb_id),
                 source=Sources.TMDB.value,
                 media_type=MediaTypes.MOVIE.value,
-            ).first()
+            )
 
         return None
 

--- a/src/integrations/imports/sonarr.py
+++ b/src/integrations/imports/sonarr.py
@@ -13,6 +13,7 @@ from integrations import import_progress
 from integrations.imports.helpers import (
     MediaImportError,
     decrypt_or_raise,
+    find_item_across_buckets,
     retry_on_lock,
 )
 from integrations.models import SonarrAccount
@@ -151,18 +152,18 @@ class SonarrImporter:
         tvdb_id = row.get("tvdbId")
 
         if tmdb_id:
-            return Item.objects.filter(
+            return find_item_across_buckets(
                 media_id=str(tmdb_id),
                 source=Sources.TMDB.value,
                 media_type=MediaTypes.TV.value,
-            ).first()
+            )
 
         if tvdb_id:
-            return Item.objects.filter(
+            return find_item_across_buckets(
                 media_id=str(tvdb_id),
                 source=Sources.TVDB.value,
                 media_type=MediaTypes.TV.value,
-            ).first()
+            )
 
         return None
 
@@ -171,11 +172,11 @@ class SonarrImporter:
         tmdb_id = row.get("tmdbId")
 
         if tmdb_id:
-            existing = Item.objects.filter(
+            existing = find_item_across_buckets(
                 media_id=str(tmdb_id),
                 source=Sources.TMDB.value,
                 media_type=MediaTypes.TV.value,
-            ).first()
+            )
             if existing:
                 return existing
 
@@ -216,11 +217,11 @@ class SonarrImporter:
             return item
 
         if tvdb_id:
-            return Item.objects.filter(
+            return find_item_across_buckets(
                 media_id=str(tvdb_id),
                 source=Sources.TVDB.value,
                 media_type=MediaTypes.TV.value,
-            ).first()
+            )
 
         return None
 
@@ -270,6 +271,18 @@ class SonarrImporter:
         )
         return True
 
+    def _child_bucket(self, show_item, default_bucket):
+        """Return the library bucket a show's season/episode rows belong in.
+
+        Mirrors Season.get_episode_item: children follow the show's grouping
+        bucket (grouped anime lives on TV rows) and otherwise fall back to
+        their own media type, never inheriting a container's 'tv' bucket.
+        """
+        show_bucket = show_item.library_media_type
+        if show_bucket and show_bucket != MediaTypes.TV.value:
+            return show_bucket
+        return default_bucket
+
     def _ensure_season_items(self, show_item, row, episode_rows):
         """Ensure season items exist so collection stats can map episodes correctly."""
         season_numbers = {
@@ -282,6 +295,8 @@ class SonarrImporter:
             for episode in episode_rows
             if episode.get("seasonNumber") is not None
         )
+
+        season_bucket = self._child_bucket(show_item, MediaTypes.SEASON.value)
 
         for season_number in season_numbers:
             season_title = (
@@ -296,21 +311,32 @@ class SonarrImporter:
                 season_title=season_title,
                 seeded_at=seeded_at,
             ):
-                season_item, _created = Item.objects.get_or_create(
+                season_item = find_item_across_buckets(
+                    preferred_bucket=season_bucket,
                     media_id=show_item.media_id,
                     source=show_item.source,
                     media_type=MediaTypes.SEASON.value,
                     season_number=season_number,
-                    defaults={
-                        "title": season_title,
-                        "original_title": season_title,
-                        "localized_title": season_title,
-                        "image": show_item.image or settings.IMG_NONE,
-                        "release_datetime": show_item.release_datetime,
-                        "genres": show_item.genres or [],
-                        "metadata_fetched_at": seeded_at,
-                    },
+                    episode_number=None,
                 )
+                if season_item is None:
+                    season_item, _created = Item.objects.get_or_create(
+                        media_id=show_item.media_id,
+                        source=show_item.source,
+                        media_type=MediaTypes.SEASON.value,
+                        library_media_type=season_bucket,
+                        season_number=season_number,
+                        episode_number=None,
+                        defaults={
+                            "title": season_title,
+                            "original_title": season_title,
+                            "localized_title": season_title,
+                            "image": show_item.image or settings.IMG_NONE,
+                            "release_datetime": show_item.release_datetime,
+                            "genres": show_item.genres or [],
+                            "metadata_fetched_at": seeded_at,
+                        },
+                    )
                 update_fields = []
                 if season_item.metadata_fetched_at is None:
                     season_item.metadata_fetched_at = seeded_at
@@ -345,24 +371,35 @@ class SonarrImporter:
         episode_title = row.get("title") or f"Episode {episode_number}"
         release_datetime = self._parse_episode_release_datetime(row)
         seeded_at = timezone.now()
+        episode_bucket = self._child_bucket(show_item, MediaTypes.EPISODE.value)
 
         def _get_or_create_episode_item():
-            episode_item, _created = Item.objects.get_or_create(
+            episode_item = find_item_across_buckets(
+                preferred_bucket=episode_bucket,
                 media_id=show_item.media_id,
                 source=show_item.source,
                 media_type=MediaTypes.EPISODE.value,
                 season_number=season_number,
                 episode_number=episode_number,
-                defaults={
-                    "title": episode_title,
-                    "original_title": episode_title,
-                    "localized_title": episode_title,
-                    "image": show_item.image or settings.IMG_NONE,
-                    "release_datetime": release_datetime,
-                    "genres": show_item.genres or [],
-                    "metadata_fetched_at": seeded_at,
-                },
             )
+            if episode_item is None:
+                episode_item, _created = Item.objects.get_or_create(
+                    media_id=show_item.media_id,
+                    source=show_item.source,
+                    media_type=MediaTypes.EPISODE.value,
+                    library_media_type=episode_bucket,
+                    season_number=season_number,
+                    episode_number=episode_number,
+                    defaults={
+                        "title": episode_title,
+                        "original_title": episode_title,
+                        "localized_title": episode_title,
+                        "image": show_item.image or settings.IMG_NONE,
+                        "release_datetime": release_datetime,
+                        "genres": show_item.genres or [],
+                        "metadata_fetched_at": seeded_at,
+                    },
+                )
             update_fields = []
             if episode_item.metadata_fetched_at is None:
                 episode_item.metadata_fetched_at = seeded_at

--- a/src/integrations/tests/test_radarr_sonarr.py
+++ b/src/integrations/tests/test_radarr_sonarr.py
@@ -330,6 +330,214 @@ class ArrImporterTests(TestCase):
     @patch("integrations.imports.sonarr.services.get_media_metadata")
     @patch("integrations.imports.sonarr.SonarrClient.episodes")
     @patch("integrations.imports.sonarr.SonarrClient.series")
+    def test_sonarr_import_reuses_episode_items_from_another_bucket(
+        self,
+        mock_series,
+        mock_episodes,
+        mock_get_media_metadata,
+    ):
+        """Sonarr should attach to the tracked episode row, not fork a new one."""
+        show_item = Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Severance",
+            image="https://example.com/severance.jpg",
+        )
+        # Episodes auto-created for a tracked season land in the show's bucket
+        # rather than the default 'episode' one.
+        tracked_episode = Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.TV.value,
+            season_number=1,
+            episode_number=1,
+            title="Good News About Hell",
+            image="https://example.com/severance-s1e1.jpg",
+        )
+
+        mock_series.return_value = [
+            {
+                "id": 77,
+                "title": "Severance",
+                "statistics": {"episodeFileCount": 1},
+                "tmdbId": 95396,
+                "seasons": [{"seasonNumber": 1}],
+            },
+        ]
+        mock_episodes.return_value = [
+            {
+                "seasonNumber": 1,
+                "episodeNumber": 1,
+                "title": "Good News About Hell",
+                "airDateUtc": "2022-02-18T00:00:00Z",
+                "episodeFileId": 11,
+            },
+        ]
+        mock_get_media_metadata.return_value = {
+            "title": "Severance",
+            "image": "https://example.com/severance.jpg",
+            "genres": [],
+        }
+
+        sonarr.importer(None, self.user, "new")
+
+        episode_items = Item.objects.filter(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+        )
+        self.assertEqual([item.pk for item in episode_items], [tracked_episode.pk])
+        self.assertTrue(
+            CollectionSourceState.objects.filter(
+                user=self.user,
+                item=tracked_episode,
+                source="sonarr",
+            ).exists(),
+        )
+        self.assertEqual(
+            get_tv_show_collection_stats(
+                self.user,
+                show_item,
+                metadata_episode_count=1,
+            )["collected_episodes"],
+            1,
+        )
+
+    @patch("integrations.imports.sonarr.services.get_media_metadata")
+    @patch("integrations.imports.sonarr.SonarrClient.episodes")
+    @patch("integrations.imports.sonarr.SonarrClient.series")
+    def test_sonarr_import_survives_existing_bucket_duplicates(
+        self,
+        mock_series,
+        mock_episodes,
+        mock_get_media_metadata,
+    ):
+        """A library already split across buckets must not crash the import."""
+        Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Severance",
+            image="https://example.com/severance.jpg",
+        )
+        for bucket in (MediaTypes.TV.value, MediaTypes.EPISODE.value):
+            Item.objects.create(
+                media_id="95396",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                library_media_type=bucket,
+                season_number=1,
+                episode_number=1,
+                title="Good News About Hell",
+                image="https://example.com/severance-s1e1.jpg",
+            )
+
+        mock_series.return_value = [
+            {
+                "id": 77,
+                "title": "Severance",
+                "statistics": {"episodeFileCount": 1},
+                "tmdbId": 95396,
+                "seasons": [{"seasonNumber": 1}],
+            },
+        ]
+        mock_episodes.return_value = [
+            {
+                "seasonNumber": 1,
+                "episodeNumber": 1,
+                "title": "Good News About Hell",
+                "airDateUtc": "2022-02-18T00:00:00Z",
+                "episodeFileId": 11,
+            },
+        ]
+        mock_get_media_metadata.return_value = {
+            "title": "Severance",
+            "image": "https://example.com/severance.jpg",
+            "genres": [],
+        }
+
+        _imported_counts, warnings = sonarr.importer(None, self.user, "new")
+
+        self.assertEqual(warnings, "")
+        self.assertEqual(
+            Item.objects.filter(
+                media_id="95396",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                season_number=1,
+                episode_number=1,
+            ).count(),
+            2,
+        )
+
+    @patch("integrations.imports.sonarr.services.get_media_metadata")
+    @patch("integrations.imports.sonarr.SonarrClient.episodes")
+    @patch("integrations.imports.sonarr.SonarrClient.series")
+    def test_sonarr_import_keeps_grouped_anime_in_its_bucket(
+        self,
+        mock_series,
+        mock_episodes,
+        mock_get_media_metadata,
+    ):
+        """Seasons and episodes of a grouped anime show stay on anime rows."""
+        Item.objects.create(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            library_media_type=MediaTypes.ANIME.value,
+            title="Severance",
+            image="https://example.com/severance.jpg",
+        )
+
+        mock_series.return_value = [
+            {
+                "id": 77,
+                "title": "Severance",
+                "statistics": {"episodeFileCount": 1},
+                "tmdbId": 95396,
+                "seasons": [{"seasonNumber": 1}],
+            },
+        ]
+        mock_episodes.return_value = [
+            {
+                "seasonNumber": 1,
+                "episodeNumber": 1,
+                "title": "Good News About Hell",
+                "airDateUtc": "2022-02-18T00:00:00Z",
+                "episodeFileId": 11,
+            },
+        ]
+        mock_get_media_metadata.return_value = {
+            "title": "Severance",
+            "image": "https://example.com/severance.jpg",
+            "genres": [],
+        }
+
+        sonarr.importer(None, self.user, "new")
+
+        season_item = Item.objects.get(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+        )
+        episode_item = Item.objects.get(
+            media_id="95396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+        )
+        self.assertEqual(season_item.library_media_type, MediaTypes.ANIME.value)
+        self.assertEqual(episode_item.library_media_type, MediaTypes.ANIME.value)
+
+    @patch("integrations.imports.sonarr.services.get_media_metadata")
+    @patch("integrations.imports.sonarr.SonarrClient.episodes")
+    @patch("integrations.imports.sonarr.SonarrClient.series")
     def test_sonarr_import_marks_existing_seeded_rows_as_fetched(
         self,
         mock_series,


### PR DESCRIPTION
## Problem

The recurring Sonarr import crashes:

```
app.models.item.Item.MultipleObjectsReturned: get() returned more than one Item -- it returned 2!
  File "/floppy/integrations/imports/sonarr.py", line 396, in _ensure_episode_item
  File "/floppy/integrations/imports/sonarr.py", line 350, in _get_or_create_episode_item
    episode_item, _created = Item.objects.get_or_create(
```

This is a fork-introduced hazard rather than an upstream bug. Upstream's three `Item` uniqueness constraints key on `[media_id, source, media_type, season_number, episode_number]`, so two rows per identity are impossible and identity-keyed `get_or_create` is safe. `0118_add_library_media_type_to_item_constraints` added `library_media_type` to all three. That made one identity storable once per bucket and silently turned every identity-keyed `get_or_create` into a latent `MultipleObjectsReturned`.

Two things go wrong in sequence. Sonarr looks an episode up by identity alone, misses the row the tracking pages use (`library_media_type='tv'`, created by `Season.get_episode_item`), and creates a second row in the default `'episode'` bucket — so collection ownership lands on a row nothing else reads and episodes show as uncollected. Then the next run's `get()` spans both rows and raises.

On my library this produced 25 split identities across 4 shows before the import started failing outright.

Sonarr is where it surfaces, not the only affected caller. `simkl.py:411`, `stremio.py:548`, `events/calendar/tv.py:164` and `webhooks/plex.py:624` have the same identity-keyed lookup; `events/calendar/tv.py` runs on a schedule for every user. I've kept those out of this PR to hold the scope down — happy to file a follow-up issue, or fold them in here if you'd rather have one pass.

## Solution

**Importer fix (commit 1).** Adds `find_item_across_buckets()` to `integrations/imports/helpers.py`, which reuses an existing row across buckets — preferring the caller's bucket, then the oldest row. This is the same resolution `TraktMetadataResolverMixin._get_or_create_item` already does; the ARR importers just never adopted it. Season and episode buckets are derived from the show, mirroring the rule in `Season.get_episode_item`, so grouped anime keeps its rows on anime and the remaining `get_or_create` calls key on the full unique tuple (bucket included) and therefore cannot raise.

**Data repair (commit 2).** `0148_merge_duplicate_item_buckets`, modelled on `0125_fix_episode_season_library_bucket`, folds every duplicated identity onto one row, repoints what referenced the losers, and deletes them. Two details worth flagging:

- The surviving bucket is chosen **per title, not per row**. A per-row choice keeps one episode of a season on `tv` and the next on `episode` purely from insertion order — the same split the migration exists to undo. Caught this on a dry run against real data.
- Rows carrying tracking history outrank rows carrying only collection ownership, so ownership moves onto the row the app actually resolves rather than the reverse.

Only duplicated identities are touched. Single rows sitting in a non-canonical bucket are left alone — they resolve fine today, and re-bucketing them would move rows the app currently finds. (My DB has ~2.5k of those; they're inconsistent but harmless, and worth their own discussion.)

## Validation

- `python manage.py test integrations.tests.test_radarr_sonarr app.tests.migrations --parallel --buffer` → **Ran 23 tests, OK**. Three new importer regression tests (reuse across buckets, survives pre-existing duplicates, grouped anime keeps its bucket) and four new migration tests following the `test_0143_fix_episode_status_backfill` pattern.
- `ruff check src` → clean for every file this PR touches. The 5 remaining findings are pre-existing in `test_signals.py`, `views/test_media_list.py` and `users/tests/test_models.py`, untouched here per the lint-cleanup rule. `ruff format --check` clean. Run with the pinned 0.15.8.
- `python manage.py check_migration_hygiene --strict` → **passed** (`base_ref=upstream/dev`, strict). The duplicate-number info line is pre-existing (`app` 0052/0053, plus `users`/`lists`/`integrations`); `0148` is unique. The migration is pure `RunPython`, so no risky-op rules apply.
- **End-to-end on a copy of a real 328 MB production database** (never against the live one): 25 duplicate groups → 0, exactly 25 rows removed, zero orphaned `Episode`/`CollectionEntry` rows. The one stray carrying real data had its `CollectionEntry` and `CollectionSourceState` moved onto the row holding the watch history. Migration applied cleanly on a DB already at 0147.
- Full suite not run locally — this environment has no outbound network and the provider-touching tests never complete offline. Leaving that to CI.

No screenshots: backend and migration only, no template, CSS or UI behaviour touched.

## Migration sequencing

This is numbered `0148` on the assumption that #526 (`fix/worker-priority-and-calendar-efficiency`, which adds `0147_item_calendar_checked_at`) lands first. It depends on `0146_backfill_reconcile_state`, not `0147`, so it applies cleanly on `latest` as it stands today.

- If #526 lands **before** this one, bump this migration's dependency from `0146` to `0147_item_calendar_checked_at` — otherwise `app` has two leaf nodes and `check_migration_hygiene --strict` fails.
- If #526 is **not accepted**, renumber this migration to `0147_merge_duplicate_item_buckets`; the `0146` dependency stays as-is.

Happy to push either change on request.

## AI Assistance

Generated with Claude Code (claude-opus-5). Reviewed and tested manually.
