### PR TITLE
Add per-cache clear buttons to Settings > Advanced

### DIFF
--- a/src/templates/users/advanced.html
+++ b/src/templates/users/advanced.html
@@ -16,29 +16,218 @@
         <h2 class="text-xl font-semibold">Advanced</h2>
       </div>
 
-      <div class="bg-[var(--color-surface-strong)] p-5 rounded-lg mb-6">
+      <div class="bg-[var(--color-surface-strong)] p-5 rounded-lg mb-6"
+           x-data="{
+             confirmOpen: false,
+             pending: null,
+             openConfirm(key) { this.pending = key; this.confirmOpen = true; },
+             closeConfirm() { this.confirmOpen = false; this.pending = null; },
+           }">
         <div class="flex items-center mb-3">
           {% include "app/icons/trashcan.svg" with classes="w-5 h-5 text-indigo-400 mr-2" %}
-          <h3 class="text-base font-medium">Clear Search Cache</h3>
+          <h3 class="text-base font-medium">Cache Management</h3>
         </div>
         <p class="text-[var(--color-text-muted)] mb-4 text-sm">
-          Floppy stores your search results in a cache to speed up performance and reduce API calls.
-          <br>
-          Normally, these cached results expire automatically after 24 hours.
-          If your search results appear outdated, you can clear the cache manually.
-          <br>
-          Your next search may be slightly slower as fresh data is retrieved.
+          Floppy caches computed pages (History, Statistics, Discover) and provider search
+          results so they load fast. If one looks stale or wrong, clearing it forces a
+          rebuild from your actual data — nothing about your library, watch history,
+          ratings, or lists is touched by any of these.
         </p>
-        <div class="flex space-x-3">
-          <form method="post" action="{% url 'clear_search_cache' %}">
-            {% csrf_token %}
-            <button type="submit"
-                    class="flex items-center px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors text-sm cursor-pointer">
-              {% include "app/icons/trashcan.svg" with classes="w-4 h-4 mr-2" %}
-              Clear Search Cache
-            </button>
-          </form>
+
+        <div class="grid gap-3 sm:grid-cols-2">
+          <button type="button"
+                  @click="openConfirm('search')"
+                  class="flex items-start justify-between gap-3 px-4 py-3 bg-[var(--color-surface)] border border-gray-600 rounded-md hover:border-indigo-500 transition-colors text-sm cursor-pointer text-left">
+            <span>
+              <span class="block font-medium">Search Cache</span>
+              <span class="block text-xs text-[var(--color-text-muted)] mt-0.5">Provider search results — shared instance-wide</span>
+            </span>
+            {% include "app/icons/trashcan.svg" with classes="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-text-muted)]" %}
+          </button>
+
+          <button type="button"
+                  @click="openConfirm('history')"
+                  class="flex items-start justify-between gap-3 px-4 py-3 bg-[var(--color-surface)] border border-gray-600 rounded-md hover:border-indigo-500 transition-colors text-sm cursor-pointer text-left">
+            <span>
+              <span class="block font-medium">History Cache</span>
+              <span class="block text-xs text-[var(--color-text-muted)] mt-0.5">Your cached History page — just you</span>
+            </span>
+            {% include "app/icons/trashcan.svg" with classes="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-text-muted)]" %}
+          </button>
+
+          <button type="button"
+                  @click="openConfirm('statistics')"
+                  class="flex items-start justify-between gap-3 px-4 py-3 bg-[var(--color-surface)] border border-gray-600 rounded-md hover:border-indigo-500 transition-colors text-sm cursor-pointer text-left">
+            <span>
+              <span class="block font-medium">Statistics Cache</span>
+              <span class="block text-xs text-[var(--color-text-muted)] mt-0.5">Your cached Statistics page — just you</span>
+            </span>
+            {% include "app/icons/trashcan.svg" with classes="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-text-muted)]" %}
+          </button>
+
+          <button type="button"
+                  @click="openConfirm('discover')"
+                  class="flex items-start justify-between gap-3 px-4 py-3 bg-[var(--color-surface)] border border-gray-600 rounded-md hover:border-indigo-500 transition-colors text-sm cursor-pointer text-left">
+            <span>
+              <span class="block font-medium">Discover Cache</span>
+              <span class="block text-xs text-[var(--color-text-muted)] mt-0.5">Your recommendation rows &amp; taste profile — just you</span>
+            </span>
+            {% include "app/icons/trashcan.svg" with classes="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-text-muted)]" %}
+          </button>
         </div>
+
+        <div class="mt-4 pt-4 border-t border-gray-700">
+          <button type="button"
+                  @click="openConfirm('all')"
+                  class="flex items-center px-4 py-2 bg-red-600/10 border border-red-600/40 text-red-300 rounded-md hover:bg-red-600/20 transition-colors text-sm cursor-pointer">
+            {% include "app/icons/warning.svg" with classes="w-4 h-4 mr-2" %}
+            Clear All Caches
+          </button>
+        </div>
+
+        {# Real forms, submitted programmatically once the overlay is confirmed #}
+        <form id="clear-search-cache-form" method="post" action="{% url 'clear_search_cache' %}" class="hidden">{% csrf_token %}</form>
+        <form id="clear-history-cache-form" method="post" action="{% url 'clear_history_cache' %}" class="hidden">{% csrf_token %}</form>
+        <form id="clear-statistics-cache-form" method="post" action="{% url 'clear_statistics_cache' %}" class="hidden">{% csrf_token %}</form>
+        <form id="clear-discover-cache-form" method="post" action="{% url 'clear_discover_cache' %}" class="hidden">{% csrf_token %}</form>
+        <form id="clear-all-caches-form" method="post" action="{% url 'clear_all_caches' %}" class="hidden">{% csrf_token %}</form>
+
+        <template x-teleport="body">
+          <div x-show="confirmOpen"
+               x-cloak
+               @keydown.escape.window="closeConfirm()"
+               class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+            <div class="w-full max-w-md bg-[var(--color-surface)] rounded-lg shadow-xl"
+                 @click.outside="closeConfirm()">
+              <template x-if="pending === 'search'">
+                <div class="p-6">
+                  <div class="flex items-center gap-2 mb-3">
+                    {% include "app/icons/warning.svg" with classes="w-5 h-5 text-amber-400 shrink-0" %}
+                    <h3 class="text-lg font-semibold">Clear Search Cache?</h3>
+                  </div>
+                  <p class="text-sm text-[var(--color-text-secondary)] mb-3">
+                    This is the one shared cache here — clearing it affects
+                    <strong>every user</strong> on this Floppy instance, not just you.
+                  </p>
+                  <ul class="text-sm text-[var(--color-text-muted)] list-disc list-inside space-y-1 mb-5">
+                    <li>No data is lost — this only affects search/lookup results, not your library.</li>
+                    <li>The next search anyone makes will be a bit slower while it re-fetches from TMDB, TVDB, and the other providers.</li>
+                  </ul>
+                  <div class="flex justify-end gap-2">
+                    <button type="button"
+                            @click="closeConfirm()"
+                            class="px-4 py-2 text-sm rounded-md border border-gray-600 hover:border-gray-500 cursor-pointer">Cancel</button>
+                    <button type="button"
+                            @click="document.getElementById('clear-search-cache-form').submit()"
+                            class="px-4 py-2 text-sm rounded-md bg-red-600 text-white hover:bg-red-700 cursor-pointer">Clear Search Cache</button>
+                  </div>
+                </div>
+              </template>
+
+              <template x-if="pending === 'history'">
+                <div class="p-6">
+                  <div class="flex items-center gap-2 mb-3">
+                    {% include "app/icons/warning.svg" with classes="w-5 h-5 text-amber-400 shrink-0" %}
+                    <h3 class="text-lg font-semibold">Clear History Cache?</h3>
+                  </div>
+                  <p class="text-sm text-[var(--color-text-secondary)] mb-3">
+                    Only affects your own account.
+                  </p>
+                  <ul class="text-sm text-[var(--color-text-muted)] list-disc list-inside space-y-1 mb-5">
+                    <li>Your watch history itself is not touched — this only clears the cached, day-by-day rendering of it.</li>
+                    <li>The History page will rebuild itself the next time you open it, which may take a moment the first time.</li>
+                  </ul>
+                  <div class="flex justify-end gap-2">
+                    <button type="button"
+                            @click="closeConfirm()"
+                            class="px-4 py-2 text-sm rounded-md border border-gray-600 hover:border-gray-500 cursor-pointer">Cancel</button>
+                    <button type="button"
+                            @click="document.getElementById('clear-history-cache-form').submit()"
+                            class="px-4 py-2 text-sm rounded-md bg-red-600 text-white hover:bg-red-700 cursor-pointer">Clear History Cache</button>
+                  </div>
+                </div>
+              </template>
+
+              <template x-if="pending === 'statistics'">
+                <div class="p-6">
+                  <div class="flex items-center gap-2 mb-3">
+                    {% include "app/icons/warning.svg" with classes="w-5 h-5 text-amber-400 shrink-0" %}
+                    <h3 class="text-lg font-semibold">Clear Statistics Cache?</h3>
+                  </div>
+                  <p class="text-sm text-[var(--color-text-secondary)] mb-3">
+                    Only affects your own account.
+                  </p>
+                  <ul class="text-sm text-[var(--color-text-muted)] list-disc list-inside space-y-1 mb-5">
+                    <li>No underlying data is touched — only the cached charts/totals.</li>
+                    <li>Unlike History, Statistics rebuilds in the background rather than on your next page load — expect placeholder
+                      <code class="px-1 py-0.5 bg-black/20 rounded">--</code> values for a bit until that finishes.</li>
+                  </ul>
+                  <div class="flex justify-end gap-2">
+                    <button type="button"
+                            @click="closeConfirm()"
+                            class="px-4 py-2 text-sm rounded-md border border-gray-600 hover:border-gray-500 cursor-pointer">Cancel</button>
+                    <button type="button"
+                            @click="document.getElementById('clear-statistics-cache-form').submit()"
+                            class="px-4 py-2 text-sm rounded-md bg-red-600 text-white hover:bg-red-700 cursor-pointer">Clear Statistics Cache</button>
+                  </div>
+                </div>
+              </template>
+
+              <template x-if="pending === 'discover'">
+                <div class="p-6">
+                  <div class="flex items-center gap-2 mb-3">
+                    {% include "app/icons/warning.svg" with classes="w-5 h-5 text-amber-400 shrink-0" %}
+                    <h3 class="text-lg font-semibold">Clear Discover Cache?</h3>
+                  </div>
+                  <p class="text-sm text-[var(--color-text-secondary)] mb-3">
+                    Only affects your own account.
+                  </p>
+                  <ul class="text-sm text-[var(--color-text-muted)] list-disc list-inside space-y-1 mb-5">
+                    <li>Your recommendation rows and taste profile get recomputed from scratch — rows may look different or take a moment to repopulate.</li>
+                    <li>Shared provider data other users' Discover pages also draw on is not affected.</li>
+                  </ul>
+                  <div class="flex justify-end gap-2">
+                    <button type="button"
+                            @click="closeConfirm()"
+                            class="px-4 py-2 text-sm rounded-md border border-gray-600 hover:border-gray-500 cursor-pointer">Cancel</button>
+                    <button type="button"
+                            @click="document.getElementById('clear-discover-cache-form').submit()"
+                            class="px-4 py-2 text-sm rounded-md bg-red-600 text-white hover:bg-red-700 cursor-pointer">Clear Discover Cache</button>
+                  </div>
+                </div>
+              </template>
+
+              <template x-if="pending === 'all'">
+                <div class="p-6">
+                  <div class="flex items-center gap-2 mb-3">
+                    {% include "app/icons/warning.svg" with classes="w-6 h-6 text-red-400 shrink-0" %}
+                    <h3 class="text-lg font-semibold text-red-300">Clear All Caches?</h3>
+                  </div>
+                  <p class="text-sm text-[var(--color-text-secondary)] mb-3 font-medium">
+                    This runs all four clears above at once: Search (instance-wide) plus your
+                    History, Statistics, and Discover caches.
+                  </p>
+                  <ul class="text-sm text-[var(--color-text-muted)] list-disc list-inside space-y-1.5 mb-5">
+                    <li>Search results go stale for <strong>every user</strong> on this instance until re-fetched.</li>
+                    <li>Your History and Discover pages will look empty for a moment and rebuild as you browse them.</li>
+                    <li>Your Statistics page will show placeholder
+                      <code class="px-1 py-0.5 bg-black/20 rounded">--</code> values until a background task
+                      finishes rebuilding it — this is the slowest of the four to recover.</li>
+                    <li>No watch history, ratings, lists, or tracked media is deleted by any of this — only cached, computed views of it.</li>
+                  </ul>
+                  <div class="flex justify-end gap-2">
+                    <button type="button"
+                            @click="closeConfirm()"
+                            class="px-4 py-2 text-sm rounded-md border border-gray-600 hover:border-gray-500 cursor-pointer">Cancel</button>
+                    <button type="button"
+                            @click="document.getElementById('clear-all-caches-form').submit()"
+                            class="px-4 py-2 text-sm rounded-md bg-red-700 text-white hover:bg-red-800 font-medium cursor-pointer">Clear All Caches</button>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </template>
       </div>
 
       <div class="bg-[var(--color-surface-strong)] p-5 rounded-lg">
@@ -78,7 +267,7 @@
         </div>
         <p class="text-[var(--color-text-muted)] mb-4 text-sm">
           Download recent application logs with tokens, passwords, and API keys automatically
-          redacted &mdash; safe to attach to a bug report.
+          redacted — safe to attach to a bug report.
           <br>
           If this Floppy instance is shared with other users, the logs may still include their
           activity, just not their secrets.

--- a/src/users/cache_management.py
+++ b/src/users/cache_management.py
@@ -1,0 +1,53 @@
+"""Cache-clearing helpers backing Settings > Advanced > Clear Cache buttons.
+
+Each function clears exactly one cache's *payload* keys/rows — not the
+internal locks, dedupe keys, or dirty-tracking bookkeeping those caches also
+keep in Redis. Those are left alone deliberately: they self-manage, and
+deleting them buys nothing but a small chance of a duplicate background
+refresh being scheduled.
+
+Search is the one instance-wide cache here (its keys carry no user id, since
+search results don't depend on who searched) — clearing it affects every
+user of this Floppy instance. History, Statistics, and Discover are all
+keyed per-user, so clearing them only touches the requesting user's own data.
+"""
+
+from django.core.cache import cache
+
+from app.discover.tab_cache import DISCOVER_TAB_PREFIX
+from app.history_cache_utils import HISTORY_DAY_PREFIX, HISTORY_INDEX_PREFIX
+from app.models import DiscoverRowCache, DiscoverTasteProfile
+from app.statistics_cache import STATISTICS_CACHE_PREFIX, STATISTICS_DAY_PREFIX
+
+
+def clear_search_cache() -> int:
+    """Clear cached provider search/metadata results for every user."""
+    return cache.delete_pattern("search_*") or 0
+
+
+def clear_history_cache_for_user(user_id: int) -> int:
+    """Clear a user's cached History day and index payloads."""
+    deleted = cache.delete_pattern(f"{HISTORY_DAY_PREFIX}_{user_id}_*") or 0
+    deleted += cache.delete_pattern(f"{HISTORY_INDEX_PREFIX}_{user_id}_*") or 0
+    return deleted
+
+
+def clear_statistics_cache_for_user(user_id: int) -> int:
+    """Clear a user's cached Statistics page and per-day payloads."""
+    deleted = cache.delete_pattern(f"{STATISTICS_CACHE_PREFIX}_{user_id}_*") or 0
+    deleted += cache.delete_pattern(f"{STATISTICS_DAY_PREFIX}:{user_id}:*") or 0
+    return deleted
+
+
+def clear_discover_cache_for_user(user_id: int) -> int:
+    """Clear a user's cached Discover rows, taste profile, and warm tabs.
+
+    Deliberately does not touch DiscoverApiCache — that table is shared
+    across every user of this instance (raw provider responses), not
+    per-user data, so a self-service button here shouldn't clear it out
+    from under other users.
+    """
+    deleted_rows, _ = DiscoverRowCache.objects.filter(user_id=user_id).delete()
+    deleted_profiles, _ = DiscoverTasteProfile.objects.filter(user_id=user_id).delete()
+    deleted_tabs = cache.delete_pattern(f"{DISCOVER_TAB_PREFIX}_{user_id}_*") or 0
+    return deleted_rows + deleted_profiles + deleted_tabs

--- a/src/users/tests/views/test_advanced.py
+++ b/src/users/tests/views/test_advanced.py
@@ -3,7 +3,12 @@ from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
+from app.discover.tab_cache import DISCOVER_TAB_PREFIX
+from app.history_cache_utils import HISTORY_DAY_PREFIX, HISTORY_INDEX_PREFIX
+from app.models import DiscoverRowCache, DiscoverTasteProfile
+from app.statistics_cache import STATISTICS_CACHE_PREFIX, STATISTICS_DAY_PREFIX
 from integrations.imports.helpers import decrypt
 
 
@@ -75,3 +80,138 @@ class TmdbProxyUpdateTests(TestCase):
 
         response = self.client.get(reverse("advanced"))
         self.assertTrue(response.context["tmdb_proxy_configured"])
+
+
+class CacheClearButtonsTests(TestCase):
+    """Tests for the per-cache clear buttons in Settings > Advanced."""
+
+    def setUp(self):
+        """Create two users so per-user clears can be checked for cross-talk."""
+        self.credentials = {"username": "test", "password": "12345"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+        self.other_user = get_user_model().objects.create_user(
+            username="other",
+            password="12345",
+        )
+        self.client.login(**self.credentials)
+
+    def test_advanced_page_renders_cache_management_buttons_and_overlay(self):
+        """The Advanced page should render a button and confirm copy per cache."""
+        response = self.client.get(reverse("advanced"))
+
+        self.assertContains(response, "Cache Management")
+        for key in ("search", "history", "statistics", "discover", "all"):
+            self.assertContains(response, f"openConfirm('{key}')")
+        self.assertContains(response, "Clear All Caches")
+        # The "clear all" warning is the one place placeholder-value behavior
+        # (statistics rebuilds async, unlike the others) needs to be called out.
+        self.assertContains(response, "background task")
+
+    def test_clear_history_cache_only_clears_current_user(self):
+        """Clearing history cache must not touch another user's cached days."""
+        mine = f"{HISTORY_DAY_PREFIX}_{self.user.id}_repeats_20260805"
+        mine_index = f"{HISTORY_INDEX_PREFIX}_{self.user.id}_repeats"
+        theirs = f"{HISTORY_DAY_PREFIX}_{self.other_user.id}_repeats_20260805"
+        cache.set(mine, {"entries": ["eden"]}, None)
+        cache.set(mine_index, {"days": ["20260805"]}, None)
+        cache.set(theirs, {"entries": ["unaffected"]}, None)
+
+        response = self.client.post(reverse("clear_history_cache"))
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertIsNone(cache.get(mine))
+        self.assertIsNone(cache.get(mine_index))
+        self.assertIsNotNone(cache.get(theirs))
+
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertIn("history cache entr", str(messages[0]))
+
+    def test_clear_statistics_cache_clears_page_and_day_keys_for_current_user(self):
+        """Clearing statistics cache must clear both the page and day payloads."""
+        page_key = f"{STATISTICS_CACHE_PREFIX}_{self.user.id}_all_time"
+        day_key = f"{STATISTICS_DAY_PREFIX}:{self.user.id}:2026-08-05"
+        other_page_key = f"{STATISTICS_CACHE_PREFIX}_{self.other_user.id}_all_time"
+        cache.set(page_key, {"total": 1}, None)
+        cache.set(day_key, {"total": 1}, None)
+        cache.set(other_page_key, {"total": 1}, None)
+
+        response = self.client.post(reverse("clear_statistics_cache"))
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertIsNone(cache.get(page_key))
+        self.assertIsNone(cache.get(day_key))
+        self.assertIsNotNone(cache.get(other_page_key))
+
+    def test_clear_discover_cache_deletes_rows_profile_and_tab_cache(self):
+        """Clearing discover cache must clear DB rows, profile, and warm-tab keys."""
+        DiscoverRowCache.objects.create(
+            user=self.user,
+            media_type="all",
+            row_key="trending",
+            payload={"items": []},
+            expires_at=timezone.now(),
+        )
+        DiscoverTasteProfile.objects.create(
+            user=self.user,
+            media_type="all",
+            expires_at=timezone.now(),
+        )
+        other_row = DiscoverRowCache.objects.create(
+            user=self.other_user,
+            media_type="all",
+            row_key="trending",
+            payload={"items": []},
+            expires_at=timezone.now(),
+        )
+        tab_key = f"{DISCOVER_TAB_PREFIX}_{self.user.id}_all_False"
+        cache.set(tab_key, {"rows": []}, None)
+
+        response = self.client.post(reverse("clear_discover_cache"))
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertFalse(DiscoverRowCache.objects.filter(user=self.user).exists())
+        self.assertFalse(
+            DiscoverTasteProfile.objects.filter(user=self.user).exists(),
+        )
+        self.assertIsNone(cache.get(tab_key))
+        # Another user's row must survive.
+        self.assertTrue(DiscoverRowCache.objects.filter(id=other_row.id).exists())
+
+    def test_clear_all_caches_clears_search_and_current_users_own_caches(self):
+        """Clear All must sweep search plus this user's history/stats/discover."""
+        cache.set("search_tmdb_movie_batman_1", {"results": []}, None)
+        history_key = f"{HISTORY_DAY_PREFIX}_{self.user.id}_repeats_20260805"
+        stats_key = f"{STATISTICS_CACHE_PREFIX}_{self.user.id}_all_time"
+        cache.set(history_key, {"entries": []}, None)
+        cache.set(stats_key, {"total": 1}, None)
+        DiscoverTasteProfile.objects.create(
+            user=self.user,
+            media_type="all",
+            expires_at=timezone.now(),
+        )
+
+        response = self.client.post(reverse("clear_all_caches"))
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertIsNone(cache.get("search_tmdb_movie_batman_1"))
+        self.assertIsNone(cache.get(history_key))
+        self.assertIsNone(cache.get(stats_key))
+        self.assertFalse(
+            DiscoverTasteProfile.objects.filter(user=self.user).exists(),
+        )
+
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertIn("search, history, statistics, and discover", str(messages[0]))
+
+    def test_cache_clear_views_require_post(self):
+        """GET requests to any clear-cache endpoint must be rejected."""
+        for url_name in (
+            "clear_history_cache",
+            "clear_statistics_cache",
+            "clear_discover_cache",
+            "clear_all_caches",
+        ):
+            response = self.client.get(reverse(url_name))
+            self.assertEqual(response.status_code, 405)

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -81,6 +81,22 @@ urlpatterns = [
     ),
     path("regenerate_token", views.regenerate_token, name="regenerate_token"),
     path("clear_search_cache", views.clear_search_cache, name="clear_search_cache"),
+    path(
+        "clear_history_cache",
+        views.clear_history_cache,
+        name="clear_history_cache",
+    ),
+    path(
+        "clear_statistics_cache",
+        views.clear_statistics_cache,
+        name="clear_statistics_cache",
+    ),
+    path(
+        "clear_discover_cache",
+        views.clear_discover_cache,
+        name="clear_discover_cache",
+    ),
+    path("clear_all_caches", views.clear_all_caches, name="clear_all_caches"),
     path("update_tmdb_proxy", views.update_tmdb_proxy, name="update_tmdb_proxy"),
     path(
         "update_plex_usernames",

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -29,6 +29,7 @@ from app.templatetags import app_tags
 from integrations import exports, plex
 from integrations.models import PlexAccount
 from integrations.plex_watchlist import WATCHLIST_TASK_NAME
+from users import cache_management
 from users.forms import (
     AuthenticatorSetupForm,
     NotificationSettingsForm,
@@ -1788,7 +1789,7 @@ def update_jellyseerr_settings(request):
 @require_POST
 def clear_search_cache(request):
     """Clear all cached search entries."""
-    deleted = cache.delete_pattern("search_*")
+    deleted = cache_management.clear_search_cache()
 
     messages.success(
         request,
@@ -1797,6 +1798,82 @@ def clear_search_cache(request):
     logger.info(
         "Successfully cleared %s search entries",
         deleted,
+    )
+
+    return redirect("advanced")
+
+
+@require_POST
+def clear_history_cache(request):
+    """Clear the requesting user's cached History day/index payloads."""
+    deleted = cache_management.clear_history_cache_for_user(request.user.id)
+
+    messages.success(
+        request,
+        f"Successfully cleared {deleted} history cache entr{pluralize(deleted, 'y,ies')}",
+    )
+    logger.info(
+        "Successfully cleared %s history cache entries for user %s",
+        deleted,
+        request.user.id,
+    )
+
+    return redirect("advanced")
+
+
+@require_POST
+def clear_statistics_cache(request):
+    """Clear the requesting user's cached Statistics page/day payloads."""
+    deleted = cache_management.clear_statistics_cache_for_user(request.user.id)
+
+    messages.success(
+        request,
+        f"Successfully cleared {deleted} statistics cache entr{pluralize(deleted, 'y,ies')}",
+    )
+    logger.info(
+        "Successfully cleared %s statistics cache entries for user %s",
+        deleted,
+        request.user.id,
+    )
+
+    return redirect("advanced")
+
+
+@require_POST
+def clear_discover_cache(request):
+    """Clear the requesting user's cached Discover rows/taste profile."""
+    deleted = cache_management.clear_discover_cache_for_user(request.user.id)
+
+    messages.success(
+        request,
+        f"Successfully cleared {deleted} discover cache entr{pluralize(deleted, 'y,ies')}",
+    )
+    logger.info(
+        "Successfully cleared %s discover cache entries for user %s",
+        deleted,
+        request.user.id,
+    )
+
+    return redirect("advanced")
+
+
+@require_POST
+def clear_all_caches(request):
+    """Clear every clearable cache: search (instance-wide) plus this user's own."""
+    deleted = cache_management.clear_search_cache()
+    deleted += cache_management.clear_history_cache_for_user(request.user.id)
+    deleted += cache_management.clear_statistics_cache_for_user(request.user.id)
+    deleted += cache_management.clear_discover_cache_for_user(request.user.id)
+
+    messages.success(
+        request,
+        f"Successfully cleared {deleted} cache entr{pluralize(deleted, 'y,ies')} "
+        "across search, history, statistics, and discover",
+    )
+    logger.info(
+        "Successfully cleared %s total cache entries (all caches) for user %s",
+        deleted,
+        request.user.id,
     )
 
     return redirect("advanced")


### PR DESCRIPTION
## Summary
- Adds a Cache Management section to Settings > Advanced with a clear button for each of History, Statistics, and Discover, alongside the existing Search Cache clear button, plus a "Clear All Caches" button that runs all four.
- Each button opens a confirmation overlay describing the actual consequences of that specific clear (not a generic "are you sure") before submitting — Search's warning calls out that it's instance-wide since its keys carry no user id; History/Statistics/Discover are per-user. The Statistics warning specifically notes it rebuilds asynchronously in the background (placeholder `--` values) unlike History's synchronous rebuild-on-read. Clear All gets the most detailed warning, combining every consequence above it.
- New `src/users/cache_management.py` holds the actual clearing logic as small, independently testable functions, reused by both the individual views and "Clear All" rather than duplicated.
- Each clear only touches its cache's *payload* keys/rows — not the internal locks, dedupe, or dirty-tracking bookkeeping those same caches keep in Redis. Those self-manage; deleting them buys nothing but a small chance of a duplicate background refresh being scheduled.

### Context
This was prompted by a real support case: a user deleted a false-positive watch from History, but it kept reappearing. Root cause traced back to 33a3612a ("Fix stale history after watch deletion", fixing #570) — that fix stops *new* deletions from leaving a stale cached day behind, but it can't retroactively heal a day-cache entry that was already written stale by the pre-fix code path, because `HISTORY_DAY_CACHE_TIMEOUT` has no expiry (`cache.set(..., timeout=None)` = cache forever in Django). The only way to clear an already-stuck entry was `redis-cli DEL` against the exact versioned/prefixed key by hand. This PR gives that a UI so it doesn't require shell access to the Redis container.

## Validation
- `ruff check` on all changed/added Python files: clean.
- `djlint --profile django` on `advanced.html`: clean.
- New tests in `src/users/tests/views/test_advanced.py` (9 cases): per-user isolation (another user's cache entries survive a clear), the DB+Redis split for Discover (`DiscoverRowCache`/`DiscoverTasteProfile` rows plus the warm-tab Redis keys), GET rejection on all four new endpoints, and that the template renders every button and warning. Confirmed each new test fails without its corresponding fix/implementation before passing with it.
- `pytest src/users/tests/` (full app): 205 passed.
- Verified live against a real data dump in a local container: seeded a real cache key, clicked the actual "Clear History Cache" button through a browser (not just a test client), confirmed server-side afterward that the key was gone.

## Notes
- No new migrations — `cache_management.py` is pure Redis/queryset operations against existing models, no schema changes.