### PR TITLE
Fall back to TMDB for empty Trakt discover rows

### DIFF
--- a/src/app/discover/service.py
+++ b/src/app/discover/service.py
@@ -1028,6 +1028,7 @@ def _build_and_cache_row(
     started = timezone.now()
     build_activity_version = tab_cache.get_activity_version(user.id, media_type)
     row_meta: dict | None = None
+    source_state = "live"
     if media_type in {
         MediaTypes.MOVIE.value,
         MediaTypes.TV.value,
@@ -1055,6 +1056,15 @@ def _build_and_cache_row(
             user, media_type, row_definition, profile_payload
         )
 
+    if not candidates and row_definition.source == "trakt":
+        fallback_candidates = _trakt_row_provider_fallback_candidates(
+            media_type,
+            row_definition.key,
+        )
+        if fallback_candidates:
+            candidates = fallback_candidates
+            source_state = "fallback"
+
     row_meta = dict(row_meta or {})
     required_schema_version = _required_row_cache_schema_version(
         media_type, row_definition.key
@@ -1071,7 +1081,7 @@ def _build_and_cache_row(
         candidates,
         defer_artwork=defer_artwork,
         show_more=show_more,
-        source_state="live",
+        source_state=source_state,
     )
 
     cache_payload = row.to_dict()

--- a/src/app/tests/discover/test_service.py
+++ b/src/app/tests/discover/test_service.py
@@ -30,6 +30,7 @@ from app.discover.service import (
     _apply_comfort_confidence,
     _apply_top_picks_source_quotas,
     _apply_wildcard_novelty,
+    _build_and_cache_row,
     _build_comfort_debug_payload,
     _clear_out_next_candidates,
     _comfort_candidates,
@@ -85,6 +86,65 @@ class DiscoverServiceTests(TestCase):
             summary["current_top_titles"],
             payload,
         )
+
+    @patch("app.discover.providers.trakt_adapter.services.api_request")
+    @patch(
+        "app.discover.providers.trakt_adapter.trakt_provider.is_configured",
+        return_value=False,
+    )
+    @patch("app.discover.service.TMDB_ADAPTER.current_cycle")
+    def test_unconfigured_trakt_rows_fall_back_to_tmdb_for_movies_and_tv(
+        self,
+        mock_current_cycle,
+        _mock_trakt_configured,
+        mock_trakt_request,
+    ):
+        row_definition = RowDefinition(
+            key="trending_right_now",
+            title="Trending Right Now",
+            mission="Cultural Moment",
+            why="What everyone has been watching this week.",
+            source="trakt",
+        )
+
+        for media_type in (MediaTypes.MOVIE.value, MediaTypes.TV.value):
+            with self.subTest(media_type=media_type):
+                mock_current_cycle.return_value = [
+                    CandidateItem(
+                        media_type=media_type,
+                        source=Sources.TMDB.value,
+                        media_id=f"fallback-{media_type}",
+                        title=f"Fallback {media_type}",
+                        image="https://example.com/poster.jpg",
+                    ),
+                ]
+
+                row = _build_and_cache_row(
+                    self.user,
+                    media_type,
+                    row_definition,
+                    {},
+                    defer_artwork=True,
+                )
+
+                self.assertEqual(row.source_state, "fallback")
+                self.assertEqual(
+                    [item.media_id for item in row.items],
+                    [f"fallback-{media_type}"],
+                )
+                mock_current_cycle.assert_called_with(media_type, limit=100)
+                cached_payload, _ = cache_repo.get_row_cache(
+                    self.user.id,
+                    media_type,
+                    row_definition.key,
+                )
+                self.assertEqual(cached_payload["source_state"], "fallback")
+                self.assertEqual(
+                    [item["media_id"] for item in cached_payload["items"]],
+                    [f"fallback-{media_type}"],
+                )
+
+        mock_trakt_request.assert_not_called()
 
     @patch("app.discover.service._build_and_cache_row")
     @patch("app.discover.service.get_rows")


### PR DESCRIPTION
## What changed

- fall back to the existing TMDB row providers when a Trakt-backed movie or TV row returns no candidates
- preserve `fallback` source state and cache the populated TMDB row instead of an empty Trakt result
- cover unconfigured Trakt behavior for both movie and TV rows, including the no-request short circuit and persisted cache payload

## Why

When Trakt is unconfigured, the adapter intentionally returns an empty successful result. The Discover service only used its TMDB fallback after exceptions, so empty movie and TV rows were cached even when TMDB was configured and healthy.

## Impact

Movie and TV discovery continues to prefer Trakt when it returns candidates. Empty or unavailable Trakt results now degrade to the existing TMDB providers for trending, top-rated, and upcoming rows. Other media types are unchanged.

## AI Assistance

Generated with OpenAI Codex (GPT-5). Reviewed and tested through the repository's automated validation.

## Validation

- `uv run --no-sync python src/manage.py test --parallel --buffer app.tests.discover.test_service` — 104 tests passed
- focused unconfigured-Trakt and exception-fallback tests — 2 tests passed
- `uv run --no-sync ruff check src/app/discover/service.py src/app/tests/discover/test_service.py` — passed
- fast suite: 3,400 tests ran; 10 unrelated baseline/environment failures remain (4 failures, 6 errors), including Windows timezone errors, ordering assertions, and a separately reproducible tab-cache timing assertion

Fixes #709
