### PR TITLE
fix(providers): paginate MyAnimeList search

### DIFF
--- a/src/app/providers/mal.py
+++ b/src/app/providers/mal.py
@@ -54,6 +54,7 @@ def search(media_type, query, page):
             "q": query,
             "fields": "media_type,start_date,alternative_titles",
             "limit": settings.PER_PAGE,
+            "offset": (page - 1) * settings.PER_PAGE,
         }
         if settings.MAL_NSFW:
             params["nsfw"] = "true"
@@ -69,7 +70,8 @@ def search(media_type, query, page):
         except requests.exceptions.HTTPError as error:
             response = handle_error(error)
 
-        response = response["data"]
+        response_data = response["data"]
+        has_next_page = bool(response.get("paging", {}).get("next"))
         results = [
             {
                 "media_id": media["node"]["id"],
@@ -82,15 +84,16 @@ def search(media_type, query, page):
                 "image": get_image_url(media["node"]),
                 "year": get_start_year(media["node"]),
             }
-            for media in response
+            for media in response_data
         ]
 
         data = helpers.format_search_response(
             page,
-            100,
-            len(results),
+            settings.PER_PAGE,
+            (page - 1) * settings.PER_PAGE + len(results) + int(has_next_page),
             results,
         )
+        data["total_pages"] = page + int(has_next_page)
 
         cache.set(cache_key, data)
 

--- a/src/app/tests/providers/test_search.py
+++ b/src/app/tests/providers/test_search.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 
 from app.models import MediaTypes, Sources
 from app.providers import (
@@ -44,6 +44,47 @@ class Search(TestCase):
         response = mal.search(MediaTypes.ANIME.value, "q", 1)
 
         self.assertEqual(response["results"], [])
+
+    @override_settings(PER_PAGE=2, MAL_NSFW=False)
+    @patch("app.providers.mal.services.api_request")
+    def test_mal_search_uses_page_offset_and_page_specific_cache(self, mock_request):
+        """MAL pagination sends offsets without mixing cached pages."""
+        mock_request.side_effect = [
+            {
+                "data": [
+                    {
+                        "node": {
+                            "id": 1,
+                            "title": "Original one",
+                            "alternative_titles": {"en": "Localized one"},
+                        },
+                    },
+                    {"node": {"id": 2, "title": "Original two"}},
+                ],
+                "paging": {"next": "https://api.myanimelist.net/v2/anime?offset=2"},
+            },
+            {
+                "data": [
+                    {"node": {"id": 3, "title": "Original three"}},
+                    {"node": {"id": 4, "title": "Original four"}},
+                ],
+                "paging": {},
+            },
+        ]
+
+        first_page = mal.search(MediaTypes.ANIME.value, "test", 1)
+        cached_first_page = mal.search(MediaTypes.ANIME.value, "test", 1)
+        second_page = mal.search(MediaTypes.ANIME.value, "test", 2)
+
+        self.assertEqual(first_page, cached_first_page)
+        self.assertEqual([result["media_id"] for result in first_page["results"]], [1, 2])
+        self.assertEqual([result["media_id"] for result in second_page["results"]], [3, 4])
+        self.assertEqual(first_page["results"][0]["title"], "Localized one")
+        self.assertEqual(first_page["total_pages"], 2)
+        self.assertEqual(second_page["total_pages"], 2)
+        self.assertEqual(mock_request.call_count, 2)
+        self.assertEqual(mock_request.call_args_list[0].kwargs["params"]["offset"], 0)
+        self.assertEqual(mock_request.call_args_list[1].kwargs["params"]["offset"], 2)
 
     @tag("network")
     def test_mangaupdates(self):


### PR DESCRIPTION
## Why

MyAnimeList search ignored the requested page, so every later page repeated page one.

## Changes

- send `offset = (page - 1) * PER_PAGE`
- keep page-one and page-two caches separate
- preserve localized-title behavior
- derive the next visible page from MAL `paging.next` instead of inventing a fixed page total
- add deterministic offline multi-page coverage

## Stack

- Base: #685, the shared provider/browser fixture isolation prerequisite
- Closes #700
- Parent provider package: #649

## Upstream attribution

Adapted from Yamtrack commit [`8aaea2d7`](https://github.com/FuzzyGrim/Yamtrack/commit/8aaea2d78409edeec5f6b4f842eb066e0cbd740a), authored by FuzzyGrim on 2026-06-01. Floppy intentionally retains localized titles and MAL response paging metadata.

## Validation

- RED: deterministic page fixture returned `total_pages=1` and had no offset
- GREEN: pagination/cache regression 1/1 passed
- focused MAL service boundary 3/3 passed
- Ruff and `git diff --check`: passed

## Review gates

- Human review: pending independent technical review and final maintainer approval
- Gstack-QA: pending scoped provider-contract QA

No merge is authorized.