### PR TITLE
[BUG] Reject failed SQLite quick-check results during startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,22 +8,18 @@ set -e
 # often means the db directory sits on a network filesystem that doesn't
 # support SQLite's WAL locking - see README's SQLite persistence note.
 if [ -z "$DB_HOST" ] && [ -f /floppy/db/db.sqlite3 ]; then
-    python -c "
-import sqlite3
-import sys
-
-try:
-    conn = sqlite3.connect('/floppy/db/db.sqlite3')
-    conn.execute('PRAGMA quick_check').fetchone()
-except sqlite3.DatabaseError as e:
-    print(f'[entrypoint] Database integrity check failed: {e}', file=sys.stderr)
-    print(
-        '[entrypoint] The SQLite file may be corrupt (see README: SQLite '
-        'network filesystem caveat)',
-        file=sys.stderr,
-    )
-    sys.exit(1)
-" || exit 1
+    if timeout 600 python -m config.sqlite_integrity /floppy/db/db.sqlite3; then
+        :
+    else
+        integrity_status=$?
+        # GNU timeout returns 124. BusyBox in the Floppy image returns 143.
+        case "$integrity_status" in
+            124|143)
+                echo "[entrypoint] Database integrity check exceeded 600 seconds. Migrations did not run. Check the database storage and try again." >&2
+                ;;
+        esac
+        exit "$integrity_status"
+    fi
 fi
 
 # Bounded, retrying migrate: a blocked migration must fail loudly and retry

--- a/src/app/tests/test_entrypoint.py
+++ b/src/app/tests/test_entrypoint.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+ENTRYPOINT = Path(__file__).resolve().parents[3] / "entrypoint.sh"
+
+
+class EntrypointSQLiteIntegrityContractTests(SimpleTestCase):
+    """Keep the SQLite startup gate ahead of database migrations."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.script = ENTRYPOINT.read_text()
+
+    def test_checker_runs_only_for_an_existing_sqlite_database(self):
+        self.assertIn(
+            'if [ -z "$DB_HOST" ] && [ -f /floppy/db/db.sqlite3 ]; then',
+            self.script,
+        )
+
+    def test_failed_check_exits_before_migrations(self):
+        checker = "python -m config.sqlite_integrity /floppy/db/db.sqlite3"
+        migration = "python manage.py migrate"
+
+        self.assertLess(self.script.index(checker), self.script.index(migration))
+        self.assertIn('exit "$integrity_status"', self.script)
+
+    def test_checker_timeout_is_bounded_and_reported(self):
+        self.assertIn(
+            "timeout 600 python -m config.sqlite_integrity /floppy/db/db.sqlite3",
+            self.script,
+        )
+        self.assertIn("124|143)", self.script)
+        self.assertIn("Database integrity check exceeded 600 seconds", self.script)

--- a/src/app/tests/test_sqlite_integrity.py
+++ b/src/app/tests/test_sqlite_integrity.py
@@ -1,0 +1,97 @@
+import io
+import sqlite3
+from contextlib import redirect_stderr
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from config.sqlite_integrity import check_database
+
+
+class SQLiteIntegrityTests(SimpleTestCase):
+    """Verify the startup integrity decision without changing a database."""
+
+    def test_exact_ok_result_succeeds_and_closes_connection(self):
+        connection = MagicMock()
+        connection.execute.return_value.fetchone.return_value = ("ok",)
+        database_path = Path("db.sqlite3").resolve()
+
+        with patch(
+            "config.sqlite_integrity.sqlite3.connect", return_value=connection
+        ) as connect:
+            status = check_database(database_path)
+
+        self.assertEqual(status, 0)
+        connect.assert_called_once_with(f"{database_path.as_uri()}?mode=ro", uri=True)
+        connection.close.assert_called_once()
+
+    def test_missing_result_fails_and_closes_connection(self):
+        connection = MagicMock()
+        connection.execute.return_value.fetchone.return_value = None
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "config.sqlite_integrity.sqlite3.connect",
+                return_value=connection,
+            ),
+            redirect_stderr(stderr),
+        ):
+            status = check_database("db.sqlite3")
+
+        self.assertEqual(status, 1)
+        self.assertIn("returned None", stderr.getvalue())
+        connection.close.assert_called_once()
+
+    def test_non_ok_result_fails_and_reports_result(self):
+        connection = MagicMock()
+        connection.execute.return_value.fetchone.return_value = (
+            "*** in database main ***",
+        )
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "config.sqlite_integrity.sqlite3.connect",
+                return_value=connection,
+            ),
+            redirect_stderr(stderr),
+        ):
+            status = check_database("db.sqlite3")
+
+        self.assertEqual(status, 1)
+        self.assertIn("*** in database main ***", stderr.getvalue())
+        self.assertIn("Migrations did not run", stderr.getvalue())
+        connection.close.assert_called_once()
+
+    def test_database_error_fails_and_closes_connection(self):
+        connection = MagicMock()
+        connection.execute.side_effect = sqlite3.DatabaseError("damaged")
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "config.sqlite_integrity.sqlite3.connect",
+                return_value=connection,
+            ),
+            redirect_stderr(stderr),
+        ):
+            status = check_database("db.sqlite3")
+
+        self.assertEqual(status, 1)
+        self.assertIn("Database integrity check failed", stderr.getvalue())
+        self.assertIn("network filesystem caveat", stderr.getvalue())
+        connection.close.assert_called_once()
+
+    def test_missing_database_is_not_created(self):
+        with TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "missing.sqlite3"
+            stderr = io.StringIO()
+
+            with redirect_stderr(stderr):
+                status = check_database(database_path)
+
+            self.assertEqual(status, 1)
+            self.assertFalse(database_path.exists())

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -1,0 +1,55 @@
+"""Check SQLite integrity before Django runs migrations."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from contextlib import closing
+from pathlib import Path
+
+
+def _write_error(message: str) -> None:
+    sys.stderr.write(f"{message}\n")
+
+
+def check_database(database_path: str | Path) -> int:
+    """Return zero only when SQLite reports an exact ``ok`` result."""
+    path = Path(database_path).resolve()
+    database_uri = f"{path.as_uri()}?mode=ro"
+
+    try:
+        with closing(sqlite3.connect(database_uri, uri=True)) as connection:
+            row = connection.execute("PRAGMA quick_check").fetchone()
+    except sqlite3.DatabaseError as exc:
+        _write_error(f"[entrypoint] Database integrity check failed for {path}: {exc}")
+        _write_error(
+            "[entrypoint] The SQLite file may be corrupt "
+            "(see README: SQLite network filesystem caveat)"
+        )
+        return 1
+
+    if not row or row[0] != "ok":
+        _write_error(
+            "[entrypoint] Database integrity check failed for "
+            f"{path}: PRAGMA quick_check returned {row!r}"
+        )
+        _write_error(
+            "[entrypoint] Migrations did not run. Restore a known-good backup. "
+            "Keep SQLite on local or block storage."
+        )
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    """Run the check for the database path on the command line."""
+    arguments = sys.argv[1:]
+    if len(arguments) != 1:
+        _write_error("Usage: python -m config.sqlite_integrity DATABASE_PATH")
+        return 2
+    return check_database(arguments[0])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
### Why
The startup script runs `PRAGMA quick_check`. It does not inspect the returned value. SQLite can return an integrity error without raising an exception. The current script can then start migrations on a damaged database.

### What changed
- Add a small SQLite integrity checker that uses the Python standard library.
- Open the existing database in read-only mode.
- Accept only the exact SQLite result `ok`.
- Fail when the result is missing or has an error.
- Stop before migrations after an integrity failure or timeout.
- Add regression tests for the checker and the entrypoint.

## AI Assistance
Main driver: Claude Opus 5 Extra.
Reviewer: Codex Sol 5.6 High.
PR submission ONLY: Gemini 3.1 Pro.
Skill used to check: https://github.com/garrytan/gstack/tree/main/qa

## RICE Score
This estimate uses the [RICE prioritization method](https://www.intercom.com/blog/rice-simple-prioritization-for-product-managers/).

| Input | Estimate |
|---|---:|
| Reach | 3 |
| Impact | 3 |
| Confidence | 95% |
| Effort | 0.5 person-week |
| RICE score | 1,710 |

Estimated implementation time with AI assistance: 0.5 to 1 working day.

This estimate does not include maintainer review or release work.

## Architecture & Tradeoffs
This pull request keeps the current database path. Issue #595 adds configurable paths in a separate pull request. The timeout accepts the status used by GNU tools and the status used by Alpine BusyBox. The script preserves other failure statuses.

## Validation
- Eight focused Django tests passed.
- Focused Ruff and format checks passed.
- The entrypoint shell syntax check passed.
- A healthy database returned exit status 0.
- A missing database returned exit status 1 and was not created.
- The branch container image built on Alpine.
- A damaged database made the container exit before migrations.

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
- [ ] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [ ] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

## Notes
- *Verify this PR does not contain any AI footprints.*
- Fixes #593
