### PR TITLE
Add TVDB to metadata backfill source allow-lists

### DIFF
--- a/src/app/management/commands/populate_runtime_data.py
+++ b/src/app/management/commands/populate_runtime_data.py
@@ -55,6 +55,7 @@ class Command(BaseCommand):
             ],
             source__in=[
                 "tmdb",
+                "tvdb",
                 "mal",
                 "simkl",
             ],  # Only process items from providers that have runtime data

--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -52,8 +52,8 @@ logger = logging.getLogger(__name__)
 
 RUNTIME_UNKNOWN_FAILED = 999999  # runtime completely unknown / failed lookup
 
-RUNTIME_BACKFILL_SOURCES = ("tmdb", "mal", "simkl")
-GENRE_BACKFILL_SOURCES = ("tmdb", "mal", "simkl", "igdb", "bgg")
+RUNTIME_BACKFILL_SOURCES = ("tmdb", "tvdb", "mal", "simkl")
+GENRE_BACKFILL_SOURCES = ("tmdb", "tvdb", "mal", "simkl", "igdb", "bgg")
 DISCOVER_PRIORITY_HISTORY_DEBOUNCE_SECONDS = 15
 DISCOVER_PRIORITY_HISTORY_COUNTDOWN = 15
 DISCOVER_PRIORITY_STATISTICS_DEBOUNCE_SECONDS = 20

--- a/src/app/tasks.py
+++ b/src/app/tasks.py
@@ -168,6 +168,7 @@ from app.tasks_tv_provider_migration import (  # noqa: E402
 
 RELEASE_BACKFILL_SOURCES = (
     Sources.TMDB.value,
+    Sources.TVDB.value,
     Sources.MAL.value,
     Sources.MANGAUPDATES.value,
     Sources.IGDB.value,

--- a/src/app/tasks_genre.py
+++ b/src/app/tasks_genre.py
@@ -32,6 +32,7 @@ BACKGROUND_TASK_PRIORITY = getattr(settings, "CELERY_TASK_PRIORITY_BACKGROUND", 
 
 GENRE_BACKFILL_SOURCES = (
     Sources.TMDB.value,
+    Sources.TVDB.value,
     Sources.MAL.value,
     "simkl",
     Sources.IGDB.value,

--- a/src/app/tasks_runtime.py
+++ b/src/app/tasks_runtime.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 BACKGROUND_TASK_PRIORITY = getattr(settings, "CELERY_TASK_PRIORITY_BACKGROUND", 9)
 
-RUNTIME_BACKFILL_SOURCES = ("tmdb", "mal", "simkl")
+RUNTIME_BACKFILL_SOURCES = ("tmdb", "tvdb", "mal", "simkl")
 RUNTIME_BACKFILL_QUEUE_TTL = 60 * 60  # 1 hour
 
 SEASON_KEY_TUPLE_LENGTH = 3  # (media_id, source, season_number)


### PR DESCRIPTION
## How this was found
A show was added to the tracker *only* by marking its first episode as watched (no library import, no explicit "track show" step) — that single action auto-created the show/season/episode records behind the scenes. It then showed up on the Home screen in the wrong place: filed under the generic "In Progress" row sorted by "Upcoming" instead of "In Progress • Not Caught Up", despite having unwatched episodes that had already aired.

Investigating that miscategorization led here first: the show's own metadata (release date, genres) was never able to self-heal via the nightly backfill or the eager on-save signal, because TVDB was missing from the relevant source allow-lists below. Digging further from there surfaced a second, deeper issue — the actual per-episode air dates were never persisted at all for episodes nobody had individually watched — which is fixed separately in #686.

## Summary
- TVDB-sourced items were silently excluded from every backfill/eager-sync path that keeps `release_datetime`, `genres`, and `runtime_minutes` fresh, because TVDB was missing from four separate source allow-lists plus a standalone management command:
  - `RELEASE_BACKFILL_SOURCES` (`app/tasks.py`)
  - `RUNTIME_BACKFILL_SOURCES` (`app/tasks_runtime.py`)
  - `GENRE_BACKFILL_SOURCES` (`app/tasks_genre.py`)
  - `RUNTIME_BACKFILL_SOURCES` / `GENRE_BACKFILL_SOURCES` in `app/signals.py` (the eager on-save trigger, a duplicated copy of the two lists above)
  - `populate_runtime_data.py` management command
- `CREDITS_BACKFILL_SOURCES` (`app/tasks_credits.py`) is intentionally left TMDB-only — it's gated by a separate, deliberate TMDB-specific code path in `metadata_sync_views.py`, not a copy-paste omission, and extending it needs its own verification of TVDB's cast/crew payload shape.

## Scope note
This fixes **show/movie-level** `release_datetime` and `genres`, and **show/movie/episode-level** `runtime_minutes`, for TVDB. It does **not** fix per-episode `release_datetime` (air dates) — that's the separate, deeper gap fixed in #686.

## Test plan
- [ ] Confirm `RELEASE_BACKFILL_SOURCES`, `RUNTIME_BACKFILL_SOURCES`, `GENRE_BACKFILL_SOURCES` each include `tvdb`
- [ ] Confirm the duplicated constants in `app/signals.py` match
- [ ] Existing backfill task test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)