### PR TITLE
Dedupe cross-provider episode duplicates on the Calendar (#639)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ TODO.txt
 .env.dev
 docker-compose.dev.yml
 db-dev/
+src/local_serve.py
 
 # Local dev DB
 db/

--- a/src/app/services/item_merge.py
+++ b/src/app/services/item_merge.py
@@ -242,3 +242,58 @@ def find_cross_provider_duplicate(item: Item) -> Item | None:
         season_number=item.season_number,
         library_media_type=item.library_media_type,
     ).first()
+
+
+def dedupe_cross_provider_items(items: list[Item], preferred_source: str) -> list[Item]:
+    """Collapse TV/season `Item`s that are a verified alias of another in the list.
+
+    Multi-provider imports can leave a TMDB and a TVDB `Item` both tracking
+    the same show/season until `app.services.tv_provider_migration` next
+    reconciles them (#620), and a user may legitimately track a show under
+    both identities on purpose - in which case both trees stay, and only the
+    non-preferred one should be hidden from render-time listings (#639).
+    This hides the item the user doesn't prefer using only the already-cached
+    `provider_external_ids["tvdb_id"]` mapping - never a title match, and
+    never a network call, so it can't misfire on unrelated shows and can't
+    slow down rendering.
+    """
+    tvdb_by_key = {
+        (
+            item.media_id,
+            item.media_type,
+            item.season_number,
+            item.library_media_type,
+        ): item
+        for item in items
+        if item.source == Sources.TVDB.value
+        and item.media_type in (MediaTypes.TV.value, MediaTypes.SEASON.value)
+    }
+    if not tvdb_by_key:
+        return items
+
+    hidden_ids = set()
+    for item in items:
+        if item.source != Sources.TMDB.value or item.media_type not in (
+            MediaTypes.TV.value,
+            MediaTypes.SEASON.value,
+        ):
+            continue
+        tvdb_id = (item.provider_external_ids or {}).get("tvdb_id")
+        if not tvdb_id:
+            continue
+        counterpart = tvdb_by_key.get(
+            (
+                str(tvdb_id),
+                item.media_type,
+                item.season_number,
+                item.library_media_type,
+            ),
+        )
+        if counterpart is None:
+            continue
+        loser = item if preferred_source == Sources.TVDB.value else counterpart
+        hidden_ids.add(loser.id)
+
+    if not hidden_ids:
+        return items
+    return [item for item in items if item.id not in hidden_ids]

--- a/src/events/models.py
+++ b/src/events/models.py
@@ -15,7 +15,8 @@ from django.db.models import (
 from django.utils import timezone
 
 from app import config
-from app.models import TV, Item, MediaTypes, Season, Status
+from app.models import TV, Item, MediaTypes, Season, Sources, Status
+from app.services.item_merge import dedupe_cross_provider_items
 
 # Statuses that represent inactive tracking
 # will be ignored when creating events
@@ -75,7 +76,68 @@ class EventManager(models.Manager):
             datetime__lte=end_datetime,
         ).select_related("item")
 
+        hidden_item_ids = self._cross_provider_hidden_season_item_ids(
+            user,
+            enabled_types,
+        )
+        if hidden_item_ids:
+            queryset = queryset.exclude(item_id__in=hidden_item_ids)
+
         return self.sort_with_sentinel_last(queryset)
+
+    def _active_tv_show_media_ids(self, user):
+        """Return media_ids of the user's actively-tracked TV shows."""
+        return (
+            TV.objects.filter(
+                user=user,
+                item__media_type=MediaTypes.TV.value,
+            )
+            .exclude(
+                status__in=INACTIVE_TRACKING_STATUSES,
+            )
+            .values_list("item__media_id", flat=True)
+        )
+
+    def _cross_provider_hidden_season_item_ids(self, user, enabled_types):
+        """Return Season `Item` ids to hide because a preferred counterpart exists.
+
+        A user can legitimately track the same show under both a TMDB and a
+        TVDB identity (the #620 dual-identity model); each identity gets its
+        own independent Season `Item`s and `Event`s. Without this, the
+        calendar shows the same real episode twice - once per identity
+        (#639). Uses the same verified `provider_external_ids["tvdb_id"]`
+        based dedup already used for Home rows.
+        """
+        if not (
+            MediaTypes.TV.value in enabled_types
+            or MediaTypes.SEASON.value in enabled_types
+        ):
+            return set()
+
+        active_tv_shows = self._active_tv_show_media_ids(user)
+        if not active_tv_shows:
+            return set()
+
+        season_items = list(
+            Item.objects.filter(
+                media_type=MediaTypes.SEASON.value,
+                media_id__in=active_tv_shows,
+            ),
+        )
+        if not season_items:
+            return set()
+
+        preferred_source = getattr(
+            user,
+            "tv_metadata_source_default",
+            Sources.TMDB.value,
+        )
+        deduped = dedupe_cross_provider_items(season_items, preferred_source)
+        if len(deduped) == len(season_items):
+            return set()
+
+        kept_ids = {item.id for item in deduped}
+        return {item.id for item in season_items if item.id not in kept_ids}
 
     def _build_tv_query(self, user, enabled_types):
         """Build query for TV shows based on TV status and season statuses."""
@@ -86,16 +148,7 @@ class EventManager(models.Manager):
             return Q()
 
         # Get active TV shows
-        active_tv_shows = (
-            TV.objects.filter(
-                user=user,
-                item__media_type=MediaTypes.TV.value,
-            )
-            .exclude(
-                status__in=INACTIVE_TRACKING_STATUSES,
-            )
-            .values_list("item__media_id", flat=True)
-        )
+        active_tv_shows = self._active_tv_show_media_ids(user)
 
         if not active_tv_shows:
             return Q()

--- a/src/events/tests/test_models.py
+++ b/src/events/tests/test_models.py
@@ -301,3 +301,169 @@ class EventManagerTests(TestCase):
             self.past_event,
             limited_events,
         )  # Past event, but filtered by active status
+
+
+class EventManagerCrossProviderDedupTests(TestCase):
+    """The calendar must not show the same real episode twice (#639)."""
+
+    def setUp(self):
+        self.credentials = {"username": "dedup-cal-user", "password": "testpass123"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+
+    def _tv_pair(self, tvdb_id="81189"):
+        """Create a show tracked under both a TMDB and a verified TVDB identity."""
+        tmdb_show = Item.objects.create(
+            title="Breaking Bad",
+            media_id="1396",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            image="",
+            provider_external_ids={"tvdb_id": tvdb_id},
+        )
+        tvdb_show = Item.objects.create(
+            title="Breaking Bad",
+            media_id=tvdb_id,
+            media_type=MediaTypes.TV.value,
+            source=Sources.TVDB.value,
+            image="",
+        )
+        TV.objects.create(
+            item=tmdb_show,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        TV.objects.create(
+            item=tvdb_show,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+
+        tmdb_season = Item.objects.create(
+            title="Breaking Bad",
+            media_id="1396",
+            media_type=MediaTypes.SEASON.value,
+            source=Sources.TMDB.value,
+            image="",
+            season_number=1,
+            provider_external_ids={"tvdb_id": tvdb_id},
+        )
+        tvdb_season = Item.objects.create(
+            title="Breaking Bad",
+            media_id=tvdb_id,
+            media_type=MediaTypes.SEASON.value,
+            source=Sources.TVDB.value,
+            image="",
+            season_number=1,
+        )
+        return tmdb_season, tvdb_season
+
+    def test_get_user_events_hides_non_preferred_duplicate(self):
+        tmdb_season, tvdb_season = self._tv_pair()
+        when = timezone.now() + datetime.timedelta(days=1)
+        tmdb_event = Event.objects.create(
+            item=tmdb_season,
+            content_number=1,
+            datetime=when,
+        )
+        tvdb_event = Event.objects.create(
+            item=tvdb_season,
+            content_number=1,
+            datetime=when,
+        )
+        self.user.tv_metadata_source_default = Sources.TMDB.value
+        self.user.save(update_fields=["tv_metadata_source_default"])
+
+        events = Event.objects.get_user_events(self.user, when.date(), when.date())
+
+        self.assertEqual(list(events), [tmdb_event])
+        self.assertNotIn(tvdb_event, events)
+
+    def test_get_user_events_follows_preferred_source_switch(self):
+        tmdb_season, tvdb_season = self._tv_pair()
+        when = timezone.now() + datetime.timedelta(days=1)
+        tmdb_event = Event.objects.create(
+            item=tmdb_season,
+            content_number=1,
+            datetime=when,
+        )
+        tvdb_event = Event.objects.create(
+            item=tvdb_season,
+            content_number=1,
+            datetime=when,
+        )
+        self.user.tv_metadata_source_default = Sources.TVDB.value
+        self.user.save(update_fields=["tv_metadata_source_default"])
+
+        events = Event.objects.get_user_events(self.user, when.date(), when.date())
+
+        self.assertEqual(list(events), [tvdb_event])
+        self.assertNotIn(tmdb_event, events)
+
+    def test_get_user_events_keeps_unrelated_shows_sharing_a_title(self):
+        """Two unrelated shows sharing a title but no verified tvdb link both survive."""
+        remake_show = Item.objects.create(
+            title="Breaking Bad",
+            media_id="999999",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            image="",
+        )
+        remake_season = Item.objects.create(
+            title="Breaking Bad",
+            media_id="999999",
+            media_type=MediaTypes.SEASON.value,
+            source=Sources.TMDB.value,
+            image="",
+            season_number=1,
+        )
+        tvdb_show = Item.objects.create(
+            title="Breaking Bad",
+            media_id="81189",
+            media_type=MediaTypes.TV.value,
+            source=Sources.TVDB.value,
+            image="",
+        )
+        tvdb_season = Item.objects.create(
+            title="Breaking Bad",
+            media_id="81189",
+            media_type=MediaTypes.SEASON.value,
+            source=Sources.TVDB.value,
+            image="",
+            season_number=1,
+        )
+        TV.objects.create(
+            item=remake_show,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        TV.objects.create(
+            item=tvdb_show,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        when = timezone.now() + datetime.timedelta(days=1)
+        remake_event = Event.objects.create(
+            item=remake_season,
+            content_number=1,
+            datetime=when,
+        )
+        tvdb_event = Event.objects.create(
+            item=tvdb_season,
+            content_number=1,
+            datetime=when,
+        )
+
+        events = Event.objects.get_user_events(self.user, when.date(), when.date())
+
+        self.assertCountEqual(list(events), [remake_event, tvdb_event])
+
+    def test_get_user_events_stays_a_queryset_for_media_type_filtering(self):
+        """download_calendar chains a media-type filter after get_user_events."""
+        tmdb_season, _tvdb_season = self._tv_pair()
+        when = timezone.now() + datetime.timedelta(days=1)
+        Event.objects.create(item=tmdb_season, content_number=1, datetime=when)
+
+        events = Event.objects.get_user_events(self.user, when.date(), when.date())
+        filtered = events.filter(item__media_type__in=[MediaTypes.SEASON.value])
+
+        self.assertEqual(filtered.count(), 1)

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -29,6 +29,7 @@ from app.models import (
     prefill_episode_runtime_index,
 )
 from app.release_years import prefill_display_release_years
+from app.services.item_merge import dedupe_cross_provider_items
 from app.templatetags import app_tags
 from lists import smart_rules
 from lists.models import CustomList
@@ -1447,49 +1448,6 @@ def _item_matches_home_media_type(item: Item, media_type: str) -> bool:
     return media_type in (library_media_type, item.media_type)
 
 
-def _dedupe_cross_provider_items(items: list[Item], preferred_source: str) -> list[Item]:
-    """Collapse TV/season `Item`s that are a verified alias of another in the row.
-
-    Multi-provider imports can leave a TMDB and a TVDB `Item` both tracking
-    the same show/season until `app.services.tv_provider_migration` next
-    reconciles them (#620). This is a defense-in-depth guard for that
-    window: it hides the tile the user doesn't prefer using only the
-    already-cached `provider_external_ids["tvdb_id"]` mapping - never a
-    title match, and never a network call, so it can't misfire on
-    unrelated shows and can't slow down rendering.
-    """
-    tvdb_by_key = {
-        (item.media_id, item.media_type, item.season_number, item.library_media_type): item
-        for item in items
-        if item.source == Sources.TVDB.value
-        and item.media_type in (MediaTypes.TV.value, MediaTypes.SEASON.value)
-    }
-    if not tvdb_by_key:
-        return items
-
-    hidden_ids = set()
-    for item in items:
-        if (
-            item.source != Sources.TMDB.value
-            or item.media_type not in (MediaTypes.TV.value, MediaTypes.SEASON.value)
-        ):
-            continue
-        tvdb_id = (item.provider_external_ids or {}).get("tvdb_id")
-        if not tvdb_id:
-            continue
-        counterpart = tvdb_by_key.get(
-            (str(tvdb_id), item.media_type, item.season_number, item.library_media_type),
-        )
-        if counterpart is None:
-            continue
-        loser = item if preferred_source == Sources.TVDB.value else counterpart
-        hidden_ids.add(loser.id)
-
-    if not hidden_ids:
-        return items
-    return [item for item in items if item.id not in hidden_ids]
-
-
 def _annotate_home_card_images(media_items):
     """Annotate season cards with show-poster fallbacks when needed."""
     season_items = [
@@ -2276,7 +2234,7 @@ def _library_query_entries(
         return []
 
     items = list(Item.objects.filter(id__in=item_ids))
-    items = _dedupe_cross_provider_items(
+    items = dedupe_cross_provider_items(
         items,
         getattr(user, "tv_metadata_source_default", Sources.TMDB.value),
     )

--- a/src/users/tests/views/test_home_screen.py
+++ b/src/users/tests/views/test_home_screen.py
@@ -23,6 +23,7 @@ from app.models import (
     Status,
     Tag,
 )
+from app.services.item_merge import dedupe_cross_provider_items
 from lists import smart_rules
 from lists.models import CustomList
 from users import home_screen
@@ -1621,7 +1622,7 @@ class CrossProviderDedupTests(TestCase):
     def test_prefers_tvdb_item_for_tvdb_preferring_user(self):
         tmdb_item, tvdb_item = self._tv_pair()
 
-        result = home_screen._dedupe_cross_provider_items(
+        result = dedupe_cross_provider_items(
             [tmdb_item, tvdb_item],
             Sources.TVDB.value,
         )
@@ -1631,7 +1632,7 @@ class CrossProviderDedupTests(TestCase):
     def test_prefers_tmdb_item_for_tmdb_preferring_user(self):
         tmdb_item, tvdb_item = self._tv_pair()
 
-        result = home_screen._dedupe_cross_provider_items(
+        result = dedupe_cross_provider_items(
             [tmdb_item, tvdb_item],
             Sources.TMDB.value,
         )
@@ -1655,7 +1656,7 @@ class CrossProviderDedupTests(TestCase):
             image="",
         )
 
-        result = home_screen._dedupe_cross_provider_items(
+        result = dedupe_cross_provider_items(
             [remake_item, tvdb_item],
             Sources.TVDB.value,
         )


### PR DESCRIPTION
## Summary
- After #620 merged *accidental* TMDB/TVDB import duplicates, Floppy's data model still intentionally keeps both a TMDB and a TVDB `Item`/`Season` tree for a show when a user genuinely tracks it under both identities. `EventManager.get_user_events` (`src/events/models.py`) had no cross-provider awareness, so the Calendar (and its `.ics` export, which reuses the same query) showed the same real episode twice — once per provider identity.
- Extracted the existing Home-screen cross-provider dedup helper (`_dedupe_cross_provider_items` in `src/users/home_screen.py`) into a shared, public `dedupe_cross_provider_items` in `src/app/services/item_merge.py` (already the home of cross-provider identity logic), and updated Home to call the shared version.
- Applied the same dedup to `EventManager.get_user_events`: after computing the user's active TV shows, it fetches the corresponding Season `Item`s, runs them through `dedupe_cross_provider_items` keyed on the user's `tv_metadata_source_default` preference, and excludes the non-preferred duplicate's events — using only the verified, cached `provider_external_ids["tvdb_id"]` mapping (never a title match, never a network call). This automatically fixes `download_calendar` too, since it shares the same query, and the exclude is applied via `.exclude(...)` so `get_user_events` keeps returning a `QuerySet` (not a list), preserving `download_calendar`'s later media-type filter chaining.
- No changes to event *generation* — both providers' `Event` rows still get created and stay in the DB (needed if the user switches `tv_metadata_source_default` later); only the read/render path hides the non-preferred duplicate, per the issue's guidance to dedupe at render time rather than force a data merge.

## AI Assistance
- This change was generated by Claude Sonnet 5 (`claude-sonnet-5`).

## Validation
- `cd src && python manage.py test users.tests.views.test_home_screen.CrossProviderDedupTests events.tests.test_models` — pass (includes 4 new tests: hides the non-preferred duplicate, follows a `tv_metadata_source_default` switch, never collapses unrelated same-titled shows without a verified `tvdb_id` link, and confirms `get_user_events` still chains as a `QuerySet` for `download_calendar`'s media-type filter).
- `cd src && python manage.py test events users app.tests.test_item_merge` — full suite, pass.
- `ruff check` / `ruff format --check` on all changed files — pass.
- Manually reproduced and validated in the running app: seeded a show tracked under both a TMDB and a verified-TVDB identity with an episode on the same air date, loaded `/calendar` in a headless browser against the pre-fix commit (duplicate tile, two distinct `/details/tmdb/...` and `/details/tvdb/...` links) and against this fix (single tile, one link matching the preferred source).

## Notes
- Closes #639


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi1JYR6wKr1afKfminN3Uc)_