### PR TITLE
Stabilize provider and browser CI tests

### DIFF
--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from playwright.sync_api import expect, sync_playwright
 
 from app.models import Game, Item, MediaTypes, Movie, Sources, Status
+from app.tests.views.test_track_modal import _tv_with_seasons_payload
 from users.models import DateFormatChoices
 
 
@@ -25,7 +26,6 @@ class IntegrationTest(StaticLiveServerTestCase):
         cls.playwright = sync_playwright().start()
         # use headless=False, slow_mo=200 to see the browser
         cls.browser = cls.playwright.chromium.launch()
-        cls.page = cls.browser.new_page()
 
     def setUp(self):
         """Set up test data for CustomList model."""
@@ -33,6 +33,29 @@ class IntegrationTest(StaticLiveServerTestCase):
         self.user = get_user_model().objects.create_user(**self.credentials)
         self.user.date_format = DateFormatChoices.ISO_8601
         self.user.save(update_fields=["date_format"])
+        show = _tv_with_seasons_payload(
+            "1396",
+            Sources.TMDB.value,
+            title="Breaking Bad",
+            episode_count=1,
+        )
+        search = {
+            "page": 1,
+            "total_pages": 1,
+            "total_results": 1,
+            "results": [show],
+        }
+        for provider_patch in (
+            patch("app.providers.tmdb.search", return_value=search),
+            patch("app.providers.tmdb.tv", return_value=show),
+            patch("app.providers.tmdb.tv_with_seasons", return_value=show),
+            patch("app.providers.tmdb.get_tvdb_episode_image_map", return_value={}),
+        ):
+            provider_patch.start()
+            self.addCleanup(provider_patch.stop)
+
+        self.context = self.browser.new_context()
+        self.page = self.context.new_page()
         self.page.goto(f"{self.live_server_url}/")
         self.page.get_by_placeholder("Enter your username").fill(
             self.credentials["username"],
@@ -56,9 +79,14 @@ class IntegrationTest(StaticLiveServerTestCase):
     @classmethod
     def tearDownClass(cls):
         """Tear down the test class."""
-        super().tearDownClass()
         cls.browser.close()
         cls.playwright.stop()
+        super().tearDownClass()
+
+    def tearDown(self):
+        """Close browser connections before Django flushes the database."""
+        self.context.close()
+        super().tearDown()
 
     def test_season_progress_edit(self):
         """Test the progress edit of a season."""


### PR DESCRIPTION
## Summary
### Why
The required app-test workflow fails on `latest` before it evaluates the changes in #612–#615.

Two independent test defects cause the failures:

- Tests for TVDB-enabled behavior do not enable TVDB. They fall back to TMDB and fail assertions for genre backfill, search, Plex imports, and Plex webhooks.
- The Playwright class reuses one browser page across database flushes and calls live TMDB search and metadata endpoints. This causes intermittent missing results and SQLite table locks.

### What changed
- Enable TVDB only in the tests that verify its configured behavior.
- Reuse the existing TV-season test payload for Playwright.
- Mock the TMDB calls made by the browser tests.
- Create and close one browser context per test before Django flushes SQLite.

No production code changed.

## AI Assistance
Main driver: Claude Opus 5 Extra.
Reviewer: Codex Sol 5.6 High.
PR submission ONLY: Gemini 3.1 Pro.
Skill used to check: https://github.com/garrytan/gstack/tree/main/qa

## Validation
- 3,254 fast tests passed.
- The complete Playwright integration class passed.
- The original nine deterministic failing tests passed.
- The full affected provider, metadata, Plex, and browser group passed in parallel.
- Focused Ruff checks passed.
- `git diff --check` passed.

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
- [ ] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [ ] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

## Notes
- *Verify this PR does not contain any AI footprints.*
- Link relevant issues (for example: `Refs #101`).
