### PR TITLE
fix(metadata): complete TVDB backfill routing

### DIFF
--- a/src/app/management/commands/populate_runtime_data.py
+++ b/src/app/management/commands/populate_runtime_data.py
@@ -50,6 +50,7 @@ class Command(BaseCommand):
             runtime_minutes__isnull=True,
             media_type__in=[
                 MediaTypes.MOVIE.value,
+                MediaTypes.TV.value,
                 MediaTypes.ANIME.value,
                 MediaTypes.EPISODE.value,
             ],

--- a/src/app/management/commands/populate_runtime_data.py
+++ b/src/app/management/commands/populate_runtime_data.py
@@ -55,6 +55,7 @@ class Command(BaseCommand):
             ],
             source__in=[
                 "tmdb",
+                "tvdb",
                 "mal",
                 "simkl",
             ],  # Only process items from providers that have runtime data

--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -52,8 +52,8 @@ logger = logging.getLogger(__name__)
 
 RUNTIME_UNKNOWN_FAILED = 999999  # runtime completely unknown / failed lookup
 
-RUNTIME_BACKFILL_SOURCES = ("tmdb", "mal", "simkl")
-GENRE_BACKFILL_SOURCES = ("tmdb", "mal", "simkl", "igdb", "bgg")
+RUNTIME_BACKFILL_SOURCES = ("tmdb", "tvdb", "mal", "simkl")
+GENRE_BACKFILL_SOURCES = ("tmdb", "tvdb", "mal", "simkl", "igdb", "bgg")
 DISCOVER_PRIORITY_HISTORY_DEBOUNCE_SECONDS = 15
 DISCOVER_PRIORITY_HISTORY_COUNTDOWN = 15
 DISCOVER_PRIORITY_STATISTICS_DEBOUNCE_SECONDS = 20

--- a/src/app/tasks.py
+++ b/src/app/tasks.py
@@ -168,6 +168,7 @@ from app.tasks_tv_provider_migration import (  # noqa: E402
 
 RELEASE_BACKFILL_SOURCES = (
     Sources.TMDB.value,
+    Sources.TVDB.value,
     Sources.MAL.value,
     Sources.MANGAUPDATES.value,
     Sources.IGDB.value,

--- a/src/app/tasks_genre.py
+++ b/src/app/tasks_genre.py
@@ -32,6 +32,7 @@ BACKGROUND_TASK_PRIORITY = getattr(settings, "CELERY_TASK_PRIORITY_BACKGROUND", 
 
 GENRE_BACKFILL_SOURCES = (
     Sources.TMDB.value,
+    Sources.TVDB.value,
     Sources.MAL.value,
     "simkl",
     Sources.IGDB.value,

--- a/src/app/tasks_runtime.py
+++ b/src/app/tasks_runtime.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 BACKGROUND_TASK_PRIORITY = getattr(settings, "CELERY_TASK_PRIORITY_BACKGROUND", 9)
 
-RUNTIME_BACKFILL_SOURCES = ("tmdb", "mal", "simkl")
+RUNTIME_BACKFILL_SOURCES = ("tmdb", "tvdb", "mal", "simkl")
 RUNTIME_BACKFILL_QUEUE_TTL = 60 * 60  # 1 hour
 
 SEASON_KEY_TUPLE_LENGTH = 3  # (media_id, source, season_number)

--- a/src/app/tests/test_populate_runtime_data_command.py
+++ b/src/app/tests/test_populate_runtime_data_command.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from app.management.commands.populate_runtime_data import Command
+from app.models import Item, MediaTypes, Sources
+
+
+class PopulateRuntimeDataCommandTests(TestCase):
+    @patch.object(Command, "_update_item_runtime")
+    def test_processes_tvdb_tv_items(self, mock_update_item_runtime):
+        item = Item.objects.create(
+            media_id="tvdb-show",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="TVDB Show",
+            image="https://example.com/show.jpg",
+            runtime_minutes=None,
+        )
+
+        call_command("populate_runtime_data", "--delay", "0")
+
+        mock_update_item_runtime.assert_called_once_with(item)

--- a/src/app/tests/test_signals.py
+++ b/src/app/tests/test_signals.py
@@ -133,6 +133,27 @@ class TaskResultOnCompletionTests(TestCase):
 
 
 class ItemSignalTests(TestCase):
+    @override_settings(TESTING=False)
+    @patch("app.tasks.enqueue_runtime_backfill_items", return_value=1)
+    @patch("app.tasks.enqueue_genre_backfill_items", return_value=1)
+    def test_tvdb_item_save_enqueues_runtime_and_genre_backfills(
+        self,
+        mock_enqueue_genre_backfill_items,
+        mock_enqueue_runtime_backfill_items,
+    ):
+        item = Item.objects.create(
+            media_id="tvdb-signal-show",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="TVDB Signal Show",
+            image="https://example.com/tvdb-signal-show.jpg",
+            runtime_minutes=None,
+            genres=[],
+        )
+
+        mock_enqueue_runtime_backfill_items.assert_called_once_with([item.id])
+        mock_enqueue_genre_backfill_items.assert_called_once_with([item.id])
+
     def test_item_save_does_not_delete_current_genre_state_on_unrelated_update(self):
         item = Item.objects.create(
             media_id="3001",

--- a/src/app/tests/test_tasks_metadata_backfill.py
+++ b/src/app/tests/test_tasks_metadata_backfill.py
@@ -44,6 +44,22 @@ class MetadataBackfillTaskTests(TestCase):
         cache.delete(INTERACTIVE_REQUEST_CACHE_KEY)
         super().setUp()
 
+    def test_tvdb_tv_is_eligible_for_metadata_quality_backfills(self):
+        item = Item.objects.create(
+            media_id="tvdb-metadata-quality",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="TVDB Show",
+            image="https://example.com/tvdb-show.jpg",
+            release_datetime=None,
+            runtime_minutes=None,
+            genres=[],
+        )
+
+        self.assertIn(item, tasks._release_items_queryset())
+        self.assertIn(item, tasks._runtime_items_queryset())
+        self.assertIn(item, tasks._genre_items_queryset())
+
     def tearDown(self):
         cache.delete(INTERACTIVE_REQUEST_CACHE_KEY)
         super().tearDown()


### PR DESCRIPTION
## Why

TVDB television items were added to most metadata backfill allow-lists, but the runtime management command still excluded the `tv` media type. This draft review stack preserves Dieter Blomme’s original #684 commit and proposes the missing command path and regression coverage.

## Changes

- preserve the original TVDB release/runtime/genre allow-list contribution from #684
- include television items in `populate_runtime_data`
- cover TVDB eligibility through command, task-query, and save-signal paths

## Stack and collaboration gate

- Base: #685, which fixes the unrelated Open Library fixture leak that made #684 red
- Related contributor PR: #684 remains open and contributor-owned
- This draft exists because GitHub rejected direct pushes to the contributor fork
- **Blocked: do not merge or use this PR to close #684 without contributor and maintainer coordination**
- After #685 merges, retarget this PR to `latest`

## Validation

- focused command/task/signal tests: 3 passed
- Ruff and `git diff --check`: passed
- independent specification/code review: READY, no findings
- Gstack-QA: 100/100 for the scoped non-browser command/task/signal surface

## Review gates

- Human review: independent technical review completed; contributor and maintainer approval pending
- Gstack-QA: passed

## Attribution

Original implementation: Dieter Blomme / @daften, commit `127406400a029f77edb3d229b9c5d3327ced3803`, preserved as the first commit in this branch.