### PR TITLE
Fix manual Plex resync skipping watched-status updates for existing episodes

### DIFF
--- a/src/integrations/imports/helpers.py
+++ b/src/integrations/imports/helpers.py
@@ -103,8 +103,15 @@ def should_process_media(
     media_id,
     mode,
     deleted_media=None,
+    skip_existing=True,
 ):
-    """Determine if a media item should be processed based on mode."""
+    """Determine if a media item should be processed based on mode.
+
+    skip_existing=False lets callers with their own per-event dedupe (e.g.
+    Plex TV episode history, where a show already being tracked shouldn't
+    block newly watched episodes of it) route an existing item through the
+    overwrite/deleted-media handling below without a blanket "new mode" skip.
+    """
     if deleted_media and media_id in deleted_media[media_type][source]:
         logger.debug(
             "Skipping deleted %s: %s (user deleted this locally)",
@@ -115,7 +122,7 @@ def should_process_media(
 
     exists = media_id in existing_media[media_type][source]
 
-    if mode == "new" and exists:
+    if mode == "new" and exists and skip_existing:
         # In "new" mode, skip if media already exists
         logger.debug(
             "Skipping existing %s: %s (mode: new)",

--- a/src/integrations/imports/plex.py
+++ b/src/integrations/imports/plex.py
@@ -989,7 +989,9 @@ class PlexHistoryImporter:
             )
         return media_id
 
-    def _should_process_media(self, media_type: str, media_id: str) -> bool:
+    def _should_process_media(
+        self, media_type: str, media_id: str, skip_existing: bool = True
+    ) -> bool:
         """Apply new/overwrite semantics for the resolved IDs."""
         return helpers.should_process_media(
             self.existing_media,
@@ -998,6 +1000,7 @@ class PlexHistoryImporter:
             Sources.TMDB.value,
             str(media_id),
             self.mode,
+            skip_existing=skip_existing,
         )
 
     def _record_movie_entry(self, metadata: dict, ids: dict) -> bool:
@@ -1142,7 +1145,12 @@ class PlexHistoryImporter:
             return False
 
         media_id = str(media_id)
-        if not self._should_process_media(MediaTypes.TV.value, media_id):
+        # skip_existing=False: an already-tracked show must not block newly
+        # watched episodes of it (issue #541); exact-duplicate watch events
+        # are still filtered per-episode by _should_skip_episode_record.
+        if not self._should_process_media(
+            MediaTypes.TV.value, media_id, skip_existing=False
+        ):
             self.summary_counts["skipped_existing"] += 1
             return True
 

--- a/src/integrations/tests/imports/test_helpers.py
+++ b/src/integrations/tests/imports/test_helpers.py
@@ -316,6 +316,48 @@ class HelpersTest(TestCase):
             self.assertFalse(result)
             self.assertEqual(to_delete, {})
 
+    def test_should_process_media_skip_existing_false_bypasses_new_mode_skip(self):
+        """skip_existing=False lets an existing item through in 'new' mode.
+
+        This is what Plex TV episode import relies on (issue #541): an
+        already-tracked show must not block newly watched episodes of it.
+        """
+        existing_media = {
+            MediaTypes.TV.value: {Sources.TMDB.value: {"12345": Mock()}},
+        }
+        to_delete = {}
+
+        result = helpers.should_process_media(
+            existing_media,
+            to_delete,
+            MediaTypes.TV.value,
+            Sources.TMDB.value,
+            "12345",
+            "new",
+            skip_existing=False,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(to_delete, {})
+
+    def test_should_process_media_skip_existing_default_still_skips(self):
+        """Default behavior (skip_existing=True) is unchanged for other callers."""
+        existing_media = {
+            MediaTypes.TV.value: {Sources.TMDB.value: {"12345": Mock()}},
+        }
+        to_delete = {}
+
+        result = helpers.should_process_media(
+            existing_media,
+            to_delete,
+            MediaTypes.TV.value,
+            Sources.TMDB.value,
+            "12345",
+            "new",
+        )
+
+        self.assertFalse(result)
+
     def test_create_import_schedule_every_2_days(self):
         """Test creating import schedule for every 2 days."""
         request = Mock()

--- a/src/integrations/tests/test_plex_import_logic.py
+++ b/src/integrations/tests/test_plex_import_logic.py
@@ -1963,3 +1963,152 @@ class TestPlexIdentityAndScorePreservation(TestCase):
         self.assertEqual(importer._episode_records[0]["tmdb_id"], "111110")
         mock_tmdb_search.assert_not_called()
         mock_services_search.assert_not_called()
+
+
+class TestPlexEpisodeResyncForExistingShow(TestCase):
+    """Regression test for issue #541.
+
+    A manual Plex resync ("new" mode) must not blanket-skip every episode
+    entry of a show that's already tracked (e.g. from an earlier Trakt
+    import) — it should still create newly watched episodes while skipping
+    exact-duplicate watch events already recorded.
+    """
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="resyncuser")
+        self.account = PlexAccount.objects.create(
+            user=self.user,
+            plex_token="token",
+            plex_username="resyncuser",
+            plex_account_id="222",
+        )
+
+        self.tv_item, _ = Item.objects.get_or_create(
+            media_id="701",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            defaults={"title": "Resync Show", "image": "https://example.com/t.jpg"},
+        )
+        self.tv_row = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season_item, _ = Item.objects.get_or_create(
+            media_id="701",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            defaults={"title": "Resync Show", "image": "https://example.com/t.jpg"},
+        )
+        self.season_row = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv_row,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Episode 1 was already imported previously (e.g. via Trakt import).
+        self.existing_watched_at = timezone.now().replace(
+            second=0,
+            microsecond=0,
+            hour=10,
+            minute=0,
+        )
+        episode1_item, _ = Item.objects.get_or_create(
+            media_id="701",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            defaults={"title": "Episode 1", "image": "https://example.com/t.jpg"},
+        )
+        Episode.objects.create(
+            item=episode1_item,
+            related_season=self.season_row,
+            end_date=self.existing_watched_at,
+        )
+
+    def _importer(self, mode="new"):
+        return PlexHistoryImporter(
+            user=self.user,
+            account=self.account,
+            mode=mode,
+            library="machine::1",
+        )
+
+    @patch("integrations.webhooks.anime_mappings.fetch_mapping_data", return_value={})
+    @patch("integrations.imports.plex.app.providers.tvdb.enabled", return_value=False)
+    def test_resync_creates_new_episode_without_blanket_skip(
+        self,
+        _mock_tvdb_enabled,
+        _mock_mapping_data,
+    ):
+        importer = self._importer()
+
+        duplicate_metadata = {
+            "type": "episode",
+            "title": "Episode 1",
+            "grandparentTitle": "Resync Show",
+            "parentIndex": 1,
+            "index": 1,
+            "viewedAt": int(self.existing_watched_at.timestamp()),
+            "ratingKey": "rk-dup",
+        }
+        new_watched_at = self.existing_watched_at + timezone.timedelta(hours=1)
+        new_metadata = {
+            "type": "episode",
+            "title": "Episode 2",
+            "grandparentTitle": "Resync Show",
+            "parentIndex": 1,
+            "index": 2,
+            "viewedAt": int(new_watched_at.timestamp()),
+            "ratingKey": "rk-new",
+        }
+        ids = {
+            "tmdb_id": "701",
+            "tvdb_id": None,
+            "imdb_id": None,
+            "anidb_id": None,
+            "plex_guid": None,
+        }
+
+        recorded_dup = importer._record_episode_entry(duplicate_metadata, ids)
+        recorded_new = importer._record_episode_entry(new_metadata, ids)
+
+        # Neither call is blanket-skipped just because the show already exists.
+        self.assertTrue(recorded_dup)
+        self.assertTrue(recorded_new)
+        self.assertEqual(importer.summary_counts["skipped_existing"], 0)
+        self.assertEqual(len(importer._episode_records), 2)
+
+        importer._tv_metadata_cache = {
+            "701": {
+                "media_id": "701",
+                "title": "Resync Show",
+                "original_title": "Resync Show",
+                "localized_title": "Resync Show",
+                "image": "https://example.com/t.jpg",
+                "season/1": {
+                    "image": "https://example.com/t-s1.jpg",
+                    "max_progress": 10,
+                    "episodes": [{"episode_number": 1}, {"episode_number": 2}],
+                },
+            },
+        }
+
+        importer._build_existing_dedupe_sets()
+        importer._build_bulk_media()
+
+        # The exact-duplicate watch event is still filtered out per-episode,
+        # while the genuinely new watch is queued for creation.
+        self.assertEqual(importer.summary_counts["created"], 1)
+        self.assertEqual(importer.summary_counts["skipped_existing"], 1)
+
+        helpers.bulk_create_media(importer.bulk_media, self.user)
+
+        episodes = Episode.objects.filter(related_season=self.season_row).order_by(
+            "item__episode_number",
+        )
+        self.assertEqual(episodes.count(), 2)
+        self.assertEqual(episodes.last().item.episode_number, 2)


### PR DESCRIPTION
A manual Plex sync in "new" mode gated episode processing on whether the
show already existed in the user's library, so any show first tracked via
another import (e.g. Trakt) had every subsequent episode history entry
blanket-skipped as "existing" — even newly watched episodes never seen
before. Existence now only needs to be checked per watch event (already
handled by the importer's episode dedupe), not per show.

should_process_media gains an opt-in skip_existing flag so Plex's episode
path can route already-tracked shows through overwrite/deleted-media
handling without discarding new watch events, while every other caller
keeps its existing behavior.

Fixes #541

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011nP59UfB7oT3xZrxQ3catJ