### PR TITLE
test(providers): update Hardcover call expectation

### DIFF
--- a/src/app/tests/providers/test_services.py
+++ b/src/app/tests/providers/test_services.py
@@ -685,7 +685,7 @@ class ServicesTests(TestCase):
 
         self.assert_metadata_title_payload(result, "Test Hardcover Book")
 
-        mock_book.assert_called_once_with("1")
+        mock_book.assert_called_once_with("1", edition_id=None)
 
     @patch("app.providers.mal.search")
     def test_search_anime(self, mock_search):


### PR DESCRIPTION
## Summary

- update the Hardcover service mock to expect the explicit `edition_id=None` argument already sent by the runtime
- keep runtime behavior unchanged

## AI Assistance

- `gpt-5.6` implemented and reviewed this one-line test-maintenance change through independent specification and quality passes.

## Validation

- red before: expected `book("1")`; actual `book("1", edition_id=None)`
- green after: `ServicesTests.test_get_media_metadata_hardcover_book` passed under Python 3.12
- Ruff passed on `src/app/tests/providers/test_services.py`
- `git diff --check` passed
- independent specification review: PASS
- independent quality review: READY

## Notes

Closes #666.

This is independent of the uv stack. It unblocks #658 / PR #663 from receiving a clean unchanged application-suite signal.