### PR TITLE
ci: skip app tests for documentation-only PRs

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - ".github/workflows/**"
+      - "**/*.md"
+      - "docs/**"
   push:
     branches:
       - latest


### PR DESCRIPTION
## Problem

The App Tests workflow installs browser/dependency tooling and runs the full application suite even when a pull request changes only documentation. The current suite takes about 20 minutes and cannot validate Markdown or files under `docs/`. Its unrelated failures also obscure the useful documentation review signal.

Related CI signal: #390. Upstream-resolution programme: #645.

## Solution

Add native pull-request `paths-ignore` entries for:

- `**/*.md`
- `docs/**`

GitHub starts the workflow when any changed file is not ignored, so mixed documentation-plus-application PRs remain covered. Pushes to `latest`/`release`, manual runs, workflow-file protections, and every existing job/step are unchanged.

## Validation

- `actionlint .github/workflows/app-tests.yml`
- docs-only path simulation: ignored
- mixed `docs/` plus `src/` path simulation: workflow starts
- `git diff --check`
- independent specification review: pass
- independent release-safety review: ready

No application tests were run because this one-file change only controls when that suite starts.

## Limitations

GitHub evaluates path filters against at most the first 3,000 changed files. If PRs of that size become realistic, replace this trigger-only filter with an always-running lightweight classifier. If App Tests later becomes a required check, its skipped-check behavior must also be accounted for in the ruleset design.

## Screenshots

Not applicable; no user interface changes.

## AI assistance

Prepared with OpenAI Codex (GPT-5.6 Luna implementation; GPT-5 parent integration and independent reviews).