### PR TITLE
fix: restrict modal season paths to season media

### DIFF
--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -1137,28 +1137,35 @@ def media_view_url(view_name, media):
     if not is_dict and not hasattr(media, "source"):
         return ""
 
+    media_type = media["media_type"] if is_dict else media.media_type
+
     # Build kwargs using either dict access or object attribute
     kwargs = {
         "source": media["source"] if is_dict else media.source,
         "media_type": (
-            media.get("route_media_type") or media["media_type"]
+            media.get("route_media_type") or media_type
             if is_dict
-            else getattr(media, "route_media_type", None) or media.media_type
+            else getattr(media, "route_media_type", None) or media_type
         ),
         "media_id": str(media["media_id"] if is_dict else media.media_id),
     }
 
-    # Handle season/episode numbers if they exist
-    if is_dict:
-        if "season_number" in media:
-            kwargs["season_number"] = media["season_number"]
-        if "episode_number" in media:
-            kwargs["episode_number"] = media["episode_number"]
-    else:
-        season_number = getattr(media, "season_number", None)
-        episode_number = getattr(media, "episode_number", None)
+    # Providers may include season_number=0 on top-level TV/anime metadata.
+    # Only season and episode objects use those values as URL path segments.
+    if media_type in (MediaTypes.SEASON.value, MediaTypes.EPISODE.value):
+        season_number = (
+            media.get("season_number")
+            if is_dict
+            else getattr(media, "season_number", None)
+        )
         if season_number is not None:
             kwargs["season_number"] = season_number
+    if media_type == MediaTypes.EPISODE.value:
+        episode_number = (
+            media.get("episode_number")
+            if is_dict
+            else getattr(media, "episode_number", None)
+        )
         if episode_number is not None:
             kwargs["episode_number"] = episode_number
 

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -880,6 +880,26 @@ class AppTagsTests(TestCase):
             expected_tv_modal,
         )
 
+        # TMDB includes season_number=0 on top-level anime metadata. It is not
+        # a season route and must not become /lists_modal/.../<id>/0.
+        anime_dict = {
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.ANIME.value,
+            "media_id": "83611",
+            "season_number": 0,
+        }
+        self.assertEqual(
+            app_tags.media_view_url("lists_modal", anime_dict),
+            reverse(
+                "lists_modal",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_type": MediaTypes.ANIME.value,
+                    "media_id": "83611",
+                },
+            ),
+        )
+
     def test_unicode_icon(self):
         """Test the unicode_icon tag for all media types."""
         # Test all media types from MediaTypes


### PR DESCRIPTION
## Summary
### What changed
- add season URL segments only for season and episode media
- add episode URL segments only for episode media
- cover TMDB top-level anime metadata containing `season_number=0`

## AI Assistance
Main driver: Claude Opus 5 Extra.
Reviewer: Codex Sol 5.6 High.
PR submission ONLY: Gemini 3.1 Pro.
Skill used to check: https://github.com/garrytan/gstack/tree/main/qa

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
- [ ] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [ ] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

## Notes
- *Verify this PR does not contain any AI footprints.*
- Link relevant issues (for example: `Refs #101`).
