### PR TITLE
[BUG] Allow the service worker to load before login

### DIFF
--- a/src/app/tests/views/test_service_worker.py
+++ b/src/app/tests/views/test_service_worker.py
@@ -23,6 +23,14 @@ class ServiceWorkerViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/javascript")
 
+    def test_service_worker_is_available_without_login(self):
+        self.client.logout()
+
+        response = self.client.get(reverse("service_worker"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/javascript")
+
     def test_service_worker_sets_no_cache_headers_and_static_only_policy(self):
         response = self.client.get(reverse("service_worker"))
 

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -1845,6 +1845,7 @@ def date_range_script(request):
         )
 
 
+@login_not_required
 @require_GET
 def service_worker(request):
     """Serve the service worker file from static files."""


### PR DESCRIPTION
## Summary
### Why
An anonymous request for `/serviceworker.js` passes through the login gate. The request can receive a login response instead of JavaScript. The browser cannot register the service worker when this occurs.

### What changed
- Exempt the service-worker view from the login gate.
- Add a regression test for an anonymous GET request.
- Keep the current JavaScript content type, scope header, and cache headers.

## AI Assistance
Main driver: Claude Opus 5 Extra.
Reviewer: Codex Sol 5.6 High.
PR submission ONLY: Gemini 3.1 Pro.
Skill used to check: https://github.com/garrytan/gstack/tree/main/qa

## RICE Score
This estimate uses the [RICE prioritization method](https://www.intercom.com/blog/rice-simple-prioritization-for-product-managers/).

| Input | Estimate |
|---|---:|
| Reach | 4 |
| Impact | 2 |
| Confidence | 95% |
| Effort | 0.5 person-week |
| RICE score | 1,520 |

Estimated implementation time with AI assistance: 2 to 4 hours.

This estimate does not include maintainer review or release work.

## Architecture & Tradeoffs
This change does not change the service-worker cache rules. It does not exempt POST requests from CSRF protection. These changes are outside this issue.

## Validation
- Five focused Django tests passed.
- Focused Ruff checks passed.
- An anonymous browser request returned HTTP 200.
- The browser received `application/javascript`.
- The response kept `Service-Worker-Allowed: /`.
- The browser console had no errors.

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
- [ ] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [ ] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

## Notes
- *Verify this PR does not contain any AI footprints.*
- Fixes #590
