### PR TITLE
Share one CollectionEntry scan per Home page build (#621)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ node_modules/
 # Brand masters are kept outside the repo; only the web-sized derivatives
 # under docs/brand/ and src/static/img/ are committed.
 docs/brand/*-source.png
+.venv/

--- a/src/lists/smart_rules.py
+++ b/src/lists/smart_rules.py
@@ -659,7 +659,7 @@ def _matches_collection_filter(
 
 
 def _collection_filter_context(owner) -> tuple[set[int], set[tuple[str, str]]]:
-    """Return cached collection lookup sets for smart list collection filtering."""
+    """Return collection lookup sets for smart list collection filtering."""
     collected_item_ids = set(
         CollectionEntry.objects.filter(user=owner).values_list("item_id", flat=True),
     )
@@ -672,16 +672,41 @@ def _collection_filter_context(owner) -> tuple[set[int], set[tuple[str, str]]]:
     return collected_item_ids, collected_episode_pairs
 
 
+def _resolve_collection_context(
+    owner,
+    collection_context: tuple[set[int], set[tuple[str, str]]] | None,
+    collection_context_cache: dict | None,
+) -> tuple[set[int], set[tuple[str, str]]]:
+    """Return a collection context, reusing a caller-supplied value or cache.
+
+    `collection_context_cache` lets callers that resolve many rows/media types
+    for the same owner in one request (e.g. building the Home page) share a
+    single `CollectionEntry` scan instead of repeating it per row/media type.
+    The cache is expected to be a plain dict scoped to a single request/call.
+    """
+    if collection_context is not None:
+        return collection_context
+    if collection_context_cache is None:
+        return _collection_filter_context(owner)
+    cache_key = getattr(owner, "id", None)
+    if cache_key not in collection_context_cache:
+        collection_context_cache[cache_key] = _collection_filter_context(owner)
+    return collection_context_cache[cache_key]
+
+
 def _collection_only_item_ids(
     owner,
     media_type: str,
     tracked_item_ids: set[int] | None = None,
     *,
     search_query: str = "",
+    collection_context_cache: dict | None = None,
 ) -> set[int]:
     """Return collected item ids that do not already have a tracker row."""
     tracked_item_ids = tracked_item_ids or set()
-    collected_item_ids, _collected_episode_pairs = _collection_filter_context(owner)
+    collected_item_ids, _collected_episode_pairs = _resolve_collection_context(
+        owner, None, collection_context_cache,
+    )
     if not collected_item_ids:
         return set()
 
@@ -792,8 +817,15 @@ def collect_matching_item_ids(
     normalized_rules: dict,
     *,
     include_collection_only_untracked: bool = False,
+    collection_context_cache: dict | None = None,
 ) -> set[int]:
-    """Return matching Item IDs for a normalized smart-rule definition."""
+    """Return matching Item IDs for a normalized smart-rule definition.
+
+    `collection_context_cache`, when passed a plain dict by the caller, lets
+    repeated calls for the same owner within one request (e.g. one Home page
+    build iterating several rows/media types) reuse a single collection scan
+    instead of re-querying `CollectionEntry` for every row.
+    """
     target_media_types = _target_media_types(
         owner, normalized_rules.get("media_types", [])
     )
@@ -814,7 +846,9 @@ def collect_matching_item_ids(
     collected_item_ids: set[int] = set()
     collected_episode_pairs: set[tuple[str, str]] = set()
     if collection_filter != "all":
-        collected_item_ids, collected_episode_pairs = _collection_filter_context(owner)
+        collected_item_ids, collected_episode_pairs = _resolve_collection_context(
+            owner, None, collection_context_cache,
+        )
 
     tag_match_ids, tag_excluded_ids = _resolve_tag_id_sets(
         owner,
@@ -853,6 +887,7 @@ def collect_matching_item_ids(
                         media_type,
                         queryset_item_ids,
                         search_query=normalized_rules.get("search", ""),
+                        collection_context_cache=collection_context_cache,
                     ),
                 )
             continue
@@ -903,6 +938,7 @@ def collect_matching_item_ids(
                 media_type,
                 queryset_item_ids,
                 search_query=normalized_rules.get("search", ""),
+                collection_context_cache=collection_context_cache,
             )
             if collection_only_ids:
                 for item in Item.objects.filter(id__in=collection_only_ids).iterator():

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -2197,7 +2197,9 @@ def sort_home_entries(
     )
 
 
-def _library_query_entries(user, row: HomeScreenRow) -> list[HomeRowEntry]:
+def _library_query_entries(
+    user, row: HomeScreenRow, collection_context_cache: dict | None = None,
+) -> list[HomeRowEntry]:
     normalized_filters = _normalized_filter_payload(row.filters or {}, row.media_type)
     if row.media_type == MediaTypes.MUSIC.value:
         subview = _canonical_music_subview(normalized_filters.get("subview"))
@@ -2225,6 +2227,7 @@ def _library_query_entries(user, row: HomeScreenRow) -> list[HomeRowEntry]:
         user,
         smart_rules.normalize_rule_payload(rule_payload, user),
         include_collection_only_untracked=True,
+        collection_context_cache=collection_context_cache,
     )
     if not item_ids:
         return []
@@ -2428,6 +2431,7 @@ def _build_row_section(
     media_type: str,
     items_limit: int,
     batch_start: int = 0,
+    collection_context_cache: dict | None = None,
 ) -> dict | None:
     """Build a single home-row section dict, or None when the row is empty."""
     if row.row_type == HomeScreenRowTypeChoices.CUSTOM_LIST:
@@ -2435,7 +2439,9 @@ def _build_row_section(
     elif row.row_type == HomeScreenRowTypeChoices.RECENTLY_UNRATED:
         entries = _recently_unrated_entries(user, row)
     else:
-        entries = _library_query_entries(user, row)
+        entries = _library_query_entries(
+            user, row, collection_context_cache=collection_context_cache,
+        )
 
     if not entries:
         return None
@@ -2486,6 +2492,7 @@ def _cached_row_section(
     items_limit: int,
     *,
     refresh: bool = False,
+    collection_context_cache: dict | None = None,
 ) -> dict | None:
     """Return a row section from cache, building and caching on miss.
 
@@ -2499,7 +2506,13 @@ def _cached_row_section(
     cache_key = cache_utils.build_home_row_cache_key(user.id, row.id, items_limit)
     cached = None if refresh else cache.get(cache_key)
     if cached is None:
-        section = _build_row_section(user, row, media_type, items_limit)
+        section = _build_row_section(
+            user,
+            row,
+            media_type,
+            items_limit,
+            collection_context_cache=collection_context_cache,
+        )
         cache.set(
             cache_key,
             section if section is not None else _HOME_ROW_EMPTY_SENTINEL,
@@ -2534,6 +2547,11 @@ def build_home_page_groups(
         if row.enabled and (only_row_ids is None or row.id in only_row_ids):
             rows_by_media_type[row.media_type].append(row)
 
+    # Shared across every row built in this call so the (potentially
+    # unscoped) CollectionEntry scan behind collection/collection-only-
+    # untracked filtering runs at most once per request instead of once per
+    # row/media type.
+    collection_context_cache: dict = {}
     groups = []
     for media_type in enabled_media_types:
         row_sections = []
@@ -2546,6 +2564,7 @@ def build_home_page_groups(
                     media_type,
                     items_limit,
                     batch_start=load_row_offset,
+                    collection_context_cache=collection_context_cache,
                 )
             else:
                 section = _cached_row_section(
@@ -2554,6 +2573,7 @@ def build_home_page_groups(
                     media_type,
                     items_limit,
                     refresh=refresh_row_cache,
+                    collection_context_cache=collection_context_cache,
                 )
             if section is None:
                 continue

--- a/src/users/tests/views/test_home_screen.py
+++ b/src/users/tests/views/test_home_screen.py
@@ -1,4 +1,5 @@
 import json
+import time
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -22,6 +23,7 @@ from app.models import (
     Status,
     Tag,
 )
+from lists import smart_rules
 from lists.models import CustomList
 from users import home_screen
 from users.models import (
@@ -447,6 +449,131 @@ class HomeScreenViewTests(TestCase):
                 "Home Library Untracked Movie",
             ],
         )
+
+    def test_empty_library_query_rows_build_quickly_on_cold_cache(self):
+        """Regression test for #621: empty rows must not stall the home page.
+
+        Mirrors the issue's repro (enable several default media-type rows,
+        clear the cache, load the home page) but also stresses the
+        collection-only-untracked resolution path with a "status: all" row
+        and a sizeable CollectionEntry table across *other* media types, so
+        an unscoped/per-row-repeated collection scan would show up as
+        elapsed time here.
+        """
+        enabled_media_types = [
+            MediaTypes.MOVIE.value,
+            MediaTypes.TV.value,
+            MediaTypes.GAME.value,
+            MediaTypes.BOOK.value,
+            MediaTypes.MANGA.value,
+        ]
+        self._set_enabled_media_types(*enabled_media_types)
+
+        # A sizeable collection in media types unrelated to the empty rows,
+        # so any unscoped CollectionEntry scan has real work to do.
+        for index in range(200):
+            collected_item = Item.objects.create(
+                title=f"Collected Anime {index}",
+                media_id=f"home-cold-cache-collected-{index}",
+                media_type=MediaTypes.ANIME.value,
+                source=Sources.TMDB.value,
+                image="https://example.com/collected.jpg",
+            )
+            CollectionEntry.objects.create(user=self.user, item=collected_item)
+
+        for media_type in enabled_media_types:
+            HomeScreenRow.objects.create(
+                user=self.user,
+                media_type=media_type,
+                position=0,
+                enabled=True,
+                row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+                sort_by=MediaSortChoices.TITLE,
+                direction=DirectionChoices.ASC,
+                filters={"status": "all"},
+            )
+
+        start = time.perf_counter()
+        groups = home_screen.build_home_page_groups(self.user, items_limit=10)
+        elapsed = time.perf_counter() - start
+
+        self.assertEqual(groups, [])
+        self.assertLess(
+            elapsed,
+            2.0,
+            f"Building only-empty home rows took {elapsed:.2f}s, "
+            "which would 504 the home page after a cache clear (#621).",
+        )
+
+    def test_library_query_rows_share_one_collection_scan_per_request(self):
+        """`_collection_filter_context` should run once per request, not per row.
+
+        `_library_query_entries` always calls `collect_matching_item_ids`
+        with `include_collection_only_untracked=True`, which needs the
+        user's collection context whenever a row's status filter is empty.
+        Building several such rows in one `build_home_page_groups` call
+        must not re-scan `CollectionEntry` once per row/media type.
+        """
+        enabled_media_types = [
+            MediaTypes.MOVIE.value,
+            MediaTypes.TV.value,
+            MediaTypes.GAME.value,
+        ]
+        self._set_enabled_media_types(*enabled_media_types)
+        for media_type in enabled_media_types:
+            HomeScreenRow.objects.create(
+                user=self.user,
+                media_type=media_type,
+                position=0,
+                enabled=True,
+                row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+                sort_by=MediaSortChoices.TITLE,
+                direction=DirectionChoices.ASC,
+                filters={"status": "all"},
+            )
+
+        with patch(
+            "lists.smart_rules._collection_filter_context",
+            wraps=smart_rules._collection_filter_context,
+        ) as spy:
+            home_screen.build_home_page_groups(self.user, items_limit=10)
+
+        self.assertEqual(
+            spy.call_count,
+            1,
+            "Expected one shared CollectionEntry scan per request, "
+            f"got {spy.call_count} calls across {len(enabled_media_types)} rows.",
+        )
+
+    def test_cached_row_section_skips_rebuild_after_empty_sentinel(self):
+        """A warm empty-row cache hit must not re-invoke the row builder."""
+        self._set_enabled_media_types(MediaTypes.MOVIE.value)
+        row = HomeScreenRow.objects.create(
+            user=self.user,
+            media_type=MediaTypes.MOVIE.value,
+            position=0,
+            enabled=True,
+            row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+            sort_by=MediaSortChoices.TITLE,
+            direction=DirectionChoices.ASC,
+            filters={"status": [Status.IN_PROGRESS.value]},
+        )
+
+        first = home_screen._cached_row_section(
+            self.user, row, MediaTypes.MOVIE.value, items_limit=10,
+        )
+        self.assertIsNone(first)
+
+        with patch.object(
+            home_screen,
+            "_build_row_section",
+            side_effect=AssertionError("row builder should not run on a warm hit"),
+        ):
+            second = home_screen._cached_row_section(
+                self.user, row, MediaTypes.MOVIE.value, items_limit=10,
+            )
+
+        self.assertIsNone(second)
 
     def test_home_progress_filter_excludes_collected_untracked_items(self):
         self._set_enabled_media_types(MediaTypes.TV.value)


### PR DESCRIPTION
## Summary
- Fixes the cold-cache stall in #621: an empty `library_query` Home row could take ~100s to build, 504-ing the Home page after a cache clear.
- `_library_query_entries` always calls `collect_matching_item_ids(..., include_collection_only_untracked=True)`, which resolves collected-but-untracked items via `_collection_filter_context` (an unscoped `CollectionEntry` scan for the user). That scan was being re-run independently for every row and for every media type within a row, instead of once per request.
- Threads an optional `collection_context_cache` dict from `build_home_page_groups` down through `_cached_row_section` → `_build_row_section` → `_library_query_entries` → `collect_matching_item_ids`/`_collection_only_item_ids`, so the collection scan runs at most once per Home page build. The parameter defaults to `None` everywhere, so other callers (smart lists, `item_matches_rules`, etc.) are unaffected.
- Static tracing (informed by the maintainer triage comment on the issue) ruled out any synchronous provider/network call in this path — the empty-row path makes zero provider requests, confirmed by code inspection.

## AI Assistance
- Implemented with AI assistance via Claude Code (Anthropic). Per this session's configuration, the specific underlying model identifier is not disclosed in repository artifacts.

## Validation
- `scripts/test.sh users.tests.views.test_home_screen lists.tests.test_models` — 60 tests, all passing (includes 3 new regression tests).
- `ruff check src/lists/smart_rules.py src/users/home_screen.py src/users/tests/views/test_home_screen.py` — clean.
- `scripts/test.sh` (full fast suite, 3315 tests) — 3 pre-existing failures in unrelated modules (`api.tests.test_fork_scrobble`, `integrations.tests.test_webhooks_stremio`), confirmed unrelated to this change (no reference to the touched files; reproduces in isolation with an unrelated sandbox SQLite journal-mode warning).

New tests added in `src/users/tests/views/test_home_screen.py`:
- `test_empty_library_query_rows_build_quickly_on_cold_cache` — timing-bound reproduction of the issue's repro (several enabled empty media-type rows + a large cross-media-type collection, cold cache).
- `test_library_query_rows_share_one_collection_scan_per_request` — spy-based test asserting `_collection_filter_context` runs once per request across multiple rows.
- `test_cached_row_section_skips_rebuild_after_empty_sentinel` — confirms a warm empty-row cache hit never re-invokes the row builder.

## Notes
- Refs #621
- I was not able to profile a live server in this environment to get exact before/after wall-clock numbers against the reported ~100s in production; the fix targets the strongest confirmed-by-code-reading source of repeated/unscoped work in the empty-row path (see triage comment on the issue for the investigation this builds on).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JuSh4CFQT7RtHQxTeUetTL)_