### PR TITLE
fix(deps): update aiohttp security patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.14.1
+aiohttp==3.14.3
 apprise==1.9.9
 beautifulsoup4==4.14.3
 celery==5.6.3


### PR DESCRIPTION
## Summary
- Update only `aiohttp` from 3.14.1 to 3.14.3.
- Clear PYSEC-2026-3545, PYSEC-2026-3546, and PYSEC-2026-3547 without changing the remaining dependency surface.

## AI Assistance
- `gpt-5.6` substantially shaped the change, verification, and PR evidence.

## Security evidence
- The same `pip-audit` check reports 3 advisories on the parent and 0 on this commit.
- 3.14.3 is the minimum release that fixes all three tracked advisories.
- Python 3.12 musllinux binary resolution passed.

## Validation
- Repository pip-audit pre-commit hook: passed.
- Focused MangaUpdates and Open Library provider tests: 4 passed.
- Gstack-QA: passed, 100/100 health and 100/100 change-scope across login, signup, password recovery, public info, and health routes; no console errors.
- `git diff --check`: passed.

## Review gates
- Human reviewed: Pending maintainer review.
- Gstack-QA: Passed.

## Migration Sync Gate
- Not applicable: this is an independent one-line security patch, not an upstream-to-latest sync.

## Notes
- Closes #670.
- Blocks #660 until this patch is represented in the shared uv lock.
- Independent from the stacked uv pull requests and safe to review or merge separately.
