### PR TITLE
Preserve watch history when merging duplicate Item rows (fixes data loss in 0148)

### DIFF
--- a/src/app/migrations/0148_merge_duplicate_item_buckets.py
+++ b/src/app/migrations/0148_merge_duplicate_item_buckets.py
@@ -92,11 +92,96 @@ def _count(item, relations):
     return total
 
 
-def _repoint(item_model, loser, keeper):
+def _absorb_tv_rows(loser, keeper, models):
+    """Move the loser's TV rows onto the keeper without dropping history.
+
+    TV is unique on (user, item), so a plain repoint collides whenever the
+    same user tracks both duplicates - and TV cascades through Season into
+    Episode, so deleting on that collision destroys watch history. Hand the
+    loser's seasons to the surviving TV row first, then delete the row once
+    it owns nothing.
+    """
+    tv_model, season_model, episode_model = models
+    for loser_tv in tv_model._base_manager.filter(item=loser):
+        surviving_tv = (
+            tv_model._base_manager.filter(item=keeper, user_id=loser_tv.user_id)
+            .order_by("id")
+            .first()
+        )
+        if surviving_tv is None:
+            loser_tv.item = keeper
+            loser_tv.save(update_fields=["item_id"])
+            continue
+
+        for season in season_model._base_manager.filter(related_tv=loser_tv):
+            _rehome_season(season, surviving_tv, season_model, episode_model)
+        loser_tv.delete()
+
+
+def _absorb_season_rows(loser, keeper, models):
+    """Move the loser's Season rows onto the keeper without dropping history.
+
+    Season is unique on (related_tv, item) and cascades into Episode, so the
+    same reasoning as _absorb_tv_rows applies one level down.
+    """
+    _tv_model, season_model, episode_model = models
+    for loser_season in season_model._base_manager.filter(item=loser):
+        surviving_season = (
+            season_model._base_manager.filter(
+                item=keeper,
+                related_tv_id=loser_season.related_tv_id,
+            )
+            .order_by("id")
+            .first()
+        )
+        if surviving_season is None:
+            loser_season.item = keeper
+            loser_season.save(update_fields=["item_id"])
+            continue
+
+        episode_model._base_manager.filter(related_season=loser_season).update(
+            related_season=surviving_season,
+        )
+        loser_season.delete()
+
+
+def _rehome_season(season, surviving_tv, season_model, episode_model):
+    """Attach one season to another TV row, folding it in if one is there."""
+    rival = (
+        season_model._base_manager.filter(
+            related_tv=surviving_tv,
+            item_id=season.item_id,
+        )
+        .order_by("id")
+        .first()
+    )
+    if rival is None:
+        season.related_tv = surviving_tv
+        season.save(update_fields=["related_tv_id"])
+        return
+
+    episode_model._base_manager.filter(related_season=season).update(
+        related_season=rival,
+    )
+    season.delete()
+
+
+def _repoint(item_model, loser, keeper, models):
     """Move everything referencing loser onto keeper."""
     for relation in item_model._meta.related_objects:
         field = relation.field
         related_manager = relation.related_model._base_manager
+        related_name = relation.related_model._meta.model_name
+
+        # TV and Season cascade into Episode, so they cannot fall through to
+        # the delete-on-conflict branch below. Episode itself has no unique
+        # constraint, so its repoint always succeeds and needs no special case.
+        if field.name == "item" and related_name == "tv":
+            _absorb_tv_rows(loser, keeper, models)
+            continue
+        if field.name == "item" and related_name == "season":
+            _absorb_season_rows(loser, keeper, models)
+            continue
 
         if relation.many_to_many:
             # 0125 predates the m2m relations on Item and did not handle them.
@@ -124,6 +209,11 @@ def merge_duplicate_item_buckets(apps, schema_editor):
     """Fold every duplicated Item identity onto a single row."""
     del schema_editor
     Item = apps.get_model("app", "Item")
+    models = (
+        apps.get_model("app", "TV"),
+        apps.get_model("app", "Season"),
+        apps.get_model("app", "Episode"),
+    )
 
     tracking_relations = [
         relation
@@ -153,7 +243,7 @@ def merge_duplicate_item_buckets(apps, schema_editor):
         for loser in items:
             if loser.pk == keeper.pk:
                 continue
-            _repoint(Item, loser, keeper)
+            _repoint(Item, loser, keeper, models)
             loser.delete()
 
 

--- a/src/app/tests/migrations/test_0148_merge_duplicate_item_buckets.py
+++ b/src/app/tests/migrations/test_0148_merge_duplicate_item_buckets.py
@@ -25,7 +25,12 @@ class _RealAppsRegistry:
 
     def get_model(self, app_label, model_name):
         del app_label
-        return {"Item": Item}[model_name]
+        return {
+            "Item": Item,
+            "TV": TV,
+            "Season": Season,
+            "Episode": Episode,
+        }[model_name]
 
 
 class MergeDuplicateItemBucketsMigration(TestCase):
@@ -142,3 +147,91 @@ class MergeDuplicateItemBucketsMigration(TestCase):
 
         lone.refresh_from_db()
         self.assertEqual(lone.library_media_type, MediaTypes.TV.value)
+
+
+class MergeDuplicateItemBucketsPreservesHistory(TestCase):
+    """Merging must never cascade-delete a user's watch history.
+
+    TV is unique on (user, item) and Season on (related_tv, item), and both
+    cascade into Episode. Repointing a duplicate's TV/Season row onto the
+    keeper therefore collides, and deleting the loser on that collision takes
+    the episode history down with it.
+    """
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="history-owner",
+            password="12345",
+        )
+        self.media_id = "129412"
+
+    def _item(self, media_type, bucket, season_number=None, episode_number=None):
+        return Item.objects.create(
+            media_id=self.media_id,
+            source=Sources.TMDB.value,
+            media_type=media_type,
+            library_media_type=bucket,
+            season_number=season_number,
+            episode_number=episode_number,
+            title="Game Changer",
+        )
+
+    def _tracked_show(self, show_bucket, season_bucket, episode_numbers):
+        """Build one fully tracked show: TV -> Season -> Episodes."""
+        tv_record = TV.objects.create(
+            item=self._item(MediaTypes.TV.value, show_bucket),
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season = Season.objects.create(
+            item=self._item(MediaTypes.SEASON.value, season_bucket, season_number=1),
+            user=self.user,
+            related_tv=tv_record,
+            status=Status.IN_PROGRESS.value,
+        )
+        for episode_number in episode_numbers:
+            Episode.objects.create(
+                item=self._item(
+                    MediaTypes.EPISODE.value,
+                    MediaTypes.EPISODE.value,
+                    season_number=1,
+                    episode_number=episode_number,
+                ),
+                related_season=season,
+            )
+        return tv_record
+
+    def test_history_survives_merging_a_show_tracked_in_two_buckets(self):
+        """No episode history may be lost when both duplicates are tracked."""
+        self._tracked_show(MediaTypes.TV.value, MediaTypes.SEASON.value, [1, 2, 3])
+        self._tracked_show(MediaTypes.SEASON.value, MediaTypes.TV.value, [4, 5])
+
+        episodes_before = Episode.objects.filter(
+            item__media_id=self.media_id,
+        ).count()
+        self.assertEqual(episodes_before, 5)
+
+        migration.merge_duplicate_item_buckets(_RealAppsRegistry(), None)
+
+        self.assertEqual(
+            Episode.objects.filter(item__media_id=self.media_id).count(),
+            episodes_before,
+        )
+        # The duplicates still collapse: one show, one season.
+        self.assertEqual(
+            Item.objects.filter(
+                media_id=self.media_id,
+                media_type=MediaTypes.TV.value,
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            Item.objects.filter(
+                media_id=self.media_id,
+                media_type=MediaTypes.SEASON.value,
+            ).count(),
+            1,
+        )
+        # And the surviving season owns every episode.
+        surviving_season = Season.objects.get(item__media_id=self.media_id)
+        self.assertEqual(surviving_season.episodes.count(), 5)


### PR DESCRIPTION
Follow-up to #543 — please prioritise this one. The migration that just merged can delete watch history, and I found it after the merge landed.

## Problem

`0148_merge_duplicate_item_buckets` repoints every relation onto the surviving Item and deletes the row whenever that raises `IntegrityError`. That is safe for `Episode`, which has no unique constraint, but not for the two models above it:

| Model | Unique constraint | Deleting one cascades to |
|---|---|---|
| `TV` | `(user, item)` | its `Season`s → their `Episode`s |
| `Season` | `(related_tv, item)` | its `Episode`s |

When a user tracks the same show under two `library_media_type` buckets — precisely the corruption the migration exists to clean up — repointing the loser's `TV` row collides on `(user, item)`. The migration then deletes that row, and the delete cascades through `Season` into `Episode`, taking the user's episode watch history with it.

Reproduced by calling the merged migration function directly against a synthetic two-bucket show:

```
BEFORE: tv=2 season=2 episode_history=5
AFTER : tv=1 season=1 episode_history=3     <- 2 rows of history destroyed
```

**Why #543's validation didn't catch it.** The database I validated against has no duplicated tv/season identity tracked twice — all 25 of its duplicates are episode-level — so the dangerous branch never executed. I also checked Item counts and orphaned rows rather than history counts, and a cascade-deleted `Episode` is not an orphan, so an orphan check structurally cannot see it. My mistake, and the new test now covers the case directly.

## Solution

Hand the loser's seasons to the surviving `TV` row, and its episodes to the surviving `Season`, before deleting the emptied row. `Episode` keeps the generic repoint — no unique constraint means it always succeeds.

This is the same reconcile-before-delete that `_merge_stray_season_item` already performs for the runtime self-heal in `app/services/metadata_resolution.py`. I ran the identical probe through that helper first to confirm the approach holds — it collapses the duplicate while keeping all 5 history rows — then mirrored its shape. It is deliberately inlined rather than imported: a data migration runs against historical models and shouldn't depend on service code that can change underneath it.

## Fixing 0148 in place rather than adding 0149

The destructive step is a one-shot `RunPython`, so the only people this can still protect are those who have not yet applied `0148`. Anyone who already ran it has already lost the rows, and no follow-up migration can restore them — a `0149` would be strictly worse, since it would leave the broken code in the tree for anyone migrating from an older version. Django records only the migration name, so editing the body is inert for installs that already applied it.

Given that #543 merged less than an hour before this was found, I'd expect very few installs to have run it yet — hence the urgency.

## Validation

- New regression test **fails against the merged migration** (`AssertionError: 3 != 5`) and passes with the fix. I confirmed it failed first, so it is known to have teeth.
- `python manage.py test app.tests.migrations` → **Ran 8 tests, OK**.
- `python manage.py check_migration_hygiene --strict` → passed.
- `ruff check src` / `ruff format --check` → clean for the files touched (pinned 0.15.8); migrations are excluded from ruff by config.
- Re-ran the real-data check against a **fresh copy of the same 328 MB production database**, this time counting watch history rather than just Items and orphans:

```
BEFORE  items=39483 tv=177 season=402 episode_history=3820 collection=12743 dupe_groups=25
AFTER   items=39458 tv=177 season=402 episode_history=3820 collection=12743 dupe_groups=0
```

25 duplicate groups collapsed and exactly 25 Item rows removed, with every `TV`, `Season`, `Episode` and `CollectionEntry` row intact. Never run against a live database.

No screenshots: migration-only change.

## AI Assistance

Generated with Claude Code (claude-opus-5). Reviewed and tested manually.
