### PR TITLE
ci: run checks from locked uv environment

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -51,91 +51,21 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Dependencies
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.3"
+
+      - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-          playwright install
-
-      - name: Ruff
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          IS_PR: ${{ github.event_name == 'pull_request' }}
-        run: |
-          if [ "$IS_PR" != "true" ]; then
-            echo "Not a pull request - running full check."
-            ruff check src
-            exit $?
-          fi
-          python - <<'PY'
-          import json, os, re, subprocess, sys
-
-          base, head = os.environ["BASE_SHA"], os.environ["HEAD_SHA"]
-
-          # Lines added/modified by this PR, per file.
-          diff = subprocess.run(
-              ["git", "diff", "--unified=0", f"{base}...{head}", "--", "src"],
-              capture_output=True, text=True, check=True,
-          ).stdout
-
-          changed: dict[str, set[int]] = {}
-          path = None
-          hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
-          for line in diff.splitlines():
-              if line.startswith("+++ b/"):
-                  path = line[6:]
-              elif line.startswith("@@") and path:
-                  m = hunk.match(line)
-                  if m:
-                      start = int(m.group(1))
-                      count = int(m.group(2) or 1)
-                      changed.setdefault(path, set()).update(
-                          range(start, start + count)
-                      )
-
-          changed = {p: lines for p, lines in changed.items() if p.endswith(".py")}
-
-          if not changed:
-              print("No changed Python lines under src/ - nothing to lint.")
-              sys.exit(0)
-
-          proc = subprocess.run(
-              ["ruff", "check", "src", "--output-format=json", "--no-cache"],
-              capture_output=True, text=True,
-          )
-          if proc.returncode not in (0, 1):
-              sys.stderr.write(proc.stderr)
-              sys.exit(proc.returncode)
-          diagnostics = json.loads(proc.stdout or "[]")
-
-          repo = os.getcwd()
-          offending = []
-          for d in diagnostics:
-              rel = os.path.relpath(d["filename"], repo)
-              row = (d.get("location") or {}).get("row")
-              if row is not None and row in changed.get(rel, ()):
-                  offending.append((rel, row, d["code"], d["message"]))
-
-          total = len(diagnostics)
-          print(f"{total} violations exist in src/; gating on changed lines only.")
-
-          if offending:
-              print(f"\n{len(offending)} violation(s) on lines this PR changed:\n")
-              for rel, row, code, msg in sorted(offending):
-                  print(f"  {rel}:{row}: {code} {msg}")
-              sys.exit(1)
-
-          print("No violations on changed lines.")
-          PY
+          uv sync --locked --no-default-groups --group test
+          uv run --no-sync playwright install
 
       - name: Set environment variables from secrets
         run: |
@@ -145,7 +75,7 @@ jobs:
           # the only variable settings.py treats as mandatory, so fall back to an
           # ephemeral one: nothing signed during a test run outlives the job.
           if [ -z "${{ secrets.SECRET }}" ]; then
-            echo "SECRET=$(python -c 'import secrets; print(secrets.token_urlsafe(50))')" >> $GITHUB_ENV
+            echo "SECRET=$(uv run --no-sync python -c 'import secrets; print(secrets.token_urlsafe(50))')" >> $GITHUB_ENV
           fi
           if [ -n "${{ secrets.TMDB_API }}" ]; then echo "TMDB_API=${{ secrets.TMDB_API }}" >> $GITHUB_ENV; fi
           if [ -n "${{ secrets.MAL_API }}" ]; then echo "MAL_API=${{ secrets.MAL_API }}" >> $GITHUB_ENV; fi
@@ -160,14 +90,15 @@ jobs:
           # flaky, and a pull request from a fork cannot read repository secrets,
           # so they fail there regardless of the change. Run them deliberately
           # with scripts/test.sh --network.
-          coverage run src/manage.py test app users integrations lists events \
+          uv run --no-sync coverage run src/manage.py test \
+            app users integrations lists events \
             --parallel --exclude-tag network
 
       - name: Build Coverage Report
         run: |
-          coverage combine
-          coverage report
-          coverage xml
+          uv run --no-sync coverage combine
+          uv run --no-sync coverage report
+          uv run --no-sync coverage xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,111 @@
+name: Lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/**"
+  push:
+    branches:
+      - latest
+      - release
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.3"
+
+      - name: Check dependency lock
+        run: uv lock --check
+
+      - name: Install lint dependencies
+        run: uv sync --locked --only-group lint
+
+      - name: Ruff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$IS_PR" != "true" ]; then
+            echo "Not a pull request - running full check."
+            uv run --no-sync ruff check src
+            exit $?
+          fi
+          uv run --no-sync python - <<'PY'
+          import json, os, re, subprocess, sys
+
+          base, head = os.environ["BASE_SHA"], os.environ["HEAD_SHA"]
+
+          # Lines added/modified by this PR, per file.
+          diff = subprocess.run(
+              ["git", "diff", "--unified=0", f"{base}...{head}", "--", "src"],
+              capture_output=True, text=True, check=True,
+          ).stdout
+
+          changed: dict[str, set[int]] = {}
+          path = None
+          hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+          for line in diff.splitlines():
+              if line.startswith("+++ b/"):
+                  path = line[6:]
+              elif line.startswith("@@") and path:
+                  m = hunk.match(line)
+                  if m:
+                      start = int(m.group(1))
+                      count = int(m.group(2) or 1)
+                      changed.setdefault(path, set()).update(
+                          range(start, start + count)
+                      )
+
+          changed = {p: lines for p, lines in changed.items() if p.endswith(".py")}
+
+          if not changed:
+              print("No changed Python lines under src/ - nothing to lint.")
+              sys.exit(0)
+
+          proc = subprocess.run(
+              ["ruff", "check", "src", "--output-format=json", "--no-cache"],
+              capture_output=True, text=True,
+          )
+          if proc.returncode not in (0, 1):
+              sys.stderr.write(proc.stderr)
+              sys.exit(proc.returncode)
+          diagnostics = json.loads(proc.stdout or "[]")
+
+          repo = os.getcwd()
+          offending = []
+          for d in diagnostics:
+              rel = os.path.relpath(d["filename"], repo)
+              row = (d.get("location") or {}).get("row")
+              if row is not None and row in changed.get(rel, ()):
+                  offending.append((rel, row, d["code"], d["message"]))
+
+          total = len(diagnostics)
+          print(f"{total} violations exist in src/; gating on changed lines only.")
+
+          if offending:
+              print(f"\n{len(offending)} violation(s) on lines this PR changed:\n")
+              for rel, row, code, msg in sorted(offending):
+                  print(f"  {rel}:{row}: {code} {msg}")
+              sys.exit(1)
+
+          print("No violations on changed lines.")
+          PY


### PR DESCRIPTION
## Summary

- install uv 0.12.3 through setup-uv v9.0.0 pinned to its immutable commit
- run App Tests from the locked runtime plus test group, preserving Playwright, fork-secret fallback, application scope, network exclusion, parallelism, coverage, and Codecov
- move the existing changed-line Ruff gate into a standalone workflow that installs only the lint group
- fail lock drift without weakening the workflow-change guard

## Stack

Layer B of #647, based on PR #663 and PR #656. This PR intentionally changes only GitHub workflow files, so App Tests and Lint remain excluded on this PR by the repository workflow-only policy. The next non-workflow layer will exercise both updated workflows.

## Upstream attribution

Adapted from FuzzyGrim/Yamtrack commits e6765fa6 and 368fc461. Floppy pins both the setup action and uv version, preserves changed-line Ruff policy and fork-secret fallback, keeps network tests excluded, and installs lint-only without loading Floppy runtime or MCP packages.

## Verification

- actionlint across both workflows
- Bash syntax validation for every run block
- workflow structure and pure/mixed path-filter simulations
- uv 0.12.3 lock check
- isolated runtime plus test sync and Playwright CLI resolution
- isolated lint-only sync proved Django, Floppy/MCP, coverage, and pytest-django absent
- independent specification review: PASS
- independent quality review: READY after lint-only fix

Known baseline: the existing full Ruff push/manual path reports D205 in src/app/middleware.py; the previous App Tests workflow ran the same full policy on those triggers, so this PR does not introduce that failure.

Closes #659
Part of #647
Stacked on #663 and #656