### PR TITLE
perf: defer first-run context query

### DIFF
--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -1,6 +1,7 @@
 # https://docs.djangoproject.com/en/stable/ref/templates/api/#writing-your-own-context-processors
 
 from django.conf import settings
+from django.utils.functional import SimpleLazyObject
 
 from app.models import MediaTypes, Sources, Status
 from users.helpers import is_first_run
@@ -15,7 +16,7 @@ def export_vars(request):
         "TRACK_TIME": settings.TRACK_TIME,
         "FORK_OWNER_NAME": settings.FORK_OWNER_NAME,
         "FORK_OWNER_URL": settings.FORK_OWNER_URL,
-        "IS_FIRST_RUN": is_first_run(),
+        "IS_FIRST_RUN": SimpleLazyObject(is_first_run),
     }
 
 


### PR DESCRIPTION
## Problem

Global template context evaluation calls `is_first_run()` on every cold-cache request, even though only login and signup templates use the value. That added one database query and broke three established query budgets on `latest`, blocking documentation-only PR #651.

Refs #645.

## Solution

Wrap the existing helper with Django `SimpleLazyObject` at the context-processor boundary. The helper, cache policy, templates, and query budgets remain unchanged; the database lookup now occurs only when a template evaluates `IS_FIRST_RUN`.

## Validation

- `floppy-web-dev`: 11 targeted query-budget, first-run helper, and signup tests passed.
- `ruff check src/app/context_processors.py` passed.
- `git diff --check origin/latest..HEAD` passed.
- Independent spec review, code-quality review, and final whole-change review found no issues.
- A local fast-suite attempt was not a clean offline signal: 14 unrelated provider/webhook tests made live provider calls or lost fixture state under parallel execution. The changed query/signup/helper tests passed; normal PR CI remains the authoritative full-suite gate.

## Screenshots

Not applicable; backend-only context evaluation change.

## AI Assistance

Generated with OpenAI Codex (GPT-5.6 Luna implementation; GPT-5 parent integration and review).