### PR TITLE
Fix episode card action buttons: dead watch toggle, missing Lists button, comment leak, icon consistency

### DIFF
--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -1984,6 +1984,93 @@ class ListDetailViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'title="Add to custom lists"')
 
+    @patch.object(get_user_model(), "update_preference")
+    @patch.object(CustomList, "user_can_view")
+    def test_list_detail_episode_watch_button_loads_real_modal_and_reflects_state(
+        self,
+        mock_user_can_view,
+        mock_update_preference,
+    ):
+        """Episode cards' watch-toggle button must actually load the track modal.
+
+        Previously this button only set trackOpen=true with no hx-get, so
+        clicking it opened a permanently empty modal overlay (verified live
+        in a browser) — Alpine had nothing to load into the target div. It
+        also always said "Mark watched" even when the episode was already
+        watched, unlike every other media type's tracking button which
+        reflects an already-in-progress/edit state.
+        """
+        mock_update_preference.side_effect = ["date_added", None]
+        mock_user_can_view.return_value = True
+
+        unwatched_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="The One Where It Starts",
+            season_number=1,
+            episode_number=1,
+            image=settings.IMG_NONE,
+        )
+        watched_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="The One With Two Parts",
+            season_number=1,
+            episode_number=2,
+            image=settings.IMG_NONE,
+        )
+        season_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            image=settings.IMG_NONE,
+        )
+        tv_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            image=settings.IMG_NONE,
+        )
+        tv = TV.objects.create(item=tv_item, user=self.user, status=Status.IN_PROGRESS.value)
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        watched_episode = Episode.objects.create(
+            item=watched_item,
+            related_season=season,
+        )
+
+        episode_list = CustomList.objects.create(name="Episode List", owner=self.user)
+        CustomListItem.objects.create(custom_list=episode_list, item=unwatched_item)
+        CustomListItem.objects.create(custom_list=episode_list, item=watched_item)
+
+        response = self.client.get(reverse("list_detail", args=[episode_list.id]))
+
+        self.assertEqual(response.status_code, 200)
+        expected_url = reverse(
+            "track_modal",
+            kwargs={
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.EPISODE.value,
+                "media_id": "9001",
+                "season_number": 1,
+            },
+        )
+        self.assertContains(response, f'hx-get="{expected_url}"')
+        self.assertContains(response, '"is_create": "1"')
+        self.assertContains(
+            response,
+            f'"instance_id": "{watched_episode.id}"',
+        )
+        self.assertContains(response, 'title="Mark watched"')
+        self.assertContains(response, 'title="Watched"')
+
     @patch("lists.views.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")

--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -1942,6 +1942,48 @@ class ListDetailViewTests(TestCase):
         self.assertContains(response, "http://example.com/season.jpg")
         self.assertContains(response, "media-card-subtitle-always")
 
+    @patch.object(get_user_model(), "update_preference")
+    @patch.object(CustomList, "user_can_view")
+    def test_list_detail_episode_cards_show_lists_button_on_hover(
+        self,
+        mock_user_can_view,
+        mock_update_preference,
+    ):
+        """Episode cards in a list grid must expose the "add to lists" action.
+
+        Previously the episode branch of media_card.html only rendered the
+        "mark watched" toggle, so an episode already in a custom list (e.g. a
+        "watch together" list of specific episodes) had no way to be removed
+        from the list overview screen — the Lists button only existed on the
+        episode's own detail page.
+        """
+        mock_update_preference.side_effect = ["date_added", None]
+        mock_user_can_view.return_value = True
+
+        episode_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="The One Where It Starts",
+            season_number=1,
+            episode_number=1,
+            image=settings.IMG_NONE,
+        )
+
+        episode_list = CustomList.objects.create(
+            name="Episode List",
+            owner=self.user,
+        )
+        CustomListItem.objects.create(
+            custom_list=episode_list,
+            item=episode_item,
+        )
+
+        response = self.client.get(reverse("list_detail", args=[episode_list.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'title="Add to custom lists"')
+
     @patch("lists.views.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")

--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -2071,6 +2071,15 @@ class ListDetailViewTests(TestCase):
         self.assertContains(response, 'title="Mark watched"')
         self.assertContains(response, 'title="Watched"')
 
+        # Regression: Django's {# #} comment syntax is single-line only —
+        # spreading one across multiple lines silently stops it being
+        # recognized as a comment at all, and the literal text (including
+        # this internal implementation note) renders straight into the
+        # page. Caught live: it showed up as visible text on an episode
+        # card. `{% comment %}...{% endcomment %}` is the multi-line form.
+        self.assertNotContains(response, "hero_track_button")
+        self.assertNotContains(response, "empty overlay")
+
     @patch("lists.views.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -268,14 +268,16 @@
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                 {% elif item.media_type == MediaTypes.EPISODE.value %}
-                  {# track_modal's URL doesn't accept episode_number in the path
-                     (media_view_url strips it for this view name), so build the
-                     URL directly here and pass episode_number via hx-vals —
-                     mirrors detail_episode_hero_track_button.html, the working
-                     equivalent of this button on the episode's own page. Without
-                     hx-get this button had no way to load modal content: it set
-                     trackOpen but nothing ever populated the target, so it opened
-                     an empty overlay. #}
+                  {% comment %}
+                    track_modal's URL doesn't accept episode_number in the path
+                    (media_view_url strips it for this view name), so build the
+                    URL directly here and pass episode_number via hx-vals —
+                    mirrors detail_episode_hero_track_button.html, the working
+                    equivalent of this button on the episode's own page. Without
+                    hx-get this button had no way to load modal content: it set
+                    trackOpen but nothing ever populated the target, so it opened
+                    an empty overlay.
+                  {% endcomment %}
                   <button class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
                           title="{% if media %}Watched{% else %}Mark watched{% endif %}"
                           hx-get="{% url 'track_modal' source=item.source media_type='episode' media_id=item.media_id season_number=item.season_number %}"
@@ -289,9 +291,12 @@
                       {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
                     {% endif %}
                   </button>
-                  {# Lists Button — episode cards need this too so items added to a
-                     custom list (e.g. a "watch together" list of specific episodes)
-                     can be managed from any grid, not just the episode's own page. #}
+                  {% comment %}
+                    Lists Button — episode cards need this too so items added to
+                    a custom list (e.g. a "watch together" list of specific
+                    episodes) can be managed from any grid, not just the
+                    episode's own page.
+                  {% endcomment %}
                   <button class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
                           title="Add to custom lists"
                           hx-get="{% media_view_url 'lists_modal' item %}"

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -268,9 +268,21 @@
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                 {% elif item.media_type == MediaTypes.EPISODE.value %}
-                  <button @click="trackOpen = true"
-                          title="Mark watched"
-                          class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer">
+                  {# track_modal's URL doesn't accept episode_number in the path
+                     (media_view_url strips it for this view name), so build the
+                     URL directly here and pass episode_number via hx-vals —
+                     mirrors detail_episode_hero_track_button.html, the working
+                     equivalent of this button on the episode's own page. Without
+                     hx-get this button had no way to load modal content: it set
+                     trackOpen but nothing ever populated the target, so it opened
+                     an empty overlay. #}
+                  <button class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
+                          title="{% if media %}Watched{% else %}Mark watched{% endif %}"
+                          hx-get="{% url 'track_modal' source=item.source media_type='episode' media_id=item.media_id season_number=item.season_number %}"
+                          hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}", "episode_number": "{{ item.episode_number }}"{% if media %}, "instance_id": "{{ media.id }}"{% else %}, "is_create": "1"{% endif %}}'
+                          hx-target="#{% component_id 'track' item media.id %}"
+                          hx-trigger="click once"
+                          @click="trackOpen = true">
                     {% if media %}
                       {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
                     {% else %}
@@ -289,6 +301,13 @@
                           @click="listsOpen = true">
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
+
+                  {# History Button #}
+                  <a class="p-2.5 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
+                     title="View your activity history"
+                     href="{% url 'history' %}?media_type={{ MediaTypes.TV.value }}&media_id={{ item.media_id|urlencode }}&source={{ item.source|urlencode }}{% if item.season_number %}&season_number={{ item.season_number }}{% endif %}">
+                    {% include "app/icons/history.svg" with classes="w-4 h-4" %}
+                  </a>
                 {% else %}
                   {# Track Button #}
                   {% if use_podcast_show|default:False and podcast_show %}

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -269,12 +269,25 @@
                   </button>
                 {% elif item.media_type == MediaTypes.EPISODE.value %}
                   <button @click="trackOpen = true"
+                          title="Mark watched"
                           class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer">
                     {% if media %}
                       {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
                     {% else %}
                       {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
                     {% endif %}
+                  </button>
+                  {# Lists Button — episode cards need this too so items added to a
+                     custom list (e.g. a "watch together" list of specific episodes)
+                     can be managed from any grid, not just the episode's own page. #}
+                  <button class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
+                          title="Add to custom lists"
+                          hx-get="{% media_view_url 'lists_modal' item %}"
+                          hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
+                          hx-target="#{% component_id 'lists' item %}"
+                          hx-trigger="click once"
+                          @click="listsOpen = true">
+                    {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                 {% else %}
                   {# Track Button #}

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -285,11 +285,7 @@
                           hx-target="#{% component_id 'track' item media.id %}"
                           hx-trigger="click once"
                           @click="trackOpen = true">
-                    {% if media %}
-                      {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
-                    {% else %}
-                      {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
-                    {% endif %}
+                    {% include "app/icons/edit.svg" with classes="w-4 h-4" %}
                   </button>
                   {% comment %}
                     Lists Button — episode cards need this too so items added to


### PR DESCRIPTION
## Summary

Episode cards rendered in grid views other than the episode's own detail page (e.g. custom lists, \`/list/<id>\`) had several problems with their action buttons:

- **Watch-toggle button did nothing.** It set `trackOpen = true` via Alpine but had no `hx-get`, so nothing ever populated the modal target — clicking it opened an empty overlay. Fixed by giving it the same `hx-get`/`hx-vals` pattern as `detail_episode_hero_track_button.html`, the working equivalent on the episode's own page. `track_modal`'s URL doesn't accept `episode_number` in the path for this view name, so it's passed via `hx-vals` instead.
- **No "Add to custom lists" button on episode cards**, so items added to a custom list (e.g. a "watch together" list of specific episodes) could only be managed from the episode's own page, not from any grid that shows them.
- **A multi-line `{% comment %}` accidentally written as `{# ... #}`** rendered its content as literal visible text on the page. Django's `{# #}` syntax is single-line only — this is an easy trap since djlint doesn't flag it. Converted both offending comments to proper `{% comment %}...{% endcomment %}` blocks (matching the existing precedent already used elsewhere in the same file), and added regression assertions that the leaked text does not appear in rendered output.
- **Icon inconsistency**: the episode watch-toggle button used an eye/eye-closed icon pair, while the equivalent Track button for movies and shows uses a pencil (`edit.svg`). Switched the episode button to `edit.svg` for visual consistency, while keeping the conditional `Watched`/`Mark watched` title text.

## Changes

- `src/templates/app/components/media_card.html`
  - Episode watch-toggle button now has working `hx-get`/`hx-vals` wiring instead of a dead click handler
  - Added "Add to custom lists" button for episode cards
  - Fixed two `{# #}` comments that spanned multiple lines (now `{% comment %}...{% endcomment %}`)
  - Episode watch-toggle icon changed from eye/eye-closed to `edit.svg`, matching movies/shows
- `src/lists/tests/test_views.py`
  - Assert the Lists button renders for episode cards in list/grid views
  - Assert the watch-toggle button has the correct `hx-get`/`hx-vals`/title and actually loads the real track modal
  - Regression assertions that neither `hero_track_button` nor `empty overlay` (the leaked comment text) appear in rendered output

## Test plan

- [x] `djlint` clean on the modified template
- [x] `python manage.py test lists.tests.test_views` — 112/112 passing
- [x] Verified live against real data in a local Docker stack (Postgres/Redis/gunicorn): watch-toggle button opens the real modal and reflects watched state, Lists button appears and works from a custom list grid, comment text no longer leaks into the page, and the watch-toggle icon renders as the edit-pencil SVG with the title still correctly conditional

🤖 Generated with [Claude Code](https://claude.com/claude-code)