### PR TITLE
Fix anime season pages not finding TV-identity-linked tracking (#623)

### DIFF
--- a/src/app/fork_services_episode.py
+++ b/src/app/fork_services_episode.py
@@ -23,14 +23,13 @@ def resolve_or_create_season(
     Mirrors the season auto-create behavior of the web episode actions:
     missing seasons are created In Progress with metadata-derived title/image.
     """
-    season_qs = Season.objects.filter(
-        item__media_id=media_id,
-        item__source=source,
-        item__season_number=season_number,
-        item__episode_number=None,
-        user=user,
+    related_season = metadata_resolution.find_tracked_season(
+        user,
+        media_id,
+        source,
+        season_number,
+        library_media_type=library_media_type or None,
     )
-    related_season = season_qs.order_by("id").first()
     if related_season is None:
         tv_with_seasons_metadata = services.get_media_metadata(
             "tv_with_seasons",
@@ -66,13 +65,6 @@ def resolve_or_create_season(
         )
 
         logger.info("%s did not exist, it was created successfully.", related_season)
-    elif season_qs.count() > 1:
-        logger.warning(
-            "Multiple Season records for media_id=%s season=%s user=%s — using oldest",
-            media_id,
-            season_number,
-            user,
-        )
 
     _sync_library_media_type(related_season, library_media_type)
     return related_season

--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -1010,22 +1010,36 @@ class Season(Media):
 
     def get_tv(self):
         """Get related TV instance for a season and create it if it doesn't exist."""
+        # Scope to the season's own bucket (anime vs. non-anime) so a season
+        # is never silently attached to a TV row from the show's other
+        # identity when both exist — see #623.
+        is_anime_bucket = self.item.library_media_type == MediaTypes.ANIME.value
+
+        def _bucket_scoped(queryset):
+            if is_anime_bucket:
+                return queryset.filter(item__library_media_type=MediaTypes.ANIME.value)
+            return queryset.exclude(item__library_media_type=MediaTypes.ANIME.value)
+
         try:
-            tv = TV.objects.get(
-                item__media_id=self.item.media_id,
-                item__media_type=MediaTypes.TV.value,
-                item__season_number=None,
-                item__source=self.item.source,
-                user=self.user,
-            )
-        except TV.MultipleObjectsReturned:
-            tv = (
+            tv = _bucket_scoped(
                 TV.objects.filter(
                     item__media_id=self.item.media_id,
                     item__media_type=MediaTypes.TV.value,
                     item__season_number=None,
                     item__source=self.item.source,
                     user=self.user,
+                ),
+            ).get()
+        except TV.MultipleObjectsReturned:
+            tv = (
+                _bucket_scoped(
+                    TV.objects.filter(
+                        item__media_id=self.item.media_id,
+                        item__media_type=MediaTypes.TV.value,
+                        item__season_number=None,
+                        item__source=self.item.source,
+                        user=self.user,
+                    ),
                 )
                 .order_by("id")
                 .first()

--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -55,6 +55,26 @@ def media_save(request):
         source=source,
         identity_media_type=identity_media_type,
     )
+
+    # A season already tracked under a different identity bucket (e.g. via
+    # the show's TV identity) must resolve to the same row here as it does
+    # on the detail page, otherwise this falls into the create path below
+    # and collides with the existing row's unique constraint — see #623.
+    if (
+        not instance_id
+        and tracking_media_type == MediaTypes.SEASON.value
+        and season_number
+    ):
+        existing_season = metadata_resolution.find_tracked_season(
+            request.user,
+            media_id,
+            source,
+            int(season_number),
+            library_media_type=library_media_type,
+        )
+        if existing_season is not None:
+            instance_id = str(existing_season.id)
+
     discover_tab_cache.mark_active_from_request(
         request,
         fallback_media_type=library_media_type or media_type,

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -136,44 +136,38 @@ def season_details(
         user_medias = []
         current_instance = None
     else:
-        if season_item_is_local_only:
-            season_qs = Season.objects.filter(
-                item__media_id=media_id,
-                item__media_type=MediaTypes.SEASON.value,
-                item__source=source,
-                item__season_number=season_number,
-                user=request.user,
-            )
-            if season_library_media_type:
-                season_qs = season_qs.filter(
-                    item__library_media_type=season_library_media_type,
-                )
-            else:
-                season_qs = season_qs.exclude(
-                    item__library_media_type=MediaTypes.ANIME.value,
-                )
+        # Resolve the tracked season across identity buckets (see #623): a
+        # season tracked via the show's TV identity must still be found from
+        # the anime-identity route, and vice versa, so read and write agree.
+        preferred_library_media_type = (
+            season_library_media_type or MediaTypes.SEASON.value
+        )
+        tracked_season = metadata_resolution.find_tracked_season(
+            request.user,
+            media_id,
+            source,
+            season_number,
+            library_media_type=preferred_library_media_type,
+        )
+        if tracked_season is None:
+            user_medias = []
+        elif season_item_is_local_only:
             user_medias = list(
-                season_qs.select_related(
-                    "item", "related_tv", "related_tv__item"
-                ).prefetch_related("episodes", "episodes__item")
+                Season.objects.filter(pk=tracked_season.pk)
+                .select_related("item", "related_tv", "related_tv__item")
+                .prefetch_related("episodes", "episodes__item")
             )
         else:
-            user_medias = BasicMedia.objects.filter_media_prefetch(
-                request.user,
-                media_id,
-                MediaTypes.SEASON.value,
-                source,
-                season_number=season_number,
+            user_medias = list(
+                BasicMedia.objects.filter_media_prefetch(
+                    request.user,
+                    media_id,
+                    MediaTypes.SEASON.value,
+                    source,
+                    season_number=season_number,
+                    library_media_type=tracked_season.item.library_media_type,
+                )
             )
-            if season_library_media_type:
-                user_medias = user_medias.filter(
-                    item__library_media_type=season_library_media_type,
-                )
-            else:
-                user_medias = user_medias.exclude(
-                    item__library_media_type=MediaTypes.ANIME.value,
-                )
-            user_medias = list(user_medias)
         current_instance = user_medias[0] if user_medias else None
 
     episodes_in_db = current_instance.episodes.all() if current_instance else []

--- a/src/app/services/metadata_resolution.py
+++ b/src/app/services/metadata_resolution.py
@@ -422,6 +422,47 @@ def upsert_provider_links(
     return external_ids
 
 
+def find_tracked_season(
+    user,
+    media_id: str,
+    source: str,
+    season_number: int,
+    *,
+    library_media_type: str | None = None,
+) -> Season | None:
+    """Return the user's existing tracked Season for this show/season, if any.
+
+    A given (user, show, season) can only be tracked once in practice, even
+    though grouped-anime shows expose it under two Item buckets (anime vs.
+    TV identity) — see #623, where the anime-bucket page and the TV-identity
+    `related_tv` link disagreed and a duplicate row was inserted. This looks
+    across buckets so read and write paths agree on "the" tracked season
+    instead of missing it. Prefers `library_media_type` when given, but
+    falls back to any bucket. Never creates — see
+    `get_or_create_tracked_season_item` / `fork_services_episode.
+    resolve_or_create_season` for get-or-create semantics.
+    """
+    queryset = Season.objects.filter(
+        item__media_id=media_id,
+        item__source=source,
+        item__media_type=MediaTypes.SEASON.value,
+        item__season_number=season_number,
+        item__episode_number=None,
+        user=user,
+    ).select_related("item", "related_tv", "related_tv__item")
+
+    if library_media_type:
+        match = (
+            queryset.filter(item__library_media_type=library_media_type)
+            .order_by("id")
+            .first()
+        )
+        if match is not None:
+            return match
+
+    return queryset.order_by("id").first()
+
+
 def get_or_create_tracked_season_item(
     media_id: str,
     source: str,

--- a/src/app/tests/models/test_season.py
+++ b/src/app/tests/models/test_season.py
@@ -677,6 +677,40 @@ class SeasonStatusTests(TestCase):
             self.assertEqual(tv.item.title, "Test Show")
             self.assertEqual(tv.status, Status.PLANNING.value)
 
+    def test_get_tv_prefers_matching_library_media_type_bucket(self):
+        """get_tv must not attach a season to a TV row from the other identity.
+
+        Regression test for GitHub issue #623: when a show is tracked under
+        both its TV identity and its anime identity (two separate TV rows,
+        distinguished only by Item.library_media_type), get_tv used to pick
+        whichever TV row matched media_id/source/user first, regardless of
+        bucket, silently mis-attaching the season.
+        """
+        self.tv_item.library_media_type = MediaTypes.TV.value
+        self.tv_item.save(update_fields=["library_media_type"])
+
+        anime_tv_item = Item.objects.create(
+            media_id="123",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test Show",
+            image="http://example.com/image.jpg",
+            library_media_type=MediaTypes.ANIME.value,
+        )
+        anime_tv = TV.objects.create(
+            item=anime_tv_item,
+            user=self.user,
+            status=Status.PLANNING.value,
+        )
+
+        self.season.related_tv = None
+        self.season.item.library_media_type = MediaTypes.ANIME.value
+        self.season.item.save(update_fields=["library_media_type"])
+
+        resolved = self.season.get_tv()
+
+        self.assertEqual(resolved.id, anime_tv.id)
+
 
 class SeasonGetRemainingEpsQuickWatchDateTests(TestCase):
     """Tests for Season.get_remaining_eps with different quick_watch_date settings."""

--- a/src/app/tests/test_metadata_resolution.py
+++ b/src/app/tests/test_metadata_resolution.py
@@ -905,3 +905,139 @@ class GetOrCreateTrackedSeasonItemTests(TestCase):
             )
 
         self.assertEqual(resolved.pk, canonical.pk)
+
+
+class FindTrackedSeasonTests(TestCase):
+    """Regression tests for issue #623: cross-identity Season lookup.
+
+    find_tracked_season must find a tracked Season regardless of which
+    Item.library_media_type bucket it's attached to, since read (season
+    detail page) and write (media_save) paths must agree on "the" tracked
+    season for a show/season/user.
+    """
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="naruto-watcher",
+            password="pw12345",
+        )
+
+    def test_returns_none_when_no_season_tracked(self):
+        resolved = metadata_resolution.find_tracked_season(
+            self.user,
+            "79824",
+            Sources.TVDB.value,
+            0,
+        )
+        self.assertIsNone(resolved)
+
+    def test_finds_season_tracked_via_other_bucket(self):
+        """A season tracked under the TV-identity bucket is still found from the anime route."""
+        tv_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Naruto Shippuden",
+            image="",
+            library_media_type=MediaTypes.TV.value,
+        )
+        tv_instance = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=0,
+            title="Naruto Shippuden",
+            image="",
+            library_media_type=MediaTypes.TV.value,
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv_instance,
+            status=Status.COMPLETED.value,
+        )
+
+        resolved = metadata_resolution.find_tracked_season(
+            self.user,
+            "79824",
+            Sources.TVDB.value,
+            0,
+            library_media_type=MediaTypes.ANIME.value,
+        )
+
+        self.assertEqual(resolved.pk, season.pk)
+
+    def test_prefers_exact_bucket_match_over_other_bucket(self):
+        """When both buckets have a tracked row, the requested bucket wins."""
+        tv_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Naruto Shippuden",
+            image="",
+            library_media_type=MediaTypes.TV.value,
+        )
+        tv_instance = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        tv_bucket_season_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=0,
+            title="Naruto Shippuden",
+            image="",
+            library_media_type=MediaTypes.TV.value,
+        )
+        Season.objects.create(
+            item=tv_bucket_season_item,
+            user=self.user,
+            related_tv=tv_instance,
+            status=Status.IN_PROGRESS.value,
+        )
+
+        anime_tv_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Naruto Shippuden",
+            image="",
+            library_media_type=MediaTypes.ANIME.value,
+        )
+        anime_tv_instance = TV.objects.create(
+            item=anime_tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        anime_bucket_season_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=0,
+            title="Naruto Shippuden",
+            image="",
+            library_media_type=MediaTypes.ANIME.value,
+        )
+        anime_season = Season.objects.create(
+            item=anime_bucket_season_item,
+            user=self.user,
+            related_tv=anime_tv_instance,
+            status=Status.COMPLETED.value,
+        )
+
+        resolved = metadata_resolution.find_tracked_season(
+            self.user,
+            "79824",
+            Sources.TVDB.value,
+            0,
+            library_media_type=MediaTypes.ANIME.value,
+        )
+
+        self.assertEqual(resolved.pk, anime_season.pk)

--- a/src/app/tests/views/test_crud.py
+++ b/src/app/tests/views/test_crud.py
@@ -517,6 +517,78 @@ class CreateMedia(TestCase):
             1,
         )
 
+    def test_media_save_updates_existing_tv_identity_linked_season(self):
+        """Saving from the anime-bucket season page must update, not duplicate.
+
+        Regression test for GitHub issue #623: when a season is already
+        tracked via `related_tv` pointing at the show's TV-identity `TV` row,
+        clicking "Add to tracker" on the anime-identity season page (which has
+        no `instance_id`, because the page failed to find the existing row)
+        used to try to INSERT a second `Season` row and 500 with
+        `IntegrityError: ... app_season_unique_tv_item`.
+        """
+        tv_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Naruto Shippuden",
+            image="http://example.com/image.jpg",
+            library_media_type=MediaTypes.TV.value,
+        )
+        tv_identity = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=0,
+            title="Naruto Shippuden",
+            image="http://example.com/season.jpg",
+            library_media_type=MediaTypes.TV.value,
+        )
+        existing_season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv_identity,
+            status=Status.IN_PROGRESS.value,
+            notes="pre-existing notes",
+            score=8.5,
+        )
+
+        response = self.client.post(
+            reverse("media_save"),
+            {
+                "media_id": "79824",
+                "source": Sources.TVDB.value,
+                "media_type": MediaTypes.SEASON.value,
+                "identity_media_type": MediaTypes.ANIME.value,
+                "library_media_type": MediaTypes.ANIME.value,
+                "season_number": 0,
+                "status": Status.COMPLETED.value,
+                # A real submission resubmits the modal's pre-filled fields
+                # unchanged alongside the one the user actually edited.
+                "notes": "pre-existing notes",
+                "score": 8.5,
+            },
+        )
+
+        self.assertNotEqual(response.status_code, 500)
+        self.assertEqual(
+            Season.objects.filter(
+                item__media_id="79824",
+                item__season_number=0,
+                user=self.user,
+            ).count(),
+            1,
+        )
+        existing_season.refresh_from_db()
+        self.assertEqual(existing_season.status, Status.COMPLETED.value)
+        self.assertEqual(existing_season.notes, "pre-existing notes")
+        self.assertEqual(existing_season.score, 8.5)
+
     @tag("network")
     def test_create_episodes(self):
         """Test the creation of Episode through views."""

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5162,6 +5162,155 @@ class MediaDetailsViewTests(TestCase):
 
     @patch("app.providers.services.get_media_metadata")
     @patch("app.providers.tmdb.process_episodes")
+    def test_anime_season_details_finds_season_tracked_via_tv_identity(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+    ):
+        """The anime-bucket season page must find a season tracked via TV identity.
+
+        Regression test for GitHub issue #623: a TVDB show tracked both as
+        anime and with its seasons tracked via `Season.related_tv` pointing
+        at the TV-identity `TV` row used to always show "Add to tracker" on
+        the anime-identity season page, even though the season was already
+        tracked.
+        """
+        tv_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Naruto Shippuden",
+            image="http://example.com/image.jpg",
+            library_media_type=MediaTypes.TV.value,
+        )
+        tv_identity = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=0,
+            title="Naruto Shippuden",
+            image="http://example.com/season.jpg",
+            library_media_type=MediaTypes.TV.value,
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv_identity,
+            status=Status.COMPLETED.value,
+        )
+
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Naruto Shippuden",
+            "media_id": "79824",
+            "source": Sources.TVDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/0": {
+                "title": "Specials",
+                "season_title": "Specials",
+                "media_id": "79824",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TVDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [],
+            },
+        }
+        mock_process_episodes.return_value = []
+
+        response = self.client.get(
+            reverse(
+                "anime_season_details",
+                kwargs={
+                    "source": Sources.TVDB.value,
+                    "media_id": "79824",
+                    "title": "naruto-shippuden",
+                    "season_number": 0,
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["current_instance"], season)
+        self.assertNotContains(response, "Add to tracker")
+
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
+    def test_anime_season_details_numbered_season_via_tv_identity(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+    ):
+        """Same as season 0 above, but for a normal numbered season."""
+        tv_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Naruto Shippuden",
+            image="http://example.com/image.jpg",
+            library_media_type=MediaTypes.TV.value,
+        )
+        tv_identity = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="79824",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Naruto Shippuden",
+            image="http://example.com/season.jpg",
+            library_media_type=MediaTypes.TV.value,
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv_identity,
+            status=Status.IN_PROGRESS.value,
+        )
+
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Naruto Shippuden",
+            "media_id": "79824",
+            "source": Sources.TVDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Season 1",
+                "season_title": "Season 1",
+                "media_id": "79824",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TVDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [],
+            },
+        }
+        mock_process_episodes.return_value = []
+
+        response = self.client.get(
+            reverse(
+                "anime_season_details",
+                kwargs={
+                    "source": Sources.TVDB.value,
+                    "media_id": "79824",
+                    "title": "naruto-shippuden",
+                    "season_number": 1,
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["current_instance"], season)
+        self.assertNotContains(response, "Add to tracker")
+
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
     def test_episode_details_view_anonymous_public(
         self,
         mock_process_episodes,

--- a/src/app/track_modal_views.py
+++ b/src/app/track_modal_views.py
@@ -270,15 +270,28 @@ def _render_standard_track_modal(
     elif request.GET.get("is_create"):
         media = None
     else:
-        user_medias = BasicMedia.objects.filter_media(
-            request.user,
-            media_id,
-            media_type,
-            source,
-            season_number=season_number,
-            episode_number=episode_number,
-        )
-        media = user_medias.first()
+        media = None
+        # A season tracked under a different identity bucket (e.g. via the
+        # show's TV identity) must still resolve here, so the modal receives
+        # the correct instance_id instead of trying to create a duplicate
+        # row on save — see #623.
+        if media_type == MediaTypes.SEASON.value and season_number is not None:
+            media = metadata_resolution.find_tracked_season(
+                request.user,
+                media_id,
+                source,
+                int(season_number),
+            )
+        if media is None:
+            user_medias = BasicMedia.objects.filter_media(
+                request.user,
+                media_id,
+                media_type,
+                source,
+                season_number=season_number,
+                episode_number=episode_number,
+            )
+            media = user_medias.first()
         if media:
             instance_id = media.id
 


### PR DESCRIPTION
## Summary
- When a TVDB/TMDB season is tracked via `Season.related_tv` pointing at the show's **TV identity**, the anime-identity season detail page couldn't find the existing `app_season` row and always showed "Add to tracker." Saving from there then tried to INSERT a duplicate `Season` row and 500'd on the `app_season_unique_tv_item` unique constraint.
- Added a shared `find_tracked_season()` resolver in `metadata_resolution.py` that looks up a user's tracked Season across identity buckets (anime vs. TV), following the existing cross-bucket resolver pattern from #326.
- Used the resolver in three places so they all agree on "the" tracked row: `season_details_views.py` (read path), `save_views.py`'s `media_save` (write-path `instance_id` backfill), and `track_modal_views.py` (modal `instance_id` resolution).
- Scoped `Season.get_tv()` to the season's own anime/non-anime bucket so new seasons don't get mis-attached to the wrong identity's `TV` row going forward.
- Refactored `fork_services_episode.resolve_or_create_season` to delegate to the same resolver instead of its own divergent inline lookup.

## AI Assistance
- This change was generated by `claude-sonnet-5`.

## Validation
- `scripts/test.sh app.tests.views.test_media_details app.tests.views.test_crud app.tests.models.test_season app.tests.test_metadata_resolution app.tests.views.test_episode_history_poll app.tests.models.test_episode` (excluding `network`/`slow` tags) — all pass except a pre-existing, network-dependent failure in `test_create_anime` unrelated to this change (fails identically on the base branch; needs live MyAnimeList access not available in this sandbox).
- `ruff check` on all changed files — clean.
- New tests added: anime-route season page finds a TV-identity-linked season (season 0 and a numbered season), `media_save` updates the existing row without a duplicate insert and preserves notes/score, `Season.get_tv()` prefers the bucket-matching TV row, and unit tests for `find_tracked_season` itself (no match, cross-bucket fallback, prefers exact match).

## Notes
- Refs #623


---
_Generated by [Claude Code](https://claude.ai/code/session_019tGC3mK4qdHBvz7w6vjZBK)_