### PR TITLE
Merge duplicate TV/season Items across TMDB/TVDB providers

### DIFF
--- a/src/app/management/commands/merge_duplicate_provider_items.py
+++ b/src/app/management/commands/merge_duplicate_provider_items.py
@@ -1,0 +1,104 @@
+"""Merge TMDB TV/season Items that duplicate an existing TVDB Item (#620).
+
+Importers that only ever resolve shows via TMDB (Trakt, mdblist) can create a
+second, independent `Item` tree for a show a TVDB-preferring user already
+tracks, since nothing reconciled the two until now. This repairs libraries
+that already accumulated such duplicates.
+
+Read-only by default. Pass --apply to write. Matching is always via a
+verified TVDB id resolution (see `app.services.item_merge`), never title -
+an unresolvable or structurally-incompatible pair is left alone.
+"""
+
+from django.core.management.base import BaseCommand
+
+from app.models import Item, MediaTypes, Sources
+from app.providers import tvdb
+from app.services import item_merge
+from app.services.tv_provider_migration import migrate_tv_item_to_tvdb
+
+
+class Command(BaseCommand):
+    """Merge duplicate TMDB/TVDB Items for the same TV show."""
+
+    help = (
+        "Merge TMDB TV Items that duplicate an existing TVDB Item for the "
+        "same show, folding watch history, tags, and other user data onto "
+        "the TVDB item"
+    )
+
+    def add_arguments(self, parser):
+        """Add command line arguments."""
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Write the changes (default is a read-only report)",
+        )
+        parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            help="Only process shows tracked by this user",
+        )
+
+    def handle(self, *_args, **options):
+        """Execute the command."""
+        self.apply = options["apply"]
+
+        if not tvdb.enabled():
+            self.stdout.write("TVDB not configured; nothing to do.")
+            return
+
+        queryset = Item.objects.filter(
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+        ).exclude(library_media_type=MediaTypes.ANIME.value)
+        if options["username"]:
+            queryset = queryset.filter(
+                tv__user__username=options["username"],
+            ).distinct()
+
+        items = list(queryset.order_by("media_id"))
+        mode = "APPLYING" if self.apply else "DRY RUN (no changes written)"
+        self.stdout.write(f"{mode} - checking {len(items)} TMDB TV item(s)\n")
+
+        counts = {"merged": 0, "would_merge": 0, "skipped": 0, "errored": 0}
+        for item in items:
+            self._process_item(item, counts)
+
+        self.stdout.write(
+            "\nMerged: {merged}  Would merge: {would_merge}  "
+            "Skipped: {skipped}  Errored: {errored}".format(**counts),
+        )
+        if not self.apply and counts["would_merge"]:
+            self.stdout.write(
+                self.style.WARNING("\nRe-run with --apply to write these changes."),
+            )
+
+    def _process_item(self, item, counts):
+        """Check one TMDB show for a verified TVDB duplicate and act on it."""
+        duplicate = item_merge.find_cross_provider_duplicate(item)
+        if duplicate is None:
+            counts["skipped"] += 1
+            return
+
+        label = f"{item.title} (TMDB {item.media_id} -> TVDB {duplicate.media_id})"
+
+        if not self.apply:
+            self.stdout.write(f"Would merge: {label}")
+            counts["would_merge"] += 1
+            return
+
+        try:
+            result = migrate_tv_item_to_tvdb(item)
+        except Exception as exc:
+            self.stdout.write(self.style.ERROR(f"Error merging {label}: {exc}"))
+            counts["errored"] += 1
+            return
+
+        if result.migrated:
+            self.stdout.write(f"Merged: {label}")
+            counts["merged"] += 1
+        else:
+            self.stdout.write(f"Skipped {label}: {result.reason}")
+            counts["skipped"] += 1

--- a/src/app/services/item_merge.py
+++ b/src/app/services/item_merge.py
@@ -1,0 +1,244 @@
+"""Merge two `Item` rows that represent the same logical media.
+
+They arise under different provider identities (e.g. a TMDB-sourced show
+and its TVDB counterpart). This reuses the repoint strategy from
+`app.migrations.0148_merge_duplicate_item_buckets`, which merges `Item`
+rows that differ only by `library_media_type`. That migration operates on
+frozen historical models inside a data migration; this module is the live
+equivalent, callable from request/task code, for merging across `source`
+instead of across bucket.
+
+Every relation that FKs `Item` falls into one of two buckets:
+
+- Owned data (playback progress, tags, collection membership, custom list
+  membership, feedback, provider-display preference, calendar events,
+  cross-provider links) represents a user's choices or a verified mapping.
+  It always survives the merge; if the keeper already has an equivalent row,
+  the loser's copy is redundant and is dropped rather than merged field by
+  field.
+- Rebuildable provider metadata (credits, backfill state) regenerates from
+  the provider, so a collision on the keeper's side just drops the loser's
+  copy.
+
+`TV` and `Season` are unique on `(user, item)` / `(related_tv, item)` and
+cascade into `Episode`, so a naive repoint can collide and, on delete,
+destroy watch history. They get the same "fold the loser's children onto
+the matching survivor row" treatment `0148` uses.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import transaction
+from django.db.utils import IntegrityError
+
+from app.models import TV, Episode, Item, MediaTypes, Season, Sources
+from app.providers import tmdb
+
+logger = logging.getLogger(__name__)
+
+
+def _relation_key(relation):
+    """Return the (app_label, model_name) of a relation's model."""
+    meta = relation.related_model._meta
+    return (meta.app_label, meta.model_name)
+
+
+def _absorb_tv_rows(loser: Item, keeper: Item) -> None:
+    """Move the loser's TV rows onto the keeper without dropping history."""
+    for loser_tv in TV._base_manager.filter(item=loser):
+        surviving_tv = (
+            TV._base_manager.filter(item=keeper, user_id=loser_tv.user_id)
+            .order_by("id")
+            .first()
+        )
+        if surviving_tv is None:
+            loser_tv.item = keeper
+            loser_tv.save(update_fields=["item_id"])
+            continue
+
+        for season in Season._base_manager.filter(related_tv=loser_tv):
+            _rehome_season(season, surviving_tv)
+        loser_tv.delete()
+
+
+def _absorb_season_rows(loser: Item, keeper: Item) -> None:
+    """Move the loser's Season rows onto the keeper without dropping history."""
+    for loser_season in Season._base_manager.filter(item=loser):
+        surviving_season = (
+            Season._base_manager.filter(
+                item=keeper,
+                related_tv_id=loser_season.related_tv_id,
+            )
+            .order_by("id")
+            .first()
+        )
+        if surviving_season is None:
+            loser_season.item = keeper
+            loser_season.save(update_fields=["item_id"])
+            continue
+
+        Episode._base_manager.filter(related_season=loser_season).update(
+            related_season=surviving_season,
+        )
+        loser_season.delete()
+
+
+def _rehome_season(season: Season, surviving_tv: TV) -> None:
+    """Attach one season to another TV row, folding it in if one is there."""
+    rival = (
+        Season._base_manager.filter(
+            related_tv=surviving_tv,
+            item_id=season.item_id,
+        )
+        .order_by("id")
+        .first()
+    )
+    if rival is None:
+        season.related_tv = surviving_tv
+        season.save(update_fields=["related_tv_id"])
+        return
+
+    Episode._base_manager.filter(related_season=season).update(related_season=rival)
+    season.delete()
+
+
+def _repoint(loser: Item, keeper: Item) -> None:
+    """Move everything referencing loser onto keeper."""
+    for relation in Item._meta.related_objects:
+        field = relation.field
+        related_manager = relation.related_model._base_manager
+        related_name = relation.related_model._meta.model_name
+
+        if field.name == "item" and related_name == "tv":
+            _absorb_tv_rows(loser, keeper)
+            continue
+        if field.name == "item" and related_name == "season":
+            _absorb_season_rows(loser, keeper)
+            continue
+
+        if relation.many_to_many:
+            for related in related_manager.filter(**{field.name: loser}):
+                getattr(related, field.name).add(keeper)
+                getattr(related, field.name).remove(loser)
+            continue
+
+        # Materialised, not an iterator: the save below changes the column
+        # the queryset filters on, which can make a streaming cursor skip
+        # rows.
+        for related in list(related_manager.filter(**{field.name: loser})):
+            setattr(related, field.name, keeper)
+            try:
+                # A savepoint keeps a collision from poisoning the
+                # surrounding transaction, so the rest of the merge can
+                # still complete.
+                with transaction.atomic():
+                    related.save(update_fields=[field.attname])
+            except IntegrityError:
+                # The keeper already has the equivalent row; the loser's
+                # copy is redundant.
+                related.delete()
+
+
+def merge_item(loser: Item, keeper: Item) -> None:
+    """Fold `loser` into `keeper`: repoint every reference, then delete `loser`.
+
+    `loser` and `keeper` must be different rows. Runs in one transaction: a
+    failure partway through leaves both items untouched.
+    """
+    if loser.pk == keeper.pk:
+        msg = "cannot merge an item into itself"
+        raise ValueError(msg)
+
+    with transaction.atomic():
+        _repoint(loser, keeper)
+        loser.delete()
+
+    logger.info(
+        "Merged item %s (%s/%s) into %s (%s/%s)",
+        loser.pk,
+        loser.source,
+        loser.media_id,
+        keeper.pk,
+        keeper.source,
+        keeper.media_id,
+    )
+
+
+def resolve_tvdb_id(item: Item) -> str | None:
+    """Return the verified TVDB id for a TMDB TV/season item, if resolvable."""
+    tvdb_id = (item.provider_external_ids or {}).get("tvdb_id")
+    if tvdb_id:
+        return str(tvdb_id)
+    if item.media_type == MediaTypes.SEASON.value:
+        return None
+    resolved = tmdb.resolve_tvdb_id_for_tmdb_show(item.media_id)
+    return str(resolved) if resolved else None
+
+
+def find_tvdb_counterpart(
+    tmdb_show_id: str,
+    media_type: str,
+    *,
+    season_number: int | None = None,
+    library_media_type: str,
+) -> Item | None:
+    """Return an existing TVDB `Item` for the same logical show/season, if any.
+
+    Resolves the show's TVDB id via TMDB's external-ids lookup - a verified
+    provider mapping, never a title guess - then looks for an `Item` already
+    tracked under that identity. Scoped to TV/season, since that's the shape
+    of the cross-provider duplicate this guards against (#620): an importer
+    that only ever supplies TMDB ids creating a second `Item` tree alongside
+    one a user already tracks under TVDB.
+    """
+    if media_type not in (MediaTypes.TV.value, MediaTypes.SEASON.value):
+        return None
+
+    resolved = tmdb.resolve_tvdb_id_for_tmdb_show(tmdb_show_id)
+    if not resolved:
+        return None
+
+    return Item.objects.filter(
+        media_id=str(resolved),
+        source=Sources.TVDB.value,
+        media_type=media_type,
+        season_number=season_number,
+        library_media_type=library_media_type,
+    ).first()
+
+
+def find_cross_provider_duplicate(item: Item) -> Item | None:
+    """Return the verified TVDB counterpart of a TMDB TV/season item, if any.
+
+    Only ever matches on a resolved provider identity (TVDB id), never on
+    title - reused titles, localized titles and remakes make title matching
+    unsafe. Returns None when the item isn't TMDB TV/season, or no verified
+    TVDB counterpart exists.
+    """
+    if item.source != Sources.TMDB.value:
+        return None
+    if item.media_type not in (MediaTypes.TV.value, MediaTypes.SEASON.value):
+        return None
+
+    if item.media_type == MediaTypes.TV.value:
+        tvdb_id = resolve_tvdb_id(item)
+    else:
+        show_item = Item.objects.filter(
+            media_id=item.media_id,
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+        ).first()
+        tvdb_id = resolve_tvdb_id(show_item) if show_item else None
+
+    if not tvdb_id:
+        return None
+
+    return Item.objects.filter(
+        media_id=tvdb_id,
+        source=Sources.TVDB.value,
+        media_type=item.media_type,
+        season_number=item.season_number,
+        library_media_type=item.library_media_type,
+    ).first()

--- a/src/app/services/tv_provider_migration.py
+++ b/src/app/services/tv_provider_migration.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 
 from app.models import Item, MediaTypes, Sources
 from app.providers import tmdb, tvdb
+from app.services import item_merge
 
 logger = logging.getLogger(__name__)
 
@@ -94,25 +95,26 @@ def _structure_is_compatible(
     return True
 
 
-def _would_collide(
+def _existing_tvdb_item(
     media_id: str,
-    source: str,
     media_type: str,
+    library_media_type: str,
     *,
     season_number: int | None = None,
     episode_number: int | None = None,
     exclude_pk: int,
-) -> bool:
+) -> Item | None:
     return (
         Item.objects.filter(
             media_id=media_id,
-            source=source,
+            source=Sources.TVDB.value,
             media_type=media_type,
+            library_media_type=library_media_type,
             season_number=season_number,
             episode_number=episode_number,
         )
         .exclude(pk=exclude_pk)
-        .exists()
+        .first()
     )
 
 
@@ -128,14 +130,78 @@ def _pin(item: Item, reason: str) -> TvMigrationResult:
     return TvMigrationResult(migrated=False, reason=reason)
 
 
+def _merge_into_existing_tvdb_show(
+    item: Item,
+    existing_show: Item,
+    local_seasons: list[Item],
+    local_episodes: list[Item],
+    tvdb_id: str,
+    tvdb_payload: dict,
+) -> TvMigrationResult:
+    """Fold a duplicate TMDB show/season/episode `Item`s onto their TVDB twins.
+
+    Reached when the show already has a separate, independently-tracked
+    TVDB `Item` - e.g. created directly, or by a Trakt (TMDB-only) import
+    alongside a TVDB-preferring user (#620). The TVDB id resolved by the
+    caller is a verified identity match, not a guess, so merging is safe.
+    Seasons/episodes without an existing TVDB counterpart are re-keyed in
+    place as usual.
+    """
+    with transaction.atomic():
+        item_merge.merge_item(item, existing_show)
+
+        for season in local_seasons:
+            existing_season = _existing_tvdb_item(
+                tvdb_id,
+                MediaTypes.SEASON.value,
+                season.library_media_type,
+                season_number=season.season_number,
+                exclude_pk=season.pk,
+            )
+            if existing_season is not None:
+                item_merge.merge_item(season, existing_season)
+                continue
+            season_payload = tvdb_payload.get(f"season/{season.season_number}") or {}
+            season.media_id = tvdb_id
+            season.source = Sources.TVDB.value
+            season.image = season_payload.get("image") or season.image
+            season.save(update_fields=["media_id", "source", "image"])
+
+        for episode in local_episodes:
+            existing_episode = _existing_tvdb_item(
+                tvdb_id,
+                MediaTypes.EPISODE.value,
+                episode.library_media_type,
+                season_number=episode.season_number,
+                episode_number=episode.episode_number,
+                exclude_pk=episode.pk,
+            )
+            if existing_episode is not None:
+                item_merge.merge_item(episode, existing_episode)
+                continue
+            episode.media_id = tvdb_id
+            episode.source = Sources.TVDB.value
+            episode.save(update_fields=["media_id", "source"])
+
+    logger.info(
+        "Merged duplicate TV item %s into existing TVDB item %s (%s)",
+        item.media_id,
+        tvdb_id,
+        existing_show.title,
+    )
+    return TvMigrationResult(migrated=True)
+
+
 def migrate_tv_item_to_tvdb(item: Item) -> TvMigrationResult:
     """Migrate a TMDB-tracked, non-anime TV show `Item` to TVDB identity in place.
 
     Never raises and never partially migrates: any check that fails aborts
-    before mutating data. Structure mismatches and identity collisions pin
-    the item (best-effort, still retried for other reasons later) instead of
-    migrating, since a bad migration would silently re-identify a user's
-    watch history under the wrong show.
+    before mutating data. A structure mismatch pins the item (best-effort,
+    still retried for other reasons later) instead of migrating, since a bad
+    migration would silently re-identify a user's watch history under the
+    wrong show. An identity collision - a separate `Item` already tracks
+    this show under TVDB - merges the two instead of pinning, since the
+    resolved TVDB id is a verified match rather than a guess.
     """
     if item.source != Sources.TMDB.value or item.media_type != MediaTypes.TV.value:
         return TvMigrationResult(migrated=False, reason="not a TMDB TV item")
@@ -147,14 +213,6 @@ def migrate_tv_item_to_tvdb(item: Item) -> TvMigrationResult:
     tvdb_id = _resolve_tvdb_id(item)
     if not tvdb_id:
         return TvMigrationResult(migrated=False, reason="no TVDB id resolvable")
-
-    if _would_collide(
-        tvdb_id,
-        Sources.TVDB.value,
-        MediaTypes.TV.value,
-        exclude_pk=item.pk,
-    ):
-        return _pin(item, "a separate item already tracks this show via TVDB")
 
     local_seasons = _local_season_items(item)
     season_numbers = [season.season_number for season in local_seasons]
@@ -174,20 +232,36 @@ def migrate_tv_item_to_tvdb(item: Item) -> TvMigrationResult:
     if not _structure_is_compatible(local_seasons, local_episodes, tvdb_payload):
         return _pin(item, "season/episode structure does not match TVDB")
 
-    for season in local_seasons:
-        if _would_collide(
+    existing_show = _existing_tvdb_item(
+        tvdb_id,
+        MediaTypes.TV.value,
+        item.library_media_type,
+        exclude_pk=item.pk,
+    )
+    if existing_show is not None:
+        return _merge_into_existing_tvdb_show(
+            item,
+            existing_show,
+            local_seasons,
+            local_episodes,
             tvdb_id,
-            Sources.TVDB.value,
+            tvdb_payload,
+        )
+
+    for season in local_seasons:
+        if _existing_tvdb_item(
+            tvdb_id,
             MediaTypes.SEASON.value,
+            season.library_media_type,
             season_number=season.season_number,
             exclude_pk=season.pk,
         ):
             return _pin(item, "a separate season item already exists under TVDB")
     for episode in local_episodes:
-        if _would_collide(
+        if _existing_tvdb_item(
             tvdb_id,
-            Sources.TVDB.value,
             MediaTypes.EPISODE.value,
+            episode.library_media_type,
             season_number=episode.season_number,
             episode_number=episode.episode_number,
             exclude_pk=episode.pk,

--- a/src/app/tests/test_item_merge.py
+++ b/src/app/tests/test_item_merge.py
@@ -1,0 +1,351 @@
+"""Tests for the live Item merge service (#620)."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import (
+    TV,
+    CollectionEntry,
+    Episode,
+    Item,
+    ItemTag,
+    MediaTypes,
+    PlaybackProgress,
+    Season,
+    Sources,
+    Status,
+    Tag,
+)
+from app.services import item_merge
+
+
+class MergeItemTests(TestCase):
+    """`merge_item` repoints every reference and deletes the loser."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="merge-user",
+            password="pw12345",
+        )
+
+    def test_rejects_merging_an_item_into_itself(self):
+        item = Item.objects.create(
+            media_id="1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Solo",
+            image="",
+        )
+        with self.assertRaises(ValueError):
+            item_merge.merge_item(item, item)
+
+    @patch("app.models.tv.TV._start_next_available_season")
+    def test_tv_row_repoints_when_keeper_has_no_tv_row(self, _mock_start_next_season):
+        loser = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        keeper = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        tv = TV.objects.create(item=loser, user=self.user, status=Status.IN_PROGRESS.value)
+
+        item_merge.merge_item(loser, keeper)
+
+        tv.refresh_from_db()
+        self.assertEqual(tv.item_id, keeper.pk)
+        self.assertFalse(Item.objects.filter(pk=loser.pk).exists())
+
+    def test_tv_row_folds_onto_survivor_when_both_are_tracked(self):
+        """Merging must not destroy the keeper's own TV row/history."""
+        loser = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        keeper = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        loser_tv = TV.objects.create(
+            item=loser,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        keeper_tv = TV.objects.create(
+            item=keeper,
+            user=self.user,
+            status=Status.COMPLETED.value,
+        )
+        loser_season_item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Breaking Bad",
+            image="",
+        )
+        loser_season = Season.objects.create(
+            item=loser_season_item,
+            user=self.user,
+            related_tv=loser_tv,
+            status=Status.IN_PROGRESS.value,
+        )
+
+        item_merge.merge_item(loser, keeper)
+
+        self.assertFalse(TV.objects.filter(pk=loser_tv.pk).exists())
+        self.assertTrue(TV.objects.filter(pk=keeper_tv.pk).exists())
+        loser_season.refresh_from_db()
+        self.assertEqual(loser_season.related_tv_id, keeper_tv.pk)
+
+    def test_season_row_folds_episodes_onto_survivor(self):
+        loser_season_item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="S1",
+            image="",
+        )
+        keeper_season_item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="S1",
+            image="",
+        )
+        tv_item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        tv = TV.objects.create(item=tv_item, user=self.user, status=Status.IN_PROGRESS.value)
+        loser_season = Season.objects.create(
+            item=loser_season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        keeper_season = Season.objects.create(
+            item=keeper_season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        loser_episode_item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="Pilot",
+            image="",
+        )
+        episode = Episode.objects.create(
+            item=loser_episode_item,
+            related_season=loser_season,
+            end_date=None,
+        )
+
+        item_merge.merge_item(loser_season_item, keeper_season_item)
+
+        episode.refresh_from_db()
+        self.assertEqual(episode.related_season_id, keeper_season.pk)
+        self.assertFalse(Season.objects.filter(pk=loser_season.pk).exists())
+        self.assertTrue(Season.objects.filter(pk=keeper_season.pk).exists())
+
+    def test_owned_data_survives_and_collisions_are_dropped(self):
+        """Tags/collection entries repoint; a colliding duplicate is dropped."""
+        loser = Item.objects.create(
+            media_id="1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Movie",
+            image="",
+        )
+        keeper = Item.objects.create(
+            media_id="2",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Movie",
+            image="",
+        )
+        tag = Tag.objects.create(user=self.user, name="Favorites")
+        ItemTag.objects.create(item=loser, tag=tag)
+        CollectionEntry.objects.create(user=self.user, item=loser)
+        loser_progress = PlaybackProgress.objects.create(
+            user=self.user,
+            item=loser,
+            position_seconds=120,
+            duration_seconds=3600,
+        )
+
+        item_merge.merge_item(loser, keeper)
+
+        self.assertTrue(ItemTag.objects.filter(item=keeper, tag=tag).exists())
+        self.assertTrue(CollectionEntry.objects.filter(item=keeper, user=self.user).exists())
+        loser_progress.refresh_from_db()
+        self.assertEqual(loser_progress.item_id, keeper.pk)
+
+    def test_playback_progress_collision_keeps_keepers_row(self):
+        loser = Item.objects.create(
+            media_id="1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Movie",
+            image="",
+        )
+        keeper = Item.objects.create(
+            media_id="2",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Movie",
+            image="",
+        )
+        PlaybackProgress.objects.create(
+            user=self.user,
+            item=loser,
+            position_seconds=60,
+            duration_seconds=3600,
+        )
+        keeper_progress = PlaybackProgress.objects.create(
+            user=self.user,
+            item=keeper,
+            position_seconds=900,
+            duration_seconds=3600,
+        )
+
+        item_merge.merge_item(loser, keeper)
+
+        self.assertEqual(PlaybackProgress.objects.filter(item=keeper).count(), 1)
+        keeper_progress.refresh_from_db()
+        self.assertEqual(keeper_progress.position_seconds, 900)
+
+
+class FindCrossProviderDuplicateTests(TestCase):
+    """Verified-identity lookup only - never title matching."""
+
+    def test_returns_none_for_non_tmdb_item(self):
+        item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        self.assertIsNone(item_merge.find_cross_provider_duplicate(item))
+
+    def test_returns_none_when_no_tvdb_counterpart_tracked(self):
+        item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+            provider_external_ids={"tvdb_id": "81189"},
+        )
+        self.assertIsNone(item_merge.find_cross_provider_duplicate(item))
+
+    def test_finds_verified_tvdb_counterpart_via_cached_id(self):
+        item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+            provider_external_ids={"tvdb_id": "81189"},
+        )
+        counterpart = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        self.assertEqual(
+            item_merge.find_cross_provider_duplicate(item).pk,
+            counterpart.pk,
+        )
+
+    def test_never_matches_purely_on_title(self):
+        """A same-titled TVDB item with no verified id link must not match."""
+        item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        Item.objects.create(
+            media_id="99999",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        with patch(
+            "app.services.item_merge.tmdb.resolve_tvdb_id_for_tmdb_show",
+            return_value=None,
+        ):
+            self.assertIsNone(item_merge.find_cross_provider_duplicate(item))
+
+
+class FindTvdbCounterpartTests(TestCase):
+    """`find_tvdb_counterpart` is the pre-creation lookup used by importers."""
+
+    def test_returns_none_for_non_tv_season_media_type(self):
+        result = item_merge.find_tvdb_counterpart(
+            "1",
+            MediaTypes.MOVIE.value,
+            library_media_type=MediaTypes.MOVIE.value,
+        )
+        self.assertIsNone(result)
+
+    @patch("app.services.item_merge.tmdb.resolve_tvdb_id_for_tmdb_show")
+    def test_finds_existing_tvdb_item(self, mock_resolve):
+        mock_resolve.return_value = "81189"
+        existing = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+
+        result = item_merge.find_tvdb_counterpart(
+            "1396",
+            MediaTypes.TV.value,
+            library_media_type=MediaTypes.TV.value,
+        )
+
+        self.assertEqual(result.pk, existing.pk)
+
+    @patch("app.services.item_merge.tmdb.resolve_tvdb_id_for_tmdb_show")
+    def test_returns_none_when_unresolvable(self, mock_resolve):
+        mock_resolve.return_value = None
+
+        result = item_merge.find_tvdb_counterpart(
+            "1396",
+            MediaTypes.TV.value,
+            library_media_type=MediaTypes.TV.value,
+        )
+
+        self.assertIsNone(result)

--- a/src/app/tests/test_merge_duplicate_provider_items.py
+++ b/src/app/tests/test_merge_duplicate_provider_items.py
@@ -1,0 +1,119 @@
+"""Tests for the merge_duplicate_provider_items repair command (#620)."""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+from app.models import TV, Item, MediaTypes, Sources, Status
+
+
+class MergeDuplicateProviderItemsTests(TestCase):
+    """A verified TMDB/TVDB duplicate pair is reported, then merged with --apply."""
+
+    def setUp(self):
+        """Create a user tracking the same show under both TMDB and TVDB."""
+        self.user = get_user_model().objects.create_user(
+            username="dup-tracker",
+            password="12345",
+        )
+        self.tmdb_item = Item.objects.create(
+            media_id="1396",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+            provider_external_ids={"tvdb_id": "81189"},
+        )
+        TV.objects.create(
+            item=self.tmdb_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.tvdb_item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        self.tvdb_enabled_patcher = patch(
+            "app.management.commands.merge_duplicate_provider_items.tvdb.enabled",
+            return_value=True,
+        )
+        self.tvdb_enabled_patcher.start()
+        self.addCleanup(self.tvdb_enabled_patcher.stop)
+
+    def test_dry_run_reports_without_writing(self):
+        """A dry run lists the proposed merge but changes nothing."""
+        out = StringIO()
+        call_command("merge_duplicate_provider_items", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Would merge", output)
+        self.assertIn("Breaking Bad", output)
+        self.assertTrue(Item.objects.filter(pk=self.tmdb_item.pk).exists())
+        self.assertTrue(Item.objects.filter(pk=self.tvdb_item.pk).exists())
+
+    @patch("app.models.tv.TV._start_next_available_season")
+    @patch("app.services.tv_provider_migration.tvdb.tv_with_seasons")
+    def test_apply_merges_the_duplicate(
+        self,
+        mock_tv_with_seasons,
+        _mock_start_next_season,
+    ):
+        """--apply merges the TMDB duplicate onto the existing TVDB item."""
+        mock_tv_with_seasons.return_value = {
+            "media_id": "81189",
+            "title": "Breaking Bad",
+            "image": "",
+        }
+
+        out = StringIO()
+        call_command("merge_duplicate_provider_items", "--apply", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Merged", output)
+        self.assertFalse(Item.objects.filter(pk=self.tmdb_item.pk).exists())
+        self.assertTrue(
+            TV.objects.filter(item=self.tvdb_item, user=self.user).exists(),
+        )
+
+    def test_skips_when_no_verified_counterpart(self):
+        """A show with no TVDB counterpart is left untouched and not counted."""
+        self.tvdb_item.delete()
+
+        out = StringIO()
+        call_command("merge_duplicate_provider_items", stdout=out)
+
+        self.assertIn("Would merge: 0", out.getvalue())
+        self.assertTrue(Item.objects.filter(pk=self.tmdb_item.pk).exists())
+
+    def test_username_filters_to_that_users_shows(self):
+        """--username scopes the check to shows tracked by that user."""
+        other_user = get_user_model().objects.create_user(
+            username="other",
+            password="12345",
+        )
+
+        out = StringIO()
+        call_command(
+            "merge_duplicate_provider_items",
+            f"--username={other_user.username}",
+            stdout=out,
+        )
+
+        self.assertIn("checking 0 TMDB TV item(s)", out.getvalue())
+
+    def test_skips_entirely_when_tvdb_not_configured(self):
+        """No candidates are examined when TVDB isn't configured."""
+        with patch(
+            "app.management.commands.merge_duplicate_provider_items.tvdb.enabled",
+            return_value=False,
+        ):
+            out = StringIO()
+            call_command("merge_duplicate_provider_items", stdout=out)
+
+        self.assertIn("not configured", out.getvalue())

--- a/src/app/tests/test_tv_provider_migration.py
+++ b/src/app/tests/test_tv_provider_migration.py
@@ -138,11 +138,81 @@ class TvProviderMigrationTests(TestCase):
         self.assertFalse(result.migrated)
 
     @patch("app.services.tv_provider_migration.tvdb.tv_with_seasons")
-    def test_pins_when_tvdb_identity_already_tracked_separately(
+    def test_merges_into_existing_tvdb_item_on_collision(
         self,
         mock_tv_with_seasons,
     ):
-        """Never create a duplicate show under an already-tracked TVDB identity."""
+        """A verified TVDB counterpart absorbs the TMDB duplicate instead of pinning."""
+        mock_tv_with_seasons.return_value = self._tvdb_payload()
+
+        existing_show = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+
+        tmdb_item_pk = self.show_item.pk
+        result = migrate_tv_item_to_tvdb(self.show_item)
+
+        self.assertTrue(result.migrated)
+        self.assertFalse(Item.objects.filter(pk=tmdb_item_pk).exists())
+        self.assertTrue(
+            TV.objects.filter(item=existing_show, user=self.user).exists(),
+        )
+        # Season/episode Items with no TVDB counterpart are re-keyed in place.
+        self.season_item.refresh_from_db()
+        self.episode_item.refresh_from_db()
+        self.assertEqual(self.season_item.source, Sources.TVDB.value)
+        self.assertEqual(self.episode_item.source, Sources.TVDB.value)
+        self.assertTrue(Episode.objects.filter(item=self.episode_item).exists())
+
+    @patch("app.services.tv_provider_migration.tvdb.tv_with_seasons")
+    def test_merge_folds_colliding_season_onto_its_tvdb_counterpart(
+        self,
+        mock_tv_with_seasons,
+    ):
+        """A season that also already exists under TVDB gets merged, not re-keyed."""
+        mock_tv_with_seasons.return_value = self._tvdb_payload()
+
+        existing_show = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        existing_season = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Breaking Bad",
+            image="",
+        )
+
+        season_item_pk = self.season_item.pk
+        result = migrate_tv_item_to_tvdb(self.show_item)
+
+        self.assertTrue(result.migrated)
+        self.assertFalse(Item.objects.filter(pk=season_item_pk).exists())
+        self.assertTrue(
+            Season.objects.filter(
+                item=existing_season,
+                related_tv=TV.objects.get(item=existing_show),
+            ).exists(),
+        )
+        self.episode_item.refresh_from_db()
+        self.assertEqual(self.episode_item.source, Sources.TVDB.value)
+
+    @patch("app.services.tv_provider_migration.tvdb.tv_with_seasons")
+    def test_pins_when_collision_and_structure_incompatible(
+        self,
+        mock_tv_with_seasons,
+    ):
+        """A structurally-incompatible collision still pins instead of merging."""
+        mock_tv_with_seasons.return_value = self._tvdb_payload(episode_numbers=(2, 3))
         Item.objects.create(
             media_id="81189",
             source=Sources.TVDB.value,
@@ -154,6 +224,6 @@ class TvProviderMigrationTests(TestCase):
         result = migrate_tv_item_to_tvdb(self.show_item)
 
         self.assertFalse(result.migrated)
-        mock_tv_with_seasons.assert_not_called()
         self.show_item.refresh_from_db()
+        self.assertEqual(self.show_item.source, Sources.TMDB.value)
         self.assertIsNotNone(self.show_item.metadata_migration_pinned_at)

--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -12,7 +12,8 @@ from simple_history.utils import bulk_update_with_history
 import app
 from app import helpers as app_helpers
 from app.models import MediaTypes, Sources, Status
-from app.providers import services
+from app.providers import services, tvdb
+from app.services import item_merge
 from integrations import import_progress
 from integrations.imports import helpers
 from integrations.imports.helpers import MediaImportError, MediaImportUnexpectedError
@@ -264,11 +265,47 @@ class TraktMetadataResolverMixin:
                     return item
             return existing[0]
 
+        preferred_provider_item = self._find_preferred_provider_item(
+            media_type,
+            tmdb_id,
+            season_number,
+            desired_bucket,
+        )
+        if preferred_provider_item is not None:
+            return preferred_provider_item
+
         return app.models.Item.objects.create(
             **item_kwargs,
             library_media_type=desired_bucket,
             **app.models.Item.title_fields_from_metadata(metadata),
             image=metadata["image"],
+        )
+
+    def _find_preferred_provider_item(
+        self,
+        media_type,
+        tmdb_id,
+        season_number,
+        desired_bucket,
+    ):
+        """Reuse an existing TVDB item instead of creating a duplicate TMDB one.
+
+        This importer only ever resolves shows/seasons via TMDB, so a
+        TVDB-preferring user who already tracks a show gets a second,
+        independent ``Item`` tree for it on every import unless we look for
+        their existing TVDB item first (#620). Scoped to users who actually
+        prefer TVDB, since the lookup costs a TMDB->TVDB id resolution call.
+        """
+        if getattr(self.user, "tv_metadata_source_default", "") != Sources.TVDB.value:
+            return None
+        if not tvdb.enabled():
+            return None
+
+        return item_merge.find_tvdb_counterpart(
+            tmdb_id,
+            media_type,
+            season_number=season_number,
+            library_media_type=desired_bucket,
         )
 
     def _get_episode_image(self, episode_number, season_metadata):

--- a/src/integrations/tests/imports/test_trakt.py
+++ b/src/integrations/tests/imports/test_trakt.py
@@ -2119,3 +2119,89 @@ class ImportTrakt(TestCase):
 
         mock_get_metadata.assert_not_called()
         self.assertEqual(TV.objects.filter(user=self.user).count(), 0)
+
+
+class ImportTraktPreferredProviderDedup(TestCase):
+    """A TVDB-preferring user's Trakt import must not create a duplicate Item (#620)."""
+
+    def setUp(self):
+        """Create a TVDB-preferring user with an existing TVDB-tracked show."""
+        self.user = get_user_model().objects.create_user(
+            username="tvdb-pref",
+            password="12345",
+        )
+        self.user.tv_metadata_source_default = Sources.TVDB.value
+        self.user.save()
+
+        self.existing_tv_item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="",
+        )
+        TV.objects.create(
+            item=self.existing_tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+
+    @patch("integrations.imports.trakt.item_merge.find_tvdb_counterpart")
+    @patch("integrations.imports.trakt.tvdb.enabled", return_value=True)
+    @patch("integrations.imports.trakt.TraktImporter._get_metadata")
+    def test_reuses_existing_tvdb_item_instead_of_creating_tmdb_duplicate(
+        self,
+        mock_get_metadata,
+        _mock_tvdb_enabled,
+        mock_find_tvdb_counterpart,
+    ):
+        """Importing a show the user already tracks via TVDB reuses that Item."""
+        mock_get_metadata.return_value = {
+            "title": "Breaking Bad",
+            "image": "tv_image.jpg",
+            "last_episode_season": 1,
+            "max_progress": 1,
+        }
+        mock_find_tvdb_counterpart.return_value = self.existing_tv_item
+
+        movie_entry = {
+            "type": "show",
+            "show": {"title": "Breaking Bad", "ids": {"tmdb": 1396}},
+            "watched_at": "2023-01-01T00:00:00.000Z",
+        }
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        tv_item = trakt_importer._get_or_create_item(
+            MediaTypes.TV.value,
+            "1396",
+            movie_entry["show"],
+        )
+
+        self.assertEqual(tv_item.pk, self.existing_tv_item.pk)
+        self.assertFalse(
+            Item.objects.filter(source=Sources.TMDB.value, media_id="1396").exists(),
+        )
+        mock_find_tvdb_counterpart.assert_called_once_with(
+            "1396",
+            MediaTypes.TV.value,
+            season_number=None,
+            library_media_type=MediaTypes.TV.value,
+        )
+
+    @patch("integrations.imports.trakt.item_merge.find_tvdb_counterpart")
+    def test_skips_lookup_for_tmdb_preferring_user(
+        self,
+        mock_find_tvdb_counterpart,
+    ):
+        """A TMDB-preferring user's import never pays for the TVDB lookup."""
+        self.user.tv_metadata_source_default = Sources.TMDB.value
+        self.user.save()
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        item = trakt_importer._get_or_create_item(
+            MediaTypes.TV.value,
+            "1396",
+            {"title": "Breaking Bad", "image": "tv_image.jpg"},
+        )
+
+        mock_find_tvdb_counterpart.assert_not_called()
+        self.assertEqual(item.source, Sources.TMDB.value)

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -1447,6 +1447,49 @@ def _item_matches_home_media_type(item: Item, media_type: str) -> bool:
     return media_type in (library_media_type, item.media_type)
 
 
+def _dedupe_cross_provider_items(items: list[Item], preferred_source: str) -> list[Item]:
+    """Collapse TV/season `Item`s that are a verified alias of another in the row.
+
+    Multi-provider imports can leave a TMDB and a TVDB `Item` both tracking
+    the same show/season until `app.services.tv_provider_migration` next
+    reconciles them (#620). This is a defense-in-depth guard for that
+    window: it hides the tile the user doesn't prefer using only the
+    already-cached `provider_external_ids["tvdb_id"]` mapping - never a
+    title match, and never a network call, so it can't misfire on
+    unrelated shows and can't slow down rendering.
+    """
+    tvdb_by_key = {
+        (item.media_id, item.media_type, item.season_number, item.library_media_type): item
+        for item in items
+        if item.source == Sources.TVDB.value
+        and item.media_type in (MediaTypes.TV.value, MediaTypes.SEASON.value)
+    }
+    if not tvdb_by_key:
+        return items
+
+    hidden_ids = set()
+    for item in items:
+        if (
+            item.source != Sources.TMDB.value
+            or item.media_type not in (MediaTypes.TV.value, MediaTypes.SEASON.value)
+        ):
+            continue
+        tvdb_id = (item.provider_external_ids or {}).get("tvdb_id")
+        if not tvdb_id:
+            continue
+        counterpart = tvdb_by_key.get(
+            (str(tvdb_id), item.media_type, item.season_number, item.library_media_type),
+        )
+        if counterpart is None:
+            continue
+        loser = item if preferred_source == Sources.TVDB.value else counterpart
+        hidden_ids.add(loser.id)
+
+    if not hidden_ids:
+        return items
+    return [item for item in items if item.id not in hidden_ids]
+
+
 def _annotate_home_card_images(media_items):
     """Annotate season cards with show-poster fallbacks when needed."""
     season_items = [
@@ -2230,6 +2273,10 @@ def _library_query_entries(user, row: HomeScreenRow) -> list[HomeRowEntry]:
         return []
 
     items = list(Item.objects.filter(id__in=item_ids))
+    items = _dedupe_cross_provider_items(
+        items,
+        getattr(user, "tv_metadata_source_default", Sources.TMDB.value),
+    )
     media_lookup = _media_lookup_for_items(
         user,
         items,

--- a/src/users/tests/views/test_home_screen.py
+++ b/src/users/tests/views/test_home_screen.py
@@ -1462,3 +1462,98 @@ class HomeScreenRandomSortTests(TestCase):
         direction = home_screen.resolve_home_row_direction(HomeSortChoices.RANDOM.value)
 
         self.assertIn(direction, DirectionChoices.values)
+
+
+class CrossProviderDedupTests(TestCase):
+    """Home rows must not show duplicate tiles for a verified TMDB/TVDB pair (#620)."""
+
+    def setUp(self):
+        self.credentials = {"username": "dedup-user", "password": "testpass123"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+
+    def _tv_pair(self):
+        tmdb_item = Item.objects.create(
+            title="Breaking Bad",
+            media_id="1396",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            image="",
+            provider_external_ids={"tvdb_id": "81189"},
+        )
+        tvdb_item = Item.objects.create(
+            title="Breaking Bad",
+            media_id="81189",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TVDB.value,
+            image="",
+        )
+        TV.objects.create(item=tmdb_item, user=self.user, status=Status.IN_PROGRESS.value)
+        TV.objects.create(item=tvdb_item, user=self.user, status=Status.IN_PROGRESS.value)
+        return tmdb_item, tvdb_item
+
+    def test_prefers_tvdb_item_for_tvdb_preferring_user(self):
+        tmdb_item, tvdb_item = self._tv_pair()
+
+        result = home_screen._dedupe_cross_provider_items(
+            [tmdb_item, tvdb_item],
+            Sources.TVDB.value,
+        )
+
+        self.assertEqual([item.pk for item in result], [tvdb_item.pk])
+
+    def test_prefers_tmdb_item_for_tmdb_preferring_user(self):
+        tmdb_item, tvdb_item = self._tv_pair()
+
+        result = home_screen._dedupe_cross_provider_items(
+            [tmdb_item, tvdb_item],
+            Sources.TMDB.value,
+        )
+
+        self.assertEqual([item.pk for item in result], [tmdb_item.pk])
+
+    def test_never_collapses_on_title_alone(self):
+        """Two unrelated items that merely share a title must both survive."""
+        remake_item = Item.objects.create(
+            title="Breaking Bad",
+            media_id="999999",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            image="",
+        )
+        tvdb_item = Item.objects.create(
+            title="Breaking Bad",
+            media_id="81189",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TVDB.value,
+            image="",
+        )
+
+        result = home_screen._dedupe_cross_provider_items(
+            [remake_item, tvdb_item],
+            Sources.TVDB.value,
+        )
+
+        self.assertCountEqual(
+            [item.pk for item in result],
+            [remake_item.pk, tvdb_item.pk],
+        )
+
+    def test_library_query_entries_returns_one_entry_for_verified_pair(self):
+        tmdb_item, tvdb_item = self._tv_pair()
+        self.user.tv_metadata_source_default = Sources.TVDB.value
+        self.user.save()
+
+        row = HomeScreenRow.objects.create(
+            user=self.user,
+            media_type=MediaTypes.TV.value,
+            position=0,
+            enabled=True,
+            row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+            sort_by=MediaSortChoices.TITLE,
+            direction=DirectionChoices.ASC,
+            filters={"status": [Status.IN_PROGRESS.value]},
+        )
+
+        entries = home_screen._library_query_entries(self.user, row)
+
+        self.assertEqual([entry.item.pk for entry in entries], [tvdb_item.pk])


### PR DESCRIPTION
## Summary
- Trakt (and mdblist, which shares the same import mixin) only ever resolves shows via TMDB, so a TVDB-preferring user who already tracks a show got a second, independent `Item` tree for it on every import - nothing reconciled the two, and Home/library rows rendered both as separate tiles.
- Added `app/services/item_merge.py`: a live merge core (repoint every FK, fold TV/Season rows onto their survivor, delete the loser) adapted from the `0148_merge_duplicate_item_buckets` data migration's bucket-merge logic, plus verified-identity lookups (TVDB id resolution only, never title matching - two shows sharing a title, e.g. a remake or reused title, must never collapse).
- `app/services/tv_provider_migration.py`: the nightly TMDB->TVDB migration now merges a duplicate onto its existing TVDB counterpart instead of pinning it.
- `integrations/imports/trakt.py`: TVDB-preferring users' imports now reuse their existing TVDB item instead of creating a new TMDB one (the actual root-cause fix).
- `app/management/commands/merge_duplicate_provider_items.py` (new): dry-run/`--apply` command to repair libraries that already accumulated duplicates.
- `users/home_screen.py`: defense-in-depth dedup on Home rows for the window before a merge runs, using only cached `provider_external_ids` - never title matching.

## AI Assistance
- Claude Sonnet 5 (`claude-sonnet-5`) planned and implemented this change.

## Validation
- `scripts/test.sh app.tests.test_item_merge app.tests.test_tv_provider_migration app.tests.test_tasks_tv_provider_migration app.tests.test_merge_duplicate_provider_items` - 29 tests, all pass.
- `scripts/test.sh integrations.tests.imports.test_trakt` - 49 tests, all pass.
- `scripts/test.sh users.tests.views.test_home_screen.CrossProviderDedupTests` - 4 tests, all pass.
- `ruff check` on all touched files - clean.
- `scripts/test.sh` (full fast suite, 3338 tests) - 31 pre-existing failures, all reproduced identically on the unmodified branch (confirmed via `git stash`); they're network-access errors (`ProxyError` reaching TMDB/MyAnimeList/etc.) from this sandbox, unrelated to this change.

## Notes
- Refs #620


---
_Generated by [Claude Code](https://claude.ai/code/session_016XdXZKQpkiQTzJXTmqasJF)_