### PR TITLE
Serialize Docker image publishes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,14 @@ on:
     branches:
       - "dev"
 
+# A push to latest must not be overtaken by an older build that started later
+# because runners were queued. Keep one publish per ref in flight and let the
+# newest pending run replace intermediate commits without cancelling the run
+# currently publishing.
+concurrency:
+  group: docker-image-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: dannyvfilms/floppy


### PR DESCRIPTION
Push-triggered Docker builds can overlap; an older build may finish after a newer one and overwrite latest with an older commit. Serialize Docker Image runs per ref without cancelling the run currently publishing. Validated with git diff --check and YAML parsing. The GHCR permission failure was separately confirmed in run 31056325881 and resolved by the one-time bootstrap run.