### PR TITLE
Fix live playback card linking to episode-level TMDB ID (#547)

### DIFF
--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -319,6 +319,79 @@ class PlexWebhookTests(TestCase):
         self.assertEqual(state["duration_seconds"], 2666)
         self.assertEqual(state["view_offset_seconds"], 1447)
 
+    @patch("app.providers.tmdb.search")
+    def test_play_event_episode_level_tmdb_id_resolves_via_title_search(
+        self,
+        mock_tmdb_search,
+    ):
+        """An episode-only TMDB GUID (no TVDB/IMDB) should resolve to the
+        show-level ID via title search rather than linking to the raw
+        episode-level ID (issue #547).
+        """
+        mock_tmdb_search.return_value = {
+            "results": [{"media_id": "60715", "title": "Bref"}],
+        }
+        payload = {
+            "event": "media.play",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "episode",
+                "grandparentTitle": "Bref",
+                "title": "Episode 82",
+                "index": 82,
+                "parentIndex": 1,
+                "ratingKey": "rk-episode-bref",
+                "duration": 300000,
+                "viewOffset": 10000,
+                "Guid": [
+                    {"id": "tmdb://1017335"},
+                ],
+            },
+        }
+
+        response = self._post_payload(payload)
+
+        self.assertEqual(response.status_code, 200)
+        state = live_playback.get_user_playback_state(self.user.id)
+        self.assertIsNotNone(state)
+        self.assertEqual(state["media_id"], "60715")
+        self.assertEqual(state["season_number"], 1)
+        self.assertEqual(state["episode_number"], 82)
+
+    @patch("app.providers.tmdb.search", return_value={"results": []})
+    def test_play_event_episode_level_tmdb_id_unresolved_does_not_500_link(
+        self,
+        _mock_tmdb_search,
+    ):
+        """When an episode-only TMDB GUID can't be resolved via title search
+        either, the raw episode-level ID must not be stored as media_id —
+        that would build a details URL that 404s/500s (issue #547).
+        """
+        payload = {
+            "event": "media.play",
+            "Account": {"title": "testuser"},
+            "Metadata": {
+                "type": "episode",
+                "grandparentTitle": "Some Unknown Show",
+                "title": "Episode 1",
+                "index": 1,
+                "parentIndex": 1,
+                "ratingKey": "rk-episode-unknown",
+                "duration": 300000,
+                "viewOffset": 10000,
+                "Guid": [
+                    {"id": "tmdb://1017335"},
+                ],
+            },
+        }
+
+        response = self._post_payload(payload)
+
+        self.assertEqual(response.status_code, 200)
+        state = live_playback.get_user_playback_state(self.user.id)
+        self.assertIsNotNone(state)
+        self.assertFalse(state.get("media_id"))
+
     def test_movie_short_stop_clears_in_progress_row_and_playback_state(self):
         """Play events don't create rows; stop with viewOffset < 60s also creates nothing."""
         play_payload = {

--- a/src/integrations/webhooks/plex.py
+++ b/src/integrations/webhooks/plex.py
@@ -216,18 +216,27 @@ class PlexWebhookProcessor(BaseWebhookProcessor):
                             "Live playback resolved show ID via TVDB/IMDB",
                         )
 
-                # Fallback: title search then raw tmdb_id
+                # Fallback: title search. The raw tmdb_id is stripped before
+                # calling _find_tv_media_id so its "direct TMDB ID" branch
+                # can't short-circuit the title search with a possibly
+                # episode-level ID — see the final fallback note below.
                 if media_id is None:
                     series_title = self._extract_series_title(payload)
-                    resolved_media_id, _, _ = self._find_tv_media_id(
-                        ids,
-                        series_title=series_title,
-                        allow_title_fallback=True,
-                    )
-                    if resolved_media_id:
-                        media_id = str(resolved_media_id)
-            if media_id is None:
-                media_id = ids.get("tmdb_id")
+                    if series_title:
+                        alt_ids = dict(ids)
+                        alt_ids["tmdb_id"] = None
+                        resolved_media_id, _, _ = self._find_tv_media_id(
+                            alt_ids,
+                            series_title=series_title,
+                            allow_title_fallback=True,
+                        )
+                        if resolved_media_id:
+                            media_id = str(resolved_media_id)
+            # Deliberately no further fallback to the raw ids["tmdb_id"] here:
+            # for TV episodes it may be episode-level (a separate TMDB ID
+            # namespace from the show), which would 404 the details page.
+            # Leaving media_id as None degrades gracefully — the card links to
+            # home instead of a URL that 500s. See issue #547.
 
         live_playback.apply_plex_event(
             user_id=user.id,


### PR DESCRIPTION
The live playback card's title-search fallback in
_update_live_playback_state() called _find_tv_media_id() with the raw
tmdb_id still in ids, so its "direct TMDB ID" branch returned that ID
immediately — before title search ever ran — even though the caller
asked for allow_title_fallback=True. When Plex sends only an
episode-level tmdb GUID (no tvdb/imdb), that episode ID then got
stored as the card's media_id, producing a /details/tmdb/tv/{id} URL
that 404s upstream and 500s in Floppy.

Strip tmdb_id from the ids passed into that title-search call (same
pattern already used for the TVDB/IMDB branch above it) so title
search gets a real chance to resolve the show-level ID. Also drop the
final blind fallback to the raw tmdb_id: since there's no TMDB
endpoint to verify or convert an episode-level ID, leaving media_id
unset degrades gracefully (card links to home) instead of producing a
URL that 500s.