### PR TITLE
fix(providers): identify Open Library requests

### DIFF
--- a/src/app/providers/openlibrary.py
+++ b/src/app/providers/openlibrary.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 base_url = "https://openlibrary.org/api"
 search_url = "https://openlibrary.org/search.json"
+REQUEST_HEADERS = {
+    "User-Agent": "Floppy/1.0 (+https://github.com/dannyvfilms/Floppy)",
+}
 
 
 def handle_error(error):
@@ -48,6 +51,7 @@ def search(query, page):
                 "GET",
                 search_url,
                 params=params,
+                headers=REQUEST_HEADERS,
             )
         except requests.RequestException as e:
             handle_error(e)
@@ -136,6 +140,7 @@ async def async_book(media_id):
                 Sources.OPENLIBRARY.value,
                 "GET",
                 book_url,
+                headers=REQUEST_HEADERS,
             )
         except requests.RequestException as e:
             handle_error(e)
@@ -151,6 +156,7 @@ async def async_book(media_id):
                     Sources.OPENLIBRARY.value,
                     "GET",
                     work_url,
+                    headers=REQUEST_HEADERS,
                 )
             except requests.RequestException as e:
                 handle_error(e)
@@ -299,7 +305,10 @@ async def get_authors_full(response):
     author_entries = response.get("authors", [])
 
     timeout = aiohttp.ClientTimeout(total=settings.REQUEST_TIMEOUT)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
+    async with aiohttp.ClientSession(
+        timeout=timeout,
+        headers=REQUEST_HEADERS,
+    ) as session:
         tasks = []
         for index, author in enumerate(author_entries):
             if isinstance(author, dict) and "author" in author:
@@ -376,7 +385,7 @@ async def get_editions(response_book, response_work):
 
     timeout = aiohttp.ClientTimeout(total=settings.REQUEST_TIMEOUT)
     async with (
-        aiohttp.ClientSession(timeout=timeout) as session,
+        aiohttp.ClientSession(timeout=timeout, headers=REQUEST_HEADERS) as session,
         session.get(url) as response,
     ):
         if response.status == requests.codes.ok:
@@ -409,7 +418,7 @@ async def get_ratings(response_work):
 
     timeout = aiohttp.ClientTimeout(total=settings.REQUEST_TIMEOUT)
     async with (
-        aiohttp.ClientSession(timeout=timeout) as session,
+        aiohttp.ClientSession(timeout=timeout, headers=REQUEST_HEADERS) as session,
         session.get(url) as response,
     ):
         if response.status == requests.codes.ok:
@@ -443,6 +452,7 @@ def _resolve_edition_id_from_work_id(work_id):
             "GET",
             editions_url,
             params={"limit": 1},
+            headers=REQUEST_HEADERS,
         )
     except requests.RequestException as error:
         logger.debug("Failed to resolve work editions for %s: %s", work_id, error)
@@ -471,12 +481,14 @@ def author_profile(author_id):
             Sources.OPENLIBRARY.value,
             "GET",
             author_url,
+            headers=REQUEST_HEADERS,
         )
         works_data = services.api_request(
             Sources.OPENLIBRARY.value,
             "GET",
             works_url,
             params={"limit": 100},
+            headers=REQUEST_HEADERS,
         )
     except requests.RequestException as error:
         handle_error(error)

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -1844,6 +1844,93 @@ class Metadata(TestCase):
         self.assertEqual(response["title"], "Nineteen Eighty-Four")
         self.assertEqual(response["details"]["author"], ["George Orwell"])
 
+    @patch("app.providers.openlibrary.services.api_request")
+    def test_openlibrary_search_sends_floppy_user_agent(self, mock_api_request):
+        openlibrary.cache.delete("search_openlibrary_book_identity_1")
+        mock_api_request.return_value = {"docs": [], "numFound": 0}
+
+        openlibrary.search("identity", 1)
+
+        self.assertEqual(
+            mock_api_request.call_args.kwargs["headers"],
+            openlibrary.REQUEST_HEADERS,
+        )
+
+    @patch("app.providers.openlibrary.get_ratings", return_value=(None, None))
+    @patch("app.providers.openlibrary.get_editions", return_value=[])
+    @patch("app.providers.openlibrary.get_authors_full", return_value=[])
+    @patch("app.providers.openlibrary.services.api_request")
+    def test_openlibrary_book_and_work_send_floppy_user_agent(
+        self,
+        mock_api_request,
+        _mock_authors,
+        _mock_editions,
+        _mock_ratings,
+    ):
+        openlibrary.cache.delete("openlibrary_book_OL1M")
+        mock_api_request.side_effect = [
+            {"key": "/books/OL1M", "title": "Book", "works": [{"key": "/works/OL1W"}]},
+            {"key": "/works/OL1W"},
+        ]
+
+        asyncio.run(openlibrary.async_book("OL1M"))
+
+        self.assertEqual(mock_api_request.call_count, 2)
+        for request_call in mock_api_request.call_args_list:
+            self.assertEqual(
+                request_call.kwargs["headers"],
+                openlibrary.REQUEST_HEADERS,
+            )
+
+    @patch("app.providers.openlibrary.aiohttp.ClientSession")
+    def test_openlibrary_async_sessions_send_floppy_user_agent(self, mock_session):
+        session = mock_session.return_value.__aenter__.return_value
+        response_context = MagicMock()
+        session.get = MagicMock(return_value=response_context)
+        response = response_context.__aenter__.return_value
+        response.status = requests.codes.service_unavailable
+
+        asyncio.run(openlibrary.get_authors_full({}))
+        asyncio.run(openlibrary.get_editions({"key": "/books/OL1M"}, {"key": "/works/OL1W"}))
+        asyncio.run(openlibrary.get_ratings({"key": "/works/OL1W"}))
+
+        self.assertEqual(mock_session.call_count, 3)
+        for session_call in mock_session.call_args_list:
+            self.assertEqual(
+                session_call.kwargs["headers"],
+                openlibrary.REQUEST_HEADERS,
+            )
+
+    def test_openlibrary_retry_preserves_user_agent(self):
+        rate_limited = MagicMock(
+            status_code=requests.codes.too_many_requests,
+            headers={"Retry-After": "0"},
+        )
+        rate_limited.raise_for_status.side_effect = requests.HTTPError(
+            response=rate_limited,
+        )
+        ok = MagicMock(status_code=requests.codes.ok)
+        ok.raise_for_status.return_value = None
+        ok.json.return_value = {"ok": True}
+
+        with (
+            patch.object(services.session, "get", side_effect=[rate_limited, ok]) as get,
+            patch.object(services.time, "sleep"),
+        ):
+            services.api_request(
+                Sources.OPENLIBRARY.value,
+                "GET",
+                "https://openlibrary.org/test.json",
+                headers=openlibrary.REQUEST_HEADERS,
+            )
+
+        self.assertEqual(get.call_count, 2)
+        for request_call in get.call_args_list:
+            self.assertEqual(
+                request_call.kwargs["headers"],
+                openlibrary.REQUEST_HEADERS,
+            )
+
     @tag("network")
     def test_comic(self):
         """Test the metadata method for comics."""
@@ -1965,6 +2052,7 @@ class Metadata(TestCase):
         openlibrary.cache.delete(f"{Sources.OPENLIBRARY.value}_person_OL1A")
 
         def _mock_api_request(_source, _method, url, params=None, **kwargs):
+            self.assertEqual(kwargs["headers"], openlibrary.REQUEST_HEADERS)
             if url.endswith("/authors/OL1A.json"):
                 return {
                     "name": "Open Author",


### PR DESCRIPTION
## Why

Open Library asks API clients to identify themselves. Floppy sent no project User-Agent on synchronous or aiohttp requests.

## Changes

- define one non-PII Floppy User-Agent with the repository URL
- reuse it for search, book, work, author, edition, and ratings requests
- preserve it across the existing bounded retry path
- add deterministic synchronous and asynchronous coverage

## Stack

- Base: #685, the shared provider/browser fixture isolation prerequisite
- Closes #701
- Parent provider package: #649

## Upstream attribution

Adapted from Yamtrack commit [`dc7271e2`](https://github.com/FuzzyGrim/Yamtrack/commit/dc7271e22ca91f1400a73978b2ed80c5844019bb), authored by FuzzyGrim on 2026-05-25. Floppy uses its own repository identity and no personal email address.

## Validation

- RED: mocked search request had no `headers` argument
- GREEN: synchronous, aiohttp, author/edition, and retry boundary 6/6 passed
- Ruff and `git diff --check`: passed

## Review gates

- Human review: pending independent technical review and final maintainer approval
- Gstack-QA: pending scoped provider-contract QA

No credentials, request bodies, or sensitive URLs are logged. No merge is authorized.