### PR TITLE
Persist episode release_datetime when viewing a season page

### DIFF
--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -342,6 +342,34 @@ def season_details(
             if episode_number is None:
                 continue
 
+            # Parse the episode's air date once — reused below both for the
+            # "aired but runtime unknown" heuristic and to persist
+            # release_datetime. Without this, release_datetime is never set
+            # for any episode the user hasn't individually tracked/watched
+            # (that's the only other code path that extracts it), so an
+            # episode created here from a page view stays permanently NULL
+            # even once the provider does have its air date.
+            air_date_dt = None
+            raw_air_date = episode.get("air_date")
+            if raw_air_date:
+                try:
+                    if isinstance(raw_air_date, str):
+                        date_obj = datetime.strptime(raw_air_date, "%Y-%m-%d")  # noqa: DTZ007  # date-only value; no timezone applies
+                        air_date_dt = timezone.make_aware(
+                            date_obj,
+                            timezone.get_current_timezone(),
+                        )
+                    elif hasattr(raw_air_date, "year"):
+                        air_date_dt = (
+                            raw_air_date
+                            if timezone.is_aware(raw_air_date)
+                            else timezone.make_aware(raw_air_date)
+                        )
+                except (ValueError, TypeError):
+                    air_date_dt = None
+                if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
+                    air_date_dt = None
+
             # Get or create episode item — retry on race condition
             lookup = {
                 "media_id": media_id,
@@ -360,6 +388,7 @@ def season_details(
                         defaults={
                             "title": season_metadata.get("title", ""),
                             "image": settings.IMG_NONE,
+                            "release_datetime": air_date_dt,
                         },
                     )
             except IntegrityError:
@@ -371,27 +400,9 @@ def season_details(
                 runtime_minutes = (
                     int(episode["runtime"]) if episode["runtime"] > 0 else None
                 )
-            elif episode.get("air_date"):
-                # Check if episode has aired
-                try:
-                    if isinstance(episode["air_date"], str):
-                        date_obj = datetime.strptime(episode["air_date"], "%Y-%m-%d")  # noqa: DTZ007  # date-only value; no timezone applies
-                        air_date_dt = timezone.make_aware(
-                            date_obj,
-                            timezone.get_current_timezone(),
-                        )
-                    else:
-                        air_date_dt = episode["air_date"]
-
-                    if (
-                        air_date_dt
-                        and air_date_dt.year > MIN_PLAUSIBLE_YEAR
-                        and air_date_dt <= current_datetime
-                    ):
-                        # Episode has aired but no runtime - mark as unknown (use 999998)
-                        runtime_minutes = 999998
-                except (ValueError, TypeError):
-                    pass
+            elif air_date_dt and air_date_dt <= current_datetime:
+                # Episode has aired but no runtime - mark as unknown (use 999998)
+                runtime_minutes = 999998
 
             # Extract provider rating from raw episode data (already in memory, no extra API call)
             score = None
@@ -412,20 +423,34 @@ def season_details(
                 episode_item.provider_rating != score
                 or episode_item.provider_rating_count != score_count
             )
+            # Only fill in a missing date, never overwrite one that's already
+            # set — this lets an episode created before its air date was
+            # known self-heal the next time anyone views the season page,
+            # without a dedicated backfill task.
+            release_datetime_changed = (
+                air_date_dt is not None and episode_item.release_datetime is None
+            )
 
             if runtime_changed:
                 episode_item.runtime_minutes = runtime_minutes
             if rating_changed:
                 episode_item.provider_rating = score
                 episode_item.provider_rating_count = score_count
+            if release_datetime_changed:
+                episode_item.release_datetime = air_date_dt
 
-            if runtime_changed or rating_changed:
+            if runtime_changed or rating_changed or release_datetime_changed:
                 episodes_to_update.append(episode_item)
 
         if episodes_to_update:
             Item.objects.bulk_update(
                 episodes_to_update,
-                ["runtime_minutes", "provider_rating", "provider_rating_count"],
+                [
+                    "runtime_minutes",
+                    "provider_rating",
+                    "provider_rating_count",
+                    "release_datetime",
+                ],
                 batch_size=100,
             )
             # Invalidate time_left + media_list cache for all users

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5421,6 +5421,154 @@ class MediaDetailsViewTests(TestCase):
         )
         mock_process_episodes.assert_called_once()
 
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
+    def test_season_details_persists_and_self_heals_episode_release_datetime(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+    ):
+        """Viewing a season page must persist release_datetime for every episode.
+
+        Regression test: episode Items created while browsing a season page
+        (as opposed to individually tracking/watching one) previously only
+        picked up runtime/rating from the live provider payload and silently
+        dropped release_datetime, leaving it NULL forever unless that exact
+        episode was later tracked or a manual metadata sync ran. This left
+        "not caught up" categorization permanently wrong for any unwatched
+        episode created this way.
+        """
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test TV Show",
+            image="http://example.com/show.jpg",
+        )
+        related_tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Test TV Show",
+            image="http://example.com/show.jpg",
+            season_number=1,
+        )
+        Season.objects.create(
+            item=season_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            related_tv=related_tv,
+        )
+
+        # Episode 1 already has a trusted release_datetime — must not be
+        # clobbered by a differing value from the live payload.
+        already_dated_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="No Shortcuts",
+            image=settings.IMG_NONE,
+            season_number=1,
+            episode_number=1,
+            release_datetime=timezone.make_aware(datetime(2023, 1, 1)),
+        )
+        # Episode 2 exists (e.g. created by an earlier page view before its
+        # air date was known) but was never given a release_datetime.
+        stale_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Test TV Show",
+            image=settings.IMG_NONE,
+            season_number=1,
+            episode_number=2,
+            release_datetime=None,
+        )
+
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Test TV Show",
+            "media_id": "1668",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Test TV Show",
+                "season_title": "Season 1",
+                "media_id": "1668",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TMDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [
+                    {
+                        "episode_number": 1,
+                        "name": "No Shortcuts",
+                        "air_date": "2023-06-01",  # differs from the stored date
+                        "runtime": 48,
+                    },
+                    {
+                        "episode_number": 2,
+                        "name": "Episode 2",
+                        "air_date": "2023-01-08",
+                        "runtime": 42,
+                    },
+                    {
+                        "episode_number": 3,
+                        "name": "Episode 3",
+                        "air_date": "2023-01-15",
+                        "runtime": 44,
+                    },
+                ],
+            },
+        }
+        mock_process_episodes.return_value = []
+
+        response = self.client.get(
+            reverse(
+                "season_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "test-tv-show",
+                    "season_number": 1,
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        already_dated_episode.refresh_from_db()
+        self.assertEqual(
+            already_dated_episode.release_datetime,
+            timezone.make_aware(datetime(2023, 1, 1)),
+            "an already-set release_datetime must not be overwritten",
+        )
+
+        stale_episode.refresh_from_db()
+        self.assertEqual(
+            stale_episode.release_datetime,
+            timezone.make_aware(datetime(2023, 1, 8)),
+            "a NULL release_datetime must self-heal from the live payload",
+        )
+
+        new_episode = Item.objects.get(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=3,
+        )
+        self.assertEqual(
+            new_episode.release_datetime,
+            timezone.make_aware(datetime(2023, 1, 15)),
+            "a newly created episode must get release_datetime from the same payload",
+        )
+
     @patch("app.views.trakt_popularity_service.refresh_trakt_popularity")
     @patch("app.providers.tmdb.get_tvdb_episode_image_map")
     @patch("app.helpers.get_tmdb_backdrop_image")


### PR DESCRIPTION
## Summary
- `season_details_views.py`'s per-episode refresh loop runs on **every** season page view, for every provider, and extracts `runtime_minutes`/`provider_rating`/`provider_rating_count` from the live metadata payload — but never reads or writes `release_datetime` at all, even though the same payload has an `air_date` field for each episode.
- The only other code path that persists an episode's `release_datetime` is `Season.get_episode_item()` (`app/models/tv.py`), which only runs for the one specific episode a user tracks/watches/drops.
- Net effect: any episode nobody has individually tracked keeps `release_datetime = NULL` forever, regardless of what the provider actually has — silently breaking "is this episode caught up" logic (e.g. the Home screen's "Not Caught Up" filter) for every unwatched episode of an in-progress show. Not TVDB-specific — this hits any source.
- Root-caused from a real case: a TVDB show stayed miscategorized as "caught up" despite unwatched, already-aired episodes, because the episodes were created while browsing the season page (before being watched) and never got a date.

## Fix
- Extract and persist `release_datetime` in the same loop, reusing the parse/sanity-check pattern already used by `get_episode_item()` and `metadata_sync_views.py` (string vs. datetime handling, plausible-year check).
- New episodes get the date set on creation.
- Existing episodes with `release_datetime` still `NULL` self-heal the next time anyone views the season page — no dedicated backfill task needed.
- An already-set `release_datetime` is never overwritten, so trusted/local data can't be clobbered by a differing provider value.

## Related
Follow-up to #684 (TVDB backfill source lists) — that PR fixes show/movie-level dates for TVDB; this one fixes the actual episode-level gap that caused the original bug report, for all providers.

## Test plan
- [x] New regression test `test_season_details_persists_and_self_heals_episode_release_datetime` — verified it fails against the old code and passes with the fix
- [x] `ruff check` clean
- [x] Full `episode`/`runtime`/`season` slice of `test_media_details.py` passes (32 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)