### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of this project seriously. 
+
+* **Primary Channel:** If you discover a sensitive security vulnerability, please report it privately via a **GitHub Security Advisory**. Please do not open public GitHub Issues or public Discord threads for security vulnerabilities.
+* **Secondary Channel:** For sensitive matters where GitHub Advisories are not feasible, you may Direct Message (DM) the maintainers on our Discord server.
+
+## Urgent Inquiries
+
+For urgent but non-sensitive matters, general questions, and immediate assistance requests, please reach out to our community Discord Channel: [https://discord.gg/sqyZUU37ZY](https://discord.gg/sqyZUU37ZY).
+
+## Contributing Security Fixes
+
+We highly encourage developers to submit Pull Requests for security patches!
+
+When contributing a security fix, please ensure that your contribution is accompanied by ample testing to prevent future regressions. Follow the guidelines outlined in our [CONTRIBUTING.md](CONTRIBUTING.md) guide for testing and development setup.


### PR DESCRIPTION
Sets up a Security Policy for Floppy. Instructs users to use GitHub Security Advisories or Discord DMs for sensitive issues, directs urgent inquiries to the community Discord, and encourages testing via CONTRIBUTING.md.