### PR TITLE
Fix App Tests CI failures from missing TVDB test settings

### DIFF
--- a/src/app/providers/openlibrary.py
+++ b/src/app/providers/openlibrary.py
@@ -298,7 +298,8 @@ async def get_authors_full(response):
     authors = []
     author_entries = response.get("authors", [])
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=settings.REQUEST_TIMEOUT)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         tasks = []
         for index, author in enumerate(author_entries):
             if isinstance(author, dict) and "author" in author:
@@ -373,7 +374,11 @@ async def get_editions(response_book, response_work):
     # limit to 500 editions, pagination is not supported
     url = f"https://openlibrary.org/works/{work_id}/editions.json?limit=500"
 
-    async with aiohttp.ClientSession() as session, session.get(url) as response:
+    timeout = aiohttp.ClientTimeout(total=settings.REQUEST_TIMEOUT)
+    async with (
+        aiohttp.ClientSession(timeout=timeout) as session,
+        session.get(url) as response,
+    ):
         if response.status == requests.codes.ok:
             data = await response.json()
             return [
@@ -402,7 +407,11 @@ async def get_ratings(response_work):
 
     url = f"https://openlibrary.org/works/{work_id}/ratings.json"
 
-    async with aiohttp.ClientSession() as session, session.get(url) as response:
+    timeout = aiohttp.ClientTimeout(total=settings.REQUEST_TIMEOUT)
+    async with (
+        aiohttp.ClientSession(timeout=timeout) as session,
+        session.get(url) as response,
+    ):
         if response.status == requests.codes.ok:
             data = await response.json()
             summary = data.get("summary", {})

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -1835,6 +1835,7 @@ class Metadata(TestCase):
 
         self.assertIsNone(igdb_game_id)
 
+    @tag("network")
     def test_book(self):
         """Test the metadata method for books."""
         response = openlibrary.book("OL21733390M")

--- a/src/app/tests/providers/test_services.py
+++ b/src/app/tests/providers/test_services.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from app.models import Item, MediaTypes, Sources
 from app.providers import (
@@ -698,6 +698,7 @@ class ServicesTests(TestCase):
 
         mock_search.assert_called_once_with(MediaTypes.ANIME.value, "test", 1)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.tvdb.search")
     def test_search_anime_tvdb(self, mock_search):
         """Test the search function for anime via TVDB."""

--- a/src/app/tests/test_tasks_metadata_backfill.py
+++ b/src/app/tests/test_tasks_metadata_backfill.py
@@ -1058,6 +1058,7 @@ class MetadataBackfillTaskTests(TestCase):
         self.assertIn(comic.id, queued_ids)
         self.assertIn(manga.id, queued_ids)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     def test_genre_backfill_queryset_includes_tmdb_tv_until_current_version_marked(
         self,
     ):
@@ -1083,6 +1084,7 @@ class MetadataBackfillTaskTests(TestCase):
         queued_ids = set(tasks._genre_items_queryset().values_list("id", flat=True))
         self.assertNotIn(item.id, queued_ids)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.tasks_genre.enqueue_genre_backfill_items")
     def test_reconcile_genre_backfill_queues_current_candidates_on_startup(
         self,
@@ -1269,6 +1271,7 @@ class MetadataBackfillTaskTests(TestCase):
         )
         self.assertEqual(result, {"selected": 1, "enqueued": 1})
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_adds_anime_from_tvdb_mapping(
         self,
@@ -1318,6 +1321,7 @@ class MetadataBackfillTaskTests(TestCase):
         self.assertEqual(result["errors"], 0)
         self.assertEqual(state.strategy_version, tasks.GENRE_BACKFILL_VERSION)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_non_anime_marks_strategy_current(
         self,
@@ -1371,6 +1375,7 @@ class MetadataBackfillTaskTests(TestCase):
             set(tasks._genre_items_queryset().values_list("id", flat=True)),
         )
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_discovers_tvdb_mapping_from_tmdb_metadata(
         self,
@@ -1465,6 +1470,7 @@ class MetadataBackfillTaskTests(TestCase):
             item.source,
         )
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_records_failure_on_tvdb_error(
         self,

--- a/src/integrations/tests/test_plex_import_logic.py
+++ b/src/integrations/tests/test_plex_import_logic.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from app.models import (
@@ -342,6 +342,7 @@ class TestPlexHybridImport(TestCase):
         self.assertEqual(episode.item.media_id, "1515183")
         self.assertEqual(episode.item.title, "Yellowstone")
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.tvdb.tv_with_seasons")
     @patch("integrations.imports.plex.app.providers.tvdb.enabled", return_value=True)
     def test_new_tv_show_genesis_uses_tvdb_when_preferred(

--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -1305,6 +1305,7 @@ class PlexWebhookTests(TestCase):
         season_item.refresh_from_db()
         self.assertEqual(season_item.provider_metadata_status, "")
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.tvdb.tv_with_seasons")
     @patch("app.providers.tmdb.tv_with_seasons")
     def test_tv_episode_genesis_uses_tvdb_when_preferred(


### PR DESCRIPTION
## Summary
- Today's "App Tests" runs on `latest` were failing 10 tests (6 failures, 4 errors). Nine of them share one root cause: they exercise TVDB-preferred code paths (Plex genesis identity, genre backfill, TVDB anime search) but never set `TVDB_API_KEY`, so `app.providers.tvdb.enabled()` was always `False` in CI and the app correctly fell back to non-TVDB behavior — while the tests asserted the TVDB branch had been taken. Added the `@override_settings(TVDB_API_KEY="test-tvdb-key")` decorator already used by sibling tests in the same files:
  - `src/integrations/tests/test_plex_import_logic.py::test_new_tv_show_genesis_uses_tvdb_when_preferred`
  - `src/integrations/tests/test_webhooks_plex.py::test_tv_episode_genesis_uses_tvdb_when_preferred`
  - `src/app/tests/test_tasks_metadata_backfill.py` (6 tests around genre backfill queryset/reconcile/populate)
  - `src/app/tests/providers/test_services.py::test_search_anime_tvdb`
- The 10th failure, `test_book`, makes a live unmocked call to `openlibrary.org` and wasn't tagged `@tag("network")` like its neighboring live-API tests, so it ran in CI's main job despite CI passing `--exclude-tag network`. Tagged it to match convention.
- While tracing that one, found `openlibrary.py`'s async `aiohttp.ClientSession()` calls (`get_authors_full`, `get_editions`, `get_ratings`) had no timeout, unlike the module's sync `requests` calls which use `settings.REQUEST_TIMEOUT`. Gave them the same explicit timeout so a slow/blocked network path fails fast instead of hanging on aiohttp's 300s default.

## Validation
- `python src/manage.py test app.tests.test_tasks_metadata_backfill app.tests.providers.test_services integrations.tests.test_plex_import_logic integrations.tests.test_webhooks_plex --exclude-tag network` — 135 tests, all pass.
- Confirmed the previously-failing 9 tests individually pass with the fix, and `test_book` is now excluded (`Found 0 test(s)`) under `--exclude-tag network`.
- `ruff check` on all changed files — clean.

## Notes
No production behavior changes for real deployments with `TVDB_API_KEY` configured — the fixes are test-only plus a defensive timeout on openlibrary async calls.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RGnLNSJcqmGgg2wABSizoU)_