### PR TITLE
test: isolate provider and wall-clock fixtures

### DIFF
--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -46,6 +46,14 @@ class IntegrationTest(StaticLiveServerTestCase):
             title="Breaking Bad",
             episode_count=1,
         )
+        episode = {
+            "title": "Breaking Bad",
+            "season_title": "Season 1",
+            "episode_title": "Episode 1",
+            "image": "https://example.com/episode.jpg",
+            "cast": [],
+            "crew": [],
+        }
         search = {
             "page": 1,
             "total_pages": 1,
@@ -69,7 +77,14 @@ class IntegrationTest(StaticLiveServerTestCase):
                 "app.providers.tmdb.tv_with_seasons",
                 side_effect=lambda *a, **k: copy.deepcopy(show),
             ),
+            patch(
+                "app.providers.tmdb.episode",
+                side_effect=lambda *a, **k: copy.deepcopy(episode),
+            ),
             patch("app.providers.tmdb.get_tvdb_episode_image_map", return_value={}),
+            patch(
+                "app.tasks_trakt.populate_trakt_episode_ratings_for_season.delay",
+            ),
         ):
             provider_patch.start()
             self.addCleanup(provider_patch.stop)

--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -337,12 +337,17 @@ class IntegrationTest(StaticLiveServerTestCase):
         expect(create_modal).to_be_visible()
 
         end_date_input = create_modal.locator('input[name="end_date"]')
-        end_date_before = end_date_input.input_value()
-        self.assertIn("T", end_date_before)
-        end_time_segment = end_date_before.split("T", 1)[1]
+        end_time_segment = "14:25"
         start_date_input = create_modal.locator('input[name="start_date"]')
 
         create_modal.get_by_role("button", name="End date picker").click()
+        end_date_picker = create_modal.get_by_role(
+            "dialog",
+            name="End date picker",
+        )
+        time_selects = end_date_picker.locator("select")
+        time_selects.nth(0).select_option("14")
+        time_selects.nth(1).select_option("25")
         create_modal.get_by_role("button", name="Release date").click()
         expect(end_date_input).to_have_value(f"2019-11-08T{end_time_segment}")
         end_hour, end_minute = [int(segment) for segment in end_time_segment.split(":")]

--- a/src/integrations/tests/test_exports.py
+++ b/src/integrations/tests/test_exports.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import UTC, datetime
 from io import StringIO
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.db.models import Q
@@ -33,7 +34,8 @@ from lists.models import CustomList, CustomListItem
 class ExportCSVTest(TestCase):
     """Test exporting media to CSV."""
 
-    def setUp(self):
+    @patch("app.providers.services.get_media_metadata", return_value={"max_progress": None})
+    def setUp(self, _mock_get_media_metadata):
         """Create necessary data for the tests."""
         self.credentials = {"username": "test", "password": "12345"}
         self.user = get_user_model().objects.create_superuser(**self.credentials)


### PR DESCRIPTION
## Summary

- Prevent ExportCSVTest setup from calling live metadata providers while it creates fixtures.
- Keep the CSV export request and assertions unmocked by patching only the shared metadata facade during setup.
- Remove a wall-clock minute-boundary race from the release-date picker browser flow by selecting a deterministic time through the real picker controls.

## Root causes

Creating an in-progress Open Library book calls Media.process_progress, which requests provider metadata. The export fixture did not mock that boundary, so App Tests could contact live providers during setup.

The date-picker test copied the current minute and later expected it to remain unchanged. CI crossed a minute while the modal was open, producing expected 23:50 versus actual 23:51 even though the release-date and runtime-backfill behavior was correct.

Evidence:

- PR #614 run 31534144431, job 93921115165: live Open Library connection reset.
- PR #695 run 31546601090, job 93960368348: one browser failure at the wall-clock minute boundary.

## Validation

- Exact ExportCSVTest class: passed.
- Network guard: proved the provider call before the fixture patch and isolation after it.
- Exact Playwright release-date flow: passed after selecting 14:25 through the picker and verifying the 2019-11-08 end date plus 95-minute start-date backfill.
- Focused Ruff and git diff check: passed.
- Independent specification review: PASS.
- Independent code-quality review of the provider-isolation change: READY, no P0-P3 findings.

## Review gates

- Human review: pending final repository maintainer approval; maintainer-directed integration review is complete.
- Gstack-QA: not rerun because both commits change tests only. The exact provider guard and exact Playwright flow are the applicable QA boundary; no application/browser/runtime code changed.

## Relations

- Test-stability prerequisite for #614, #695, #696, #697, and #698.
- Related to the test-remediation work under #645.
