### PR TITLE
fix(tv): persist trustworthy episode release dates

### DIFF
--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_not_required
@@ -55,6 +56,7 @@ from lists.models import CustomList
 logger = logging.getLogger(__name__)
 
 MIN_PLAUSIBLE_YEAR = 1900
+UNKNOWN_RELEASE_YEAR = 9999
 
 
 @login_not_required
@@ -353,13 +355,16 @@ def season_details(
             # shared Item does not depend on the timezone of the first viewer.
             normalized_air_date = (
                 raw_air_date.date().isoformat()
-                if isinstance(raw_air_date, timezone.datetime)
+                if isinstance(raw_air_date, datetime)
                 else raw_air_date
             )
             air_date_dt = helpers.extract_release_datetime(
                 {"release_date": normalized_air_date},
             )
-            if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
+            if air_date_dt and (
+                air_date_dt.year <= MIN_PLAUSIBLE_YEAR
+                or air_date_dt.year == UNKNOWN_RELEASE_YEAR
+            ):
                 air_date_dt = None
 
             # Get or create episode item — retry on race condition

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib.auth.decorators import login_not_required
 from django.db import IntegrityError, transaction
+from django.db.models import Case, DateTimeField, Value, When
 from django.shortcuts import render
 from django.utils import timezone
 from django.views.decorators.http import require_GET
@@ -336,6 +337,7 @@ def season_details(
         raw_episodes = season_metadata["episodes"]
         current_datetime = timezone.now()
         episodes_to_update = []
+        release_datetime_updates = []
 
         for episode in raw_episodes:
             episode_number = episode.get("episode_number")
@@ -434,9 +436,9 @@ def season_details(
                 episode_item.provider_rating = score
                 episode_item.provider_rating_count = score_count
             if release_datetime_changed:
-                episode_item.release_datetime = air_date_dt
+                release_datetime_updates.append((episode_item.pk, air_date_dt))
 
-            if runtime_changed or rating_changed or release_datetime_changed:
+            if runtime_changed or rating_changed:
                 episodes_to_update.append(episode_item)
 
         if episodes_to_update:
@@ -446,10 +448,28 @@ def season_details(
                     "runtime_minutes",
                     "provider_rating",
                     "provider_rating_count",
-                    "release_datetime",
                 ],
                 batch_size=100,
             )
+
+        for batch_start in range(0, len(release_datetime_updates), 100):
+            release_datetime_batch = release_datetime_updates[
+                batch_start : batch_start + 100
+            ]
+            Item.objects.filter(
+                pk__in=[item_id for item_id, _ in release_datetime_batch],
+                release_datetime__isnull=True,
+            ).update(
+                release_datetime=Case(
+                    *(
+                        When(pk=item_id, then=Value(release_datetime))
+                        for item_id, release_datetime in release_datetime_batch
+                    ),
+                    output_field=DateTimeField(),
+                ),
+            )
+
+        if episodes_to_update or release_datetime_updates:
             # Invalidate time_left + media_list cache for all users
             from app.cache_utils import (
                 clear_media_list_cache_for_user,

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -342,6 +342,34 @@ def season_details(
             if episode_number is None:
                 continue
 
+            # Parse the episode's air date once — reused below both for the
+            # "aired but runtime unknown" heuristic and to persist
+            # release_datetime. Without this, release_datetime is never set
+            # for any episode the user hasn't individually tracked/watched
+            # (that's the only other code path that extracts it), so an
+            # episode created here from a page view stays permanently NULL
+            # even once the provider does have its air date.
+            air_date_dt = None
+            raw_air_date = episode.get("air_date")
+            if raw_air_date:
+                try:
+                    if isinstance(raw_air_date, str):
+                        date_obj = datetime.strptime(raw_air_date, "%Y-%m-%d")  # noqa: DTZ007  # date-only value; no timezone applies
+                        air_date_dt = timezone.make_aware(
+                            date_obj,
+                            timezone.get_current_timezone(),
+                        )
+                    elif hasattr(raw_air_date, "year"):
+                        air_date_dt = (
+                            raw_air_date
+                            if timezone.is_aware(raw_air_date)
+                            else timezone.make_aware(raw_air_date)
+                        )
+                except (ValueError, TypeError):
+                    air_date_dt = None
+                if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
+                    air_date_dt = None
+
             # Get or create episode item — retry on race condition
             lookup = {
                 "media_id": media_id,
@@ -360,6 +388,7 @@ def season_details(
                         defaults={
                             "title": season_metadata.get("title", ""),
                             "image": settings.IMG_NONE,
+                            "release_datetime": air_date_dt,
                         },
                     )
             except IntegrityError:
@@ -371,27 +400,9 @@ def season_details(
                 runtime_minutes = (
                     int(episode["runtime"]) if episode["runtime"] > 0 else None
                 )
-            elif episode.get("air_date"):
-                # Check if episode has aired
-                try:
-                    if isinstance(episode["air_date"], str):
-                        date_obj = datetime.strptime(episode["air_date"], "%Y-%m-%d")  # noqa: DTZ007  # date-only value; no timezone applies
-                        air_date_dt = timezone.make_aware(
-                            date_obj,
-                            timezone.get_current_timezone(),
-                        )
-                    else:
-                        air_date_dt = episode["air_date"]
-
-                    if (
-                        air_date_dt
-                        and air_date_dt.year > MIN_PLAUSIBLE_YEAR
-                        and air_date_dt <= current_datetime
-                    ):
-                        # Episode has aired but no runtime - mark as unknown (use 999998)
-                        runtime_minutes = 999998
-                except (ValueError, TypeError):
-                    pass
+            elif air_date_dt and air_date_dt <= current_datetime:
+                # Episode has aired but no runtime - mark as unknown (use 999998)
+                runtime_minutes = 999998
 
             # Extract provider rating from raw episode data (already in memory, no extra API call)
             score = None
@@ -412,20 +423,34 @@ def season_details(
                 episode_item.provider_rating != score
                 or episode_item.provider_rating_count != score_count
             )
+            # Only fill in a missing date, never overwrite one that's already
+            # set — this lets an episode created before its air date was
+            # known self-heal the next time anyone views the season page,
+            # without a dedicated backfill task.
+            release_datetime_changed = (
+                air_date_dt is not None and episode_item.release_datetime is None
+            )
 
             if runtime_changed:
                 episode_item.runtime_minutes = runtime_minutes
             if rating_changed:
                 episode_item.provider_rating = score
                 episode_item.provider_rating_count = score_count
+            if release_datetime_changed:
+                episode_item.release_datetime = air_date_dt
 
-            if runtime_changed or rating_changed:
+            if runtime_changed or rating_changed or release_datetime_changed:
                 episodes_to_update.append(episode_item)
 
         if episodes_to_update:
             Item.objects.bulk_update(
                 episodes_to_update,
-                ["runtime_minutes", "provider_rating", "provider_rating_count"],
+                [
+                    "runtime_minutes",
+                    "provider_rating",
+                    "provider_rating_count",
+                    "release_datetime",
+                ],
                 batch_size=100,
             )
             # Invalidate time_left + media_list cache for all users

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -331,8 +331,6 @@ def season_details(
         and source != Sources.MANUAL.value
         and season_metadata.get("episodes")
     ):
-        from datetime import datetime
-
         raw_episodes = season_metadata["episodes"]
         current_datetime = timezone.now()
         episodes_to_update = []
@@ -349,26 +347,20 @@ def season_details(
             # (that's the only other code path that extracts it), so an
             # episode created here from a page view stays permanently NULL
             # even once the provider does have its air date.
-            air_date_dt = None
             raw_air_date = episode.get("air_date")
-            if raw_air_date:
-                try:
-                    if isinstance(raw_air_date, str):
-                        date_obj = datetime.strptime(raw_air_date, "%Y-%m-%d")  # noqa: DTZ007  # date-only value; no timezone applies
-                        air_date_dt = timezone.make_aware(
-                            date_obj,
-                            timezone.get_current_timezone(),
-                        )
-                    elif hasattr(raw_air_date, "year"):
-                        air_date_dt = (
-                            raw_air_date
-                            if timezone.is_aware(raw_air_date)
-                            else timezone.make_aware(raw_air_date)
-                        )
-                except (ValueError, TypeError):
-                    air_date_dt = None
-                if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
-                    air_date_dt = None
+            # Episode provider dates are calendar dates, even when a provider
+            # has already wrapped one in a datetime. Persist UTC midnight so a
+            # shared Item does not depend on the timezone of the first viewer.
+            normalized_air_date = (
+                raw_air_date.date().isoformat()
+                if isinstance(raw_air_date, timezone.datetime)
+                else raw_air_date
+            )
+            air_date_dt = helpers.extract_release_datetime(
+                {"release_date": normalized_air_date},
+            )
+            if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
+                air_date_dt = None
 
             # Get or create episode item — retry on race condition
             lookup = {

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5535,6 +5535,12 @@ class MediaDetailsViewTests(TestCase):
                         "air_date": "0001-01-01",
                         "runtime": 45,
                     },
+                    {
+                        "episode_number": 5,
+                        "name": "Episode 5",
+                        "air_date": "9999-12-31",
+                        "runtime": 46,
+                    },
                 ],
             },
         }
@@ -5594,6 +5600,16 @@ class MediaDetailsViewTests(TestCase):
                 episode_number=4,
             ).release_datetime,
             "unknown-date sentinels must remain NULL",
+        )
+        self.assertIsNone(
+            Item.objects.get(
+                media_id="1668",
+                source=Sources.TVDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                season_number=1,
+                episode_number=5,
+            ).release_datetime,
+            "year-9999 unknown-date sentinels must remain NULL",
         )
 
     @patch("app.views.trakt_popularity_service.refresh_trakt_popularity")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5440,7 +5440,7 @@ class MediaDetailsViewTests(TestCase):
         """
         tv_item = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.TV.value,
             title="Test TV Show",
             image="http://example.com/show.jpg",
@@ -5452,7 +5452,7 @@ class MediaDetailsViewTests(TestCase):
         )
         season_item = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.SEASON.value,
             title="Test TV Show",
             image="http://example.com/show.jpg",
@@ -5469,7 +5469,7 @@ class MediaDetailsViewTests(TestCase):
         # clobbered by a differing value from the live payload.
         already_dated_episode = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.EPISODE.value,
             title="No Shortcuts",
             image=settings.IMG_NONE,
@@ -5481,7 +5481,7 @@ class MediaDetailsViewTests(TestCase):
         # air date was known) but was never given a release_datetime.
         stale_episode = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.EPISODE.value,
             title="Test TV Show",
             image=settings.IMG_NONE,
@@ -5493,7 +5493,7 @@ class MediaDetailsViewTests(TestCase):
         mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
             "title": "Test TV Show",
             "media_id": "1668",
-            "source": Sources.TMDB.value,
+            "source": Sources.TVDB.value,
             "media_type": MediaTypes.TV.value,
             "image": "http://example.com/image.jpg",
             "season/1": {
@@ -5513,7 +5513,14 @@ class MediaDetailsViewTests(TestCase):
                     {
                         "episode_number": 2,
                         "name": "Episode 2",
-                        "air_date": "2023-01-08",
+                        # TVDB normalizes its date-only value to an aware
+                        # datetime before this view receives it.
+                        "air_date": datetime(
+                            2023,
+                            1,
+                            8,
+                            tzinfo=timezone.get_fixed_timezone(840),
+                        ),
                         "runtime": 42,
                     },
                     {
@@ -5522,23 +5529,33 @@ class MediaDetailsViewTests(TestCase):
                         "air_date": "2023-01-15",
                         "runtime": 44,
                     },
+                    {
+                        "episode_number": 4,
+                        "name": "Episode 4",
+                        "air_date": "0001-01-01",
+                        "runtime": 45,
+                    },
                 ],
             },
         }
         mock_process_episodes.return_value = []
 
-        response = self.client.get(
-            reverse(
-                "season_details",
-                kwargs={
-                    "source": Sources.TMDB.value,
-                    "media_id": "1668",
-                    "title": "test-tv-show",
-                    "season_number": 1,
-                },
-            ),
-            {"fragment": "secondary"},
-        )
+        with (
+            patch("app.providers.trakt.is_configured", return_value=False),
+            timezone.override("Pacific/Kiritimati"),
+        ):
+            response = self.client.get(
+                reverse(
+                    "season_details",
+                    kwargs={
+                        "source": Sources.TVDB.value,
+                        "media_id": "1668",
+                        "title": "test-tv-show",
+                        "season_number": 1,
+                    },
+                ),
+                {"fragment": "secondary"},
+            )
 
         self.assertEqual(response.status_code, 200)
 
@@ -5552,21 +5569,31 @@ class MediaDetailsViewTests(TestCase):
         stale_episode.refresh_from_db()
         self.assertEqual(
             stale_episode.release_datetime,
-            timezone.make_aware(datetime(2023, 1, 8)),
+            datetime(2023, 1, 8, tzinfo=UTC),
             "a NULL release_datetime must self-heal from the live payload",
         )
 
         new_episode = Item.objects.get(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.EPISODE.value,
             season_number=1,
             episode_number=3,
         )
         self.assertEqual(
             new_episode.release_datetime,
-            timezone.make_aware(datetime(2023, 1, 15)),
+            datetime(2023, 1, 15, tzinfo=UTC),
             "a newly created episode must get release_datetime from the same payload",
+        )
+        self.assertIsNone(
+            Item.objects.get(
+                media_id="1668",
+                source=Sources.TVDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                season_number=1,
+                episode_number=4,
+            ).release_datetime,
+            "unknown-date sentinels must remain NULL",
         )
 
     @patch("app.views.trakt_popularity_service.refresh_trakt_popularity")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5489,6 +5489,17 @@ class MediaDetailsViewTests(TestCase):
             episode_number=2,
             release_datetime=None,
         )
+        concurrent_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Test TV Show",
+            image=settings.IMG_NONE,
+            season_number=1,
+            episode_number=6,
+            release_datetime=None,
+        )
+        concurrent_trusted_date = datetime(2024, 2, 2, tzinfo=UTC)
 
         mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
             "title": "Test TV Show",
@@ -5541,12 +5552,31 @@ class MediaDetailsViewTests(TestCase):
                         "air_date": "9999-12-31",
                         "runtime": 46,
                     },
+                    {
+                        "episode_number": 6,
+                        "name": "Episode 6",
+                        "air_date": "2023-01-22",
+                        "runtime": 47,
+                    },
                 ],
             },
         }
         mock_process_episodes.return_value = []
 
+        original_bulk_update = Item.objects.bulk_update
+
+        def bulk_update_after_concurrent_date(objects, fields, batch_size=None):
+            Item.objects.filter(pk=concurrent_episode.pk).update(
+                release_datetime=concurrent_trusted_date,
+            )
+            return original_bulk_update(objects, fields, batch_size=batch_size)
+
         with (
+            patch.object(
+                Item.objects,
+                "bulk_update",
+                side_effect=bulk_update_after_concurrent_date,
+            ),
             patch("app.providers.trakt.is_configured", return_value=False),
             timezone.override("Pacific/Kiritimati"),
         ):
@@ -5610,6 +5640,12 @@ class MediaDetailsViewTests(TestCase):
                 episode_number=5,
             ).release_datetime,
             "year-9999 unknown-date sentinels must remain NULL",
+        )
+        concurrent_episode.refresh_from_db()
+        self.assertEqual(
+            concurrent_episode.release_datetime,
+            concurrent_trusted_date,
+            "an intervening trusted date must survive the metadata batch update",
         )
 
     @patch("app.views.trakt_popularity_service.refresh_trakt_popularity")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5421,6 +5421,154 @@ class MediaDetailsViewTests(TestCase):
         )
         mock_process_episodes.assert_called_once()
 
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
+    def test_season_details_persists_and_self_heals_episode_release_datetime(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+    ):
+        """Viewing a season page must persist release_datetime for every episode.
+
+        Regression test: episode Items created while browsing a season page
+        (as opposed to individually tracking/watching one) previously only
+        picked up runtime/rating from the live provider payload and silently
+        dropped release_datetime, leaving it NULL forever unless that exact
+        episode was later tracked or a manual metadata sync ran. This left
+        "not caught up" categorization permanently wrong for any unwatched
+        episode created this way.
+        """
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test TV Show",
+            image="http://example.com/show.jpg",
+        )
+        related_tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Test TV Show",
+            image="http://example.com/show.jpg",
+            season_number=1,
+        )
+        Season.objects.create(
+            item=season_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            related_tv=related_tv,
+        )
+
+        # Episode 1 already has a trusted release_datetime — must not be
+        # clobbered by a differing value from the live payload.
+        already_dated_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="No Shortcuts",
+            image=settings.IMG_NONE,
+            season_number=1,
+            episode_number=1,
+            release_datetime=timezone.make_aware(datetime(2023, 1, 1)),
+        )
+        # Episode 2 exists (e.g. created by an earlier page view before its
+        # air date was known) but was never given a release_datetime.
+        stale_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Test TV Show",
+            image=settings.IMG_NONE,
+            season_number=1,
+            episode_number=2,
+            release_datetime=None,
+        )
+
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Test TV Show",
+            "media_id": "1668",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Test TV Show",
+                "season_title": "Season 1",
+                "media_id": "1668",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TMDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [
+                    {
+                        "episode_number": 1,
+                        "name": "No Shortcuts",
+                        "air_date": "2023-06-01",  # differs from the stored date
+                        "runtime": 48,
+                    },
+                    {
+                        "episode_number": 2,
+                        "name": "Episode 2",
+                        "air_date": "2023-01-08",
+                        "runtime": 42,
+                    },
+                    {
+                        "episode_number": 3,
+                        "name": "Episode 3",
+                        "air_date": "2023-01-15",
+                        "runtime": 44,
+                    },
+                ],
+            },
+        }
+        mock_process_episodes.return_value = []
+
+        response = self.client.get(
+            reverse(
+                "season_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "test-tv-show",
+                    "season_number": 1,
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        already_dated_episode.refresh_from_db()
+        self.assertEqual(
+            already_dated_episode.release_datetime,
+            timezone.make_aware(datetime(2023, 1, 1)),
+            "an already-set release_datetime must not be overwritten",
+        )
+
+        stale_episode.refresh_from_db()
+        self.assertEqual(
+            stale_episode.release_datetime,
+            timezone.make_aware(datetime(2023, 1, 8)),
+            "a NULL release_datetime must self-heal from the live payload",
+        )
+
+        new_episode = Item.objects.get(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=3,
+        )
+        self.assertEqual(
+            new_episode.release_datetime,
+            timezone.make_aware(datetime(2023, 1, 15)),
+            "a newly created episode must get release_datetime from the same payload",
+        )
+
     @patch("app.views.trakt_popularity_service.refresh_trakt_popularity")
     @patch("app.providers.tmdb.get_tvdb_episode_image_map")
     @patch("app.helpers.get_tmdb_backdrop_image")


### PR DESCRIPTION
## Why

Season-detail metadata can fill missing episode release dates, but review of #686 found timezone, sentinel, and concurrent-write boundaries that need agreement before integration. This draft preserves Dieter Blomme’s original contribution and proposes focused fixes.

## Changes

- persist missing episode dates from season metadata
- normalize provider calendar dates to UTC midnight
- keep legacy minimum and maximum unknown-date sentinels as `NULL`
- never overwrite an existing trusted release date
- separate runtime/rating writes from conditional date fills
- isolate tests from live Trakt calls and cover TVDB datetimes, sentinels, and the concurrent-write window

## Stack and collaboration gate

- Base: #685
- Related contributor PR: #686 remains open and contributor-owned
- This draft exists because GitHub rejected direct pushes to the contributor fork
- Compatible with #683
- **Blocked: do not merge or use this PR to close #686 without contributor and maintainer coordination**

## Validation

- focused season-detail persistence/sentinel/concurrency tests: 3 passed
- Ruff and `git diff --check`: passed
- independent code review: READY after the concurrency finding was fixed
- Gstack-QA: 100/100 scoped season-page flow

## Review gates

- Human review: independent technical review completed; contributor and maintainer approval pending
- Gstack-QA: passed

## Attribution

Original implementation: Dieter Blomme / @daften, commit `cd0746ecec38ed91745dda809e011fffa9875e17`, preserved as the first commit in this branch.