### PR TITLE
Fix CI-only test failures caused by TVDB_API_KEY not being set

### DIFF
--- a/src/app/tests/providers/test_services.py
+++ b/src/app/tests/providers/test_services.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from app.models import Item, MediaTypes, Sources
 from app.providers import (
@@ -698,6 +698,7 @@ class ServicesTests(TestCase):
 
         mock_search.assert_called_once_with(MediaTypes.ANIME.value, "test", 1)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.tvdb.search")
     def test_search_anime_tvdb(self, mock_search):
         """Test the search function for anime via TVDB."""

--- a/src/app/tests/test_tasks_metadata_backfill.py
+++ b/src/app/tests/test_tasks_metadata_backfill.py
@@ -1058,6 +1058,7 @@ class MetadataBackfillTaskTests(TestCase):
         self.assertIn(comic.id, queued_ids)
         self.assertIn(manga.id, queued_ids)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     def test_genre_backfill_queryset_includes_tmdb_tv_until_current_version_marked(
         self,
     ):
@@ -1083,6 +1084,7 @@ class MetadataBackfillTaskTests(TestCase):
         queued_ids = set(tasks._genre_items_queryset().values_list("id", flat=True))
         self.assertNotIn(item.id, queued_ids)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.tasks_genre.enqueue_genre_backfill_items")
     def test_reconcile_genre_backfill_queues_current_candidates_on_startup(
         self,
@@ -1269,6 +1271,7 @@ class MetadataBackfillTaskTests(TestCase):
         )
         self.assertEqual(result, {"selected": 1, "enqueued": 1})
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_adds_anime_from_tvdb_mapping(
         self,
@@ -1318,6 +1321,7 @@ class MetadataBackfillTaskTests(TestCase):
         self.assertEqual(result["errors"], 0)
         self.assertEqual(state.strategy_version, tasks.GENRE_BACKFILL_VERSION)
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_non_anime_marks_strategy_current(
         self,
@@ -1371,6 +1375,7 @@ class MetadataBackfillTaskTests(TestCase):
             set(tasks._genre_items_queryset().values_list("id", flat=True)),
         )
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_discovers_tvdb_mapping_from_tmdb_metadata(
         self,
@@ -1465,6 +1470,7 @@ class MetadataBackfillTaskTests(TestCase):
             item.source,
         )
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.services.get_media_metadata")
     def test_populate_genre_data_for_tmdb_tv_records_failure_on_tvdb_error(
         self,

--- a/src/integrations/tests/test_plex_import_logic.py
+++ b/src/integrations/tests/test_plex_import_logic.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from app.models import (
@@ -342,6 +342,7 @@ class TestPlexHybridImport(TestCase):
         self.assertEqual(episode.item.media_id, "1515183")
         self.assertEqual(episode.item.title, "Yellowstone")
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.tvdb.tv_with_seasons")
     @patch("integrations.imports.plex.app.providers.tvdb.enabled", return_value=True)
     def test_new_tv_show_genesis_uses_tvdb_when_preferred(

--- a/src/integrations/tests/test_webhooks_plex.py
+++ b/src/integrations/tests/test_webhooks_plex.py
@@ -1305,6 +1305,7 @@ class PlexWebhookTests(TestCase):
         season_item.refresh_from_db()
         self.assertEqual(season_item.provider_metadata_status, "")
 
+    @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.providers.tvdb.tv_with_seasons")
     @patch("app.providers.tmdb.tv_with_seasons")
     def test_tv_episode_genesis_uses_tvdb_when_preferred(


### PR DESCRIPTION
## Summary
- `latest`'s CI (`app-tests.yml`, `test (3.12)`) has been red for two days: the workflow never forwards a `TVDB_API_KEY` secret, so `settings.TVDB_API_KEY` defaults to `""` and `app.providers.tvdb.enabled()` returns `False` in CI.
- Several tests assumed TVDB was enabled but didn't set `@override_settings(TVDB_API_KEY=...)` (the established pattern used elsewhere, e.g. `test_tvdb.py`, `test_metadata.py`). Without it, `app.providers.services._resolve_search_source()` silently falls back from TVDB to TMDB, and since TMDB *is* configured in CI, the tests' TVDB-only mocks never intercept — the code made real, unmocked TMDB network calls instead, producing wrong/nondeterministic results in CI while passing locally (where devs typically have `TVDB_API_KEY` set).
- Added `@override_settings(TVDB_API_KEY="test-tvdb-key")` to each affected test so the TVDB code path is actually exercised and the existing mocks intercept as intended. Test-only fix — no `.env`/CI secret changes; CI never needs real TVDB credentials since the provider calls are already mocked.

## Validation
- Reproduced CI exactly by unsetting `TVDB_API_KEY` locally and running the targeted modules (`app.tests.providers.test_services`, `app.tests.test_tasks_metadata_backfill`, `integrations.tests.test_plex_import_logic`, `integrations.tests.test_webhooks_plex`): all 9 previously-failing tests failed pre-fix and pass post-fix (178/178 tests in these modules pass).
- Ran the full fast suite (`scripts/test.sh`, 3264 tests): 32 pre-existing failures remain (jellyfin/fork-scrobble tests failing on sandbox network/proxy restrictions), confirmed identical with and without this fix — unrelated to TVDB.
- Could not validate `app.tests.test_integration.IntegrationTest.test_season_completed` locally due to a Playwright browser-version mismatch in the sandbox unrelated to this fix; CI runs `playwright install` so this shouldn't be affected, but worth a spot-check on the next CI run.
- Verified the branch merges cleanly into `latest` with no conflicts.

## Notes
- Refs the Baseline Zero Policy in `AGENTS.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013pjDb6VU7sWKzZj6uQXtEq)_