### PR TITLE
fix(lists): complete episode card actions

### DIFF
--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -1984,6 +1984,93 @@ class ListDetailViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'title="Add to custom lists"')
 
+    @patch.object(get_user_model(), "update_preference")
+    @patch.object(CustomList, "user_can_view")
+    def test_list_detail_episode_watch_button_loads_real_modal_and_reflects_state(
+        self,
+        mock_user_can_view,
+        mock_update_preference,
+    ):
+        """Episode cards' watch-toggle button must actually load the track modal.
+
+        Previously this button only set trackOpen=true with no hx-get, so
+        clicking it opened a permanently empty modal overlay (verified live
+        in a browser) — Alpine had nothing to load into the target div. It
+        also always said "Mark watched" even when the episode was already
+        watched, unlike every other media type's tracking button which
+        reflects an already-in-progress/edit state.
+        """
+        mock_update_preference.side_effect = ["date_added", None]
+        mock_user_can_view.return_value = True
+
+        unwatched_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="The One Where It Starts",
+            season_number=1,
+            episode_number=1,
+            image=settings.IMG_NONE,
+        )
+        watched_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="The One With Two Parts",
+            season_number=1,
+            episode_number=2,
+            image=settings.IMG_NONE,
+        )
+        season_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            image=settings.IMG_NONE,
+        )
+        tv_item = Item.objects.create(
+            media_id="9001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            image=settings.IMG_NONE,
+        )
+        tv = TV.objects.create(item=tv_item, user=self.user, status=Status.IN_PROGRESS.value)
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        watched_episode = Episode.objects.create(
+            item=watched_item,
+            related_season=season,
+        )
+
+        episode_list = CustomList.objects.create(name="Episode List", owner=self.user)
+        CustomListItem.objects.create(custom_list=episode_list, item=unwatched_item)
+        CustomListItem.objects.create(custom_list=episode_list, item=watched_item)
+
+        response = self.client.get(reverse("list_detail", args=[episode_list.id]))
+
+        self.assertEqual(response.status_code, 200)
+        expected_url = reverse(
+            "track_modal",
+            kwargs={
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.EPISODE.value,
+                "media_id": "9001",
+                "season_number": 1,
+            },
+        )
+        self.assertContains(response, f'hx-get="{expected_url}"')
+        self.assertContains(response, '"is_create": "1"')
+        self.assertContains(
+            response,
+            f'"instance_id": "{watched_episode.id}"',
+        )
+        self.assertContains(response, 'title="Mark watched"')
+        self.assertContains(response, 'title="Watched"')
+
     @patch("lists.views.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")

--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -1942,6 +1942,48 @@ class ListDetailViewTests(TestCase):
         self.assertContains(response, "http://example.com/season.jpg")
         self.assertContains(response, "media-card-subtitle-always")
 
+    @patch.object(get_user_model(), "update_preference")
+    @patch.object(CustomList, "user_can_view")
+    def test_list_detail_episode_cards_show_lists_button_on_hover(
+        self,
+        mock_user_can_view,
+        mock_update_preference,
+    ):
+        """Episode cards in a list grid must expose the "add to lists" action.
+
+        Previously the episode branch of media_card.html only rendered the
+        "mark watched" toggle, so an episode already in a custom list (e.g. a
+        "watch together" list of specific episodes) had no way to be removed
+        from the list overview screen — the Lists button only existed on the
+        episode's own detail page.
+        """
+        mock_update_preference.side_effect = ["date_added", None]
+        mock_user_can_view.return_value = True
+
+        episode_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="The One Where It Starts",
+            season_number=1,
+            episode_number=1,
+            image=settings.IMG_NONE,
+        )
+
+        episode_list = CustomList.objects.create(
+            name="Episode List",
+            owner=self.user,
+        )
+        CustomListItem.objects.create(
+            custom_list=episode_list,
+            item=episode_item,
+        )
+
+        response = self.client.get(reverse("list_detail", args=[episode_list.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'title="Add to custom lists"')
+
     @patch("lists.views.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")

--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -2071,6 +2071,15 @@ class ListDetailViewTests(TestCase):
         self.assertContains(response, 'title="Mark watched"')
         self.assertContains(response, 'title="Watched"')
 
+        # Regression: Django's {# #} comment syntax is single-line only —
+        # spreading one across multiple lines silently stops it being
+        # recognized as a comment at all, and the literal text (including
+        # this internal implementation note) renders straight into the
+        # page. Caught live: it showed up as visible text on an episode
+        # card. `{% comment %}...{% endcomment %}` is the multi-line form.
+        self.assertNotContains(response, "hero_track_button")
+        self.assertNotContains(response, "empty overlay")
+
     @patch("lists.views.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")

--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -1984,12 +1984,14 @@ class ListDetailViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'title="Add to custom lists"')
 
+    @patch("app.models.tv.providers.services.get_media_metadata")
     @patch.object(get_user_model(), "update_preference")
     @patch.object(CustomList, "user_can_view")
     def test_list_detail_episode_watch_button_loads_real_modal_and_reflects_state(
         self,
         mock_user_can_view,
         mock_update_preference,
+        mock_get_metadata,
     ):
         """Episode cards' watch-toggle button must actually load the track modal.
 
@@ -2002,6 +2004,9 @@ class ListDetailViewTests(TestCase):
         """
         mock_update_preference.side_effect = ["date_added", None]
         mock_user_can_view.return_value = True
+        mock_get_metadata.return_value = {
+            "season/1": {"episodes": [{"episode_number": 1}, {"episode_number": 2}]},
+        }
 
         unwatched_item = Item.objects.create(
             media_id="9001",
@@ -2070,6 +2075,7 @@ class ListDetailViewTests(TestCase):
         )
         self.assertContains(response, 'title="Mark watched"')
         self.assertContains(response, 'title="Watched"')
+        self.assertContains(response, 'aria-label="Edit watched entry"')
 
         # Regression: Django's {# #} comment syntax is single-line only —
         # spreading one across multiple lines silently stops it being
@@ -2149,6 +2155,7 @@ class ListDetailViewTests(TestCase):
         self.assertContains(response, "Rebirth")
         self.assertEqual(episode_item.title, "Rebirth")
         self.assertContains(response, "http://example.com/season-zero.jpg")
+        self.assertContains(response, "&season_number=0")
 
 
 class CreateListViewTest(TestCase):

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -287,8 +287,10 @@
                     trackOpen but nothing ever populated the target, so it opened
                     an empty overlay.
                   {% endcomment %}
-                  <button class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
+                  <button type="button"
+                          class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
                           title="{% if media %}Watched{% else %}Mark watched{% endif %}"
+                          aria-label="{% if media %}Edit watched entry{% else %}Mark watched{% endif %}"
                           hx-get="{% url 'track_modal' source=item.source media_type='episode' media_id=item.media_id season_number=item.season_number %}"
                           hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}", "episode_number": "{{ item.episode_number }}"{% if media %}, "instance_id": "{{ media.id }}"{% else %}, "is_create": "1"{% endif %}}'
                           hx-target="#{% component_id 'track' item media.id %}"
@@ -302,7 +304,8 @@
                     episodes) can be managed from any grid, not just the
                     episode's own page.
                   {% endcomment %}
-                  <button class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
+                  <button type="button"
+                          class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
                           title="Add to custom lists"
                           hx-get="{% media_view_url 'lists_modal' item %}"
                           hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
@@ -315,7 +318,7 @@
                   {# History Button #}
                   <a class="p-2.5 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
                      title="View your activity history"
-                     href="{% url 'history' %}?media_type={{ MediaTypes.TV.value }}&media_id={{ item.media_id|urlencode }}&source={{ item.source|urlencode }}{% if item.season_number %}&season_number={{ item.season_number }}{% endif %}">
+                     href="{% url 'history' %}?media_type={{ MediaTypes.TV.value }}&media_id={{ item.media_id|urlencode }}&source={{ item.source|urlencode }}{% if item.season_number is not None %}&season_number={{ item.season_number }}{% endif %}">
                     {% include "app/icons/history.svg" with classes="w-4 h-4" %}
                   </a>
                 {% else %}

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -277,14 +277,16 @@
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                 {% elif item.media_type == MediaTypes.EPISODE.value %}
-                  {# track_modal's URL doesn't accept episode_number in the path
-                     (media_view_url strips it for this view name), so build the
-                     URL directly here and pass episode_number via hx-vals —
-                     mirrors detail_episode_hero_track_button.html, the working
-                     equivalent of this button on the episode's own page. Without
-                     hx-get this button had no way to load modal content: it set
-                     trackOpen but nothing ever populated the target, so it opened
-                     an empty overlay. #}
+                  {% comment %}
+                    track_modal's URL doesn't accept episode_number in the path
+                    (media_view_url strips it for this view name), so build the
+                    URL directly here and pass episode_number via hx-vals —
+                    mirrors detail_episode_hero_track_button.html, the working
+                    equivalent of this button on the episode's own page. Without
+                    hx-get this button had no way to load modal content: it set
+                    trackOpen but nothing ever populated the target, so it opened
+                    an empty overlay.
+                  {% endcomment %}
                   <button class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
                           title="{% if media %}Watched{% else %}Mark watched{% endif %}"
                           hx-get="{% url 'track_modal' source=item.source media_type='episode' media_id=item.media_id season_number=item.season_number %}"
@@ -298,9 +300,12 @@
                       {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
                     {% endif %}
                   </button>
-                  {# Lists Button — episode cards need this too so items added to a
-                     custom list (e.g. a "watch together" list of specific episodes)
-                     can be managed from any grid, not just the episode's own page. #}
+                  {% comment %}
+                    Lists Button — episode cards need this too so items added to
+                    a custom list (e.g. a "watch together" list of specific
+                    episodes) can be managed from any grid, not just the
+                    episode's own page.
+                  {% endcomment %}
                   <button class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
                           title="Add to custom lists"
                           hx-get="{% media_view_url 'lists_modal' item %}"

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -278,12 +278,25 @@
                   </button>
                 {% elif item.media_type == MediaTypes.EPISODE.value %}
                   <button @click="trackOpen = true"
+                          title="Mark watched"
                           class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer">
                     {% if media %}
                       {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
                     {% else %}
                       {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
                     {% endif %}
+                  </button>
+                  {# Lists Button — episode cards need this too so items added to a
+                     custom list (e.g. a "watch together" list of specific episodes)
+                     can be managed from any grid, not just the episode's own page. #}
+                  <button class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
+                          title="Add to custom lists"
+                          hx-get="{% media_view_url 'lists_modal' item %}"
+                          hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
+                          hx-target="#{% component_id 'lists' item %}"
+                          hx-trigger="click once"
+                          @click="listsOpen = true">
+                    {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                 {% else %}
                   {# Track Button #}

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -294,11 +294,7 @@
                           hx-target="#{% component_id 'track' item media.id %}"
                           hx-trigger="click once"
                           @click="trackOpen = true">
-                    {% if media %}
-                      {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
-                    {% else %}
-                      {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
-                    {% endif %}
+                    {% include "app/icons/edit.svg" with classes="w-4 h-4" %}
                   </button>
                   {% comment %}
                     Lists Button — episode cards need this too so items added to

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -243,7 +243,7 @@
               
               <a href="{% if media.album %}{{ media.album|music_album_url }}{% elif media.artist %}{{ media.artist|music_artist_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% else %}{{ item|media_url }}{% endif %}" class="absolute inset-0 z-0"></a>
 
-              <div class="relative z-10 flex items-center justify-center space-x-2.5"
+              <div class="relative z-10 flex items-center justify-center {% if item.media_type == MediaTypes.EPISODE.value %}gap-1{% else %}space-x-2.5{% endif %}"
                    {% if list_ordering_enabled|default:False %}
                      x-show="!isOrderEditing"
                    {% endif %}>
@@ -288,7 +288,7 @@
                     an empty overlay.
                   {% endcomment %}
                   <button type="button"
-                          class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
+                          class="p-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
                           title="{% if media %}Watched{% else %}Mark watched{% endif %}"
                           aria-label="{% if media %}Edit watched entry{% else %}Mark watched{% endif %}"
                           hx-get="{% url 'track_modal' source=item.source media_type='episode' media_id=item.media_id season_number=item.season_number %}"
@@ -305,7 +305,7 @@
                     episode's own page.
                   {% endcomment %}
                   <button type="button"
-                          class="p-2.5 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
+                          class="p-2 bg-emerald-600 text-white rounded-full hover:bg-emerald-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(16,185,129,0.5)] transition-all duration-200 cursor-pointer"
                           title="Add to custom lists"
                           hx-get="{% media_view_url 'lists_modal' item %}"
                           hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}"}'
@@ -316,7 +316,7 @@
                   </button>
 
                   {# History Button #}
-                  <a class="p-2.5 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
+                  <a class="p-2 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
                      title="View your activity history"
                      href="{% url 'history' %}?media_type={{ MediaTypes.TV.value }}&media_id={{ item.media_id|urlencode }}&source={{ item.source|urlencode }}{% if item.season_number is not None %}&season_number={{ item.season_number }}{% endif %}">
                     {% include "app/icons/history.svg" with classes="w-4 h-4" %}

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -277,9 +277,21 @@
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                 {% elif item.media_type == MediaTypes.EPISODE.value %}
-                  <button @click="trackOpen = true"
-                          title="Mark watched"
-                          class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer">
+                  {# track_modal's URL doesn't accept episode_number in the path
+                     (media_view_url strips it for this view name), so build the
+                     URL directly here and pass episode_number via hx-vals —
+                     mirrors detail_episode_hero_track_button.html, the working
+                     equivalent of this button on the episode's own page. Without
+                     hx-get this button had no way to load modal content: it set
+                     trackOpen but nothing ever populated the target, so it opened
+                     an empty overlay. #}
+                  <button class="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full hover:scale-110 hover:shadow-[0_0_15px_rgba(99,102,241,0.5)] transition-all duration-200 cursor-pointer"
+                          title="{% if media %}Watched{% else %}Mark watched{% endif %}"
+                          hx-get="{% url 'track_modal' source=item.source media_type='episode' media_id=item.media_id season_number=item.season_number %}"
+                          hx-vals='{"return_url": "{{ request.get_full_path|urlencode }}", "episode_number": "{{ item.episode_number }}"{% if media %}, "instance_id": "{{ media.id }}"{% else %}, "is_create": "1"{% endif %}}'
+                          hx-target="#{% component_id 'track' item media.id %}"
+                          hx-trigger="click once"
+                          @click="trackOpen = true">
                     {% if media %}
                       {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
                     {% else %}
@@ -298,6 +310,13 @@
                           @click="listsOpen = true">
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
+
+                  {# History Button #}
+                  <a class="p-2.5 bg-amber-600 text-white rounded-full hover:bg-amber-500 hover:scale-110 hover:shadow-[0_0_15px_rgba(245,158,11,0.5)] transition-all duration-200 cursor-pointer"
+                     title="View your activity history"
+                     href="{% url 'history' %}?media_type={{ MediaTypes.TV.value }}&media_id={{ item.media_id|urlencode }}&source={{ item.source|urlencode }}{% if item.season_number %}&season_number={{ item.season_number }}{% endif %}">
+                    {% include "app/icons/history.svg" with classes="w-4 h-4" %}
+                  </a>
                 {% else %}
                   {# Track Button #}
                   {% if use_podcast_show|default:False and podcast_show %}


### PR DESCRIPTION
## Summary

- Preserve all four @daften commits from #611, including authorship and intent.
- Propose deterministic, accessible episode watch, Lists, and History controls.
- Preserve season 0 in History links and isolate focused tests from live providers.
- Fit all three controls within the mobile card while retaining WCAG 2.2 target sizing.

## Why

#611 contains useful contributor work. This draft review stack holds tested fix proposals because GitHub rejected direct pushes to the contributor fork. It is not a replacement for #611.

## Collaboration gate

- Related contributor PR: #611 remains open and contributor-owned
- Base: #685
- **Blocked: do not merge or use this PR to close #611 without contributor and maintainer coordination**
- Contributor commits remain first in branch history

## Validation

- focused list-detail regressions: 4/4 passed
- djlint and `git diff --check`: passed
- independent code review: READY
- Gstack-QA desktop and 390x844 mobile: passed after the scoped overflow fix
- Nielsen/accessibility review: passed

## Review gates

- Human review: independent technical review completed; contributor and maintainer approval pending
- Gstack-QA: passed on 2026-08-12

## Scope

Two files only: episode card template and closest view tests. No model, migration, provider, API, OpenAPI, or configuration changes.