### PR TITLE
Make progress unit/scope explicit in API, add game platform search

### DIFF
--- a/mcp_server/floppy_mcp/server.py
+++ b/mcp_server/floppy_mcp/server.py
@@ -73,7 +73,11 @@ async def search_media(media_type: str, query: str, page: int = 1) -> Any:
     media_type: one of tv, movie, anime, manga, game, book, comic,
     boardgame, music, podcast, comicissue.
     Returns provider results including the source and media_id needed by
-    track_media.
+    track_media. For games, each result also includes "platforms" and
+    "year" so you can pick the right release (e.g. the GameCube version vs.
+    a remaster) without a follow-up get_media call. If a title is ambiguous
+    across platforms, prefer showing the candidates to the user over
+    guessing one.
     """
     return await _call(
         "get",
@@ -174,6 +178,15 @@ async def track_media(
     "Dropped". score is 0-10. Only pass the fields you want to set. Set
     new_play=True to append a separate consumption instead of updating an
     existing one.
+
+    progress is always the value for THIS ONE tracked entry, never a sum
+    across a user's other entries for the same item (each response also
+    carries progress_scope="entry" for clarity). Its unit depends on
+    media_type: minutes for games, episodes for tv/season/anime, plays for
+    boardgame/music, percentage/pages/chapters for book/manga/comic
+    depending on the user's preference and format, seconds for podcast.
+    Each response's progress_unit field states the unit actually in use;
+    check it rather than assuming from media_type alone.
     """
     try:
         status_code = _status_code(status)
@@ -246,10 +259,14 @@ async def update_progress(
     operation: str,
     season_number: int | None = None,
 ) -> Any:
-    """Increase or decrease progress by one unit (operation: "increase"|"decrease").
+    """Increase or decrease progress by one step (operation: "increase"|"decrease").
 
     For TV shows, pass season_number to advance/rewind that season's next
-    episode; omit it for movies, games, books, etc.
+    episode; omit it for movies, games, books, etc. The step size is not
+    always 1: games step by 30 minutes, and book/manga/comic step by one
+    percentage point when percentage tracking is on. To log an exact
+    duration or amount instead of stepping, use track_media with an
+    explicit progress value (and new_play=True for a fresh session).
     """
     path = f"media/{media_type}/{source}/{media_id}"
     if season_number is not None:

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -687,6 +687,18 @@ class MediaSerializer(serializers.ModelSerializer):
             else None,
             "status": StatusField().to_representation(instance),
             "progress": instance.progress if hasattr(instance, "progress") else None,
+            # `progress` is always this single entry's own value (this play,
+            # session, or re-watch), never a sum across a user's entries for the
+            # item; `progress_unit` names what it counts so clients don't have to
+            # infer it from media_type (e.g. minutes for games, episodes for TV,
+            # plays for boardgame/music, percentage/pages/chapters for
+            # book/manga/comic depending on preference and format).
+            "progress_scope": "entry"
+            if getattr(instance, "progress", None) is not None
+            else None,
+            "progress_unit": instance.progress_unit
+            if hasattr(instance, "progress_unit")
+            else None,
             "progressed_at": instance.progressed_at
             if hasattr(instance, "progressed_at")
             else None,
@@ -744,6 +756,8 @@ class UntrackedMediaSerializer(serializers.Serializer):
             "score": None,
             "status": None,
             "progress": None,
+            "progress_scope": None,
+            "progress_unit": None,
             "progressed_at": None,
             "start_date": None,
             "end_date": None,

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -11,7 +11,7 @@ from django.utils.timezone import datetime, localdate, make_aware
 
 # FORK: the fork pins django-health-check 3.x (no async HealthCheckView);
 # HealthView below is implemented against the 3.x CheckMixin plugin API.
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema
 from health_check.mixins import CheckMixin
 from rest_framework import permissions
 from rest_framework import views as drf_views
@@ -920,6 +920,14 @@ class MediaTypeListView(drf_views.APIView):
         This append-oriented endpoint keeps its historical default: omitted
         status means Planning. Clients updating an existing play should first
         read its consumption_id and use the exact history route instead.
+
+        `progress` set here (and returned by every media/history endpoint) is
+        always this one consumption's own value, never a sum across a user's
+        other entries for the same item -- the response's `progress_scope`
+        field is explicitly "entry" for this reason. Its unit varies by
+        media_type (e.g. minutes for games, episodes for tv/season/anime,
+        plays for boardgame/music) and is named in the response's
+        `progress_unit` field.
         """
         if not check_valid_type(media_type, complete=True):
             return Response(
@@ -4302,6 +4310,38 @@ class SearchProviderView(drf_views.APIView):
                 },
             },
         },
+        examples=[
+            OpenApiExample(
+                "Game search result (igdb)",
+                description="Game results include `platforms` and `year` so a "
+                "client can pick the right release without a follow-up detail "
+                "fetch. If a title is ambiguous across platforms, all "
+                "candidates are returned rather than a single guess.",
+                value={
+                    "pagination": {
+                        "total": 1,
+                        "limit": 20,
+                        "offset": 0,
+                        "next": None,
+                        "previous": None,
+                    },
+                    "results": [
+                        {
+                            "media_id": "2256",
+                            "source": "igdb",
+                            "media_type": "game",
+                            "title": "Super Mario Strikers",
+                            "image": "https://images.igdb.com/igdb/image/upload/"
+                            "t_original/example.jpg",
+                            "year": 2005,
+                            "platforms": ["Nintendo GameCube"],
+                        },
+                    ],
+                },
+                response_only=True,
+                media_type="application/json",
+            ),
+        ],
     )
     def get(self, request, media_type):
         """Search for media using the specified provider."""

--- a/src/app/models/media.py
+++ b/src/app/models/media.py
@@ -262,6 +262,11 @@ class Media(models.Model):
         return False
 
     @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in, or None if not well-defined."""
+        return None
+
+    @property
     def formatted_aggregated_progress(self):
         """Return formatted aggregated progress string."""
         if (
@@ -707,6 +712,11 @@ class Manga(Media):
         """Return whether formatted_progress is rendering a percentage."""
         return _percentage_progress_text(self) is not None
 
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "percentage" if self.progress_is_percentage else "chapters"
+
     def increase_progress(self):
         """Increase progress, respecting the percentage tracking preference."""
         _percentage_increase_progress(self)
@@ -839,6 +849,11 @@ class Anime(Media):
                 )
                 return
 
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "episodes"
+
 
 class Movie(Media):
     """Model for movies."""
@@ -927,6 +942,11 @@ class Game(Media):
         """Return progress in hours:minutes format."""
         return app.helpers.minutes_to_hhmm(self.progress)
 
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "minutes"
+
     def increase_progress(self):
         """Increase the progress of the media by 30 minutes."""
         self.progress += 30
@@ -958,6 +978,11 @@ class BoardGame(Media):
         value = plays if plays is not None else self.progress
         return f"{value} play{'s' if value != 1 else ''}"
 
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "plays"
+
 
 class Book(Media):
     """Model for books."""
@@ -978,6 +1003,15 @@ class Book(Media):
     def progress_is_percentage(self):
         """Return whether formatted_progress is rendering a percentage."""
         return _percentage_progress_text(self) is not None
+
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        if self.progress_is_percentage:
+            return "percentage"
+        if getattr(self, "item", None) and self.item.format == "audiobook":
+            return "minutes"
+        return "pages"
 
     def increase_progress(self):
         """Increase progress, respecting the percentage tracking preference."""
@@ -1003,6 +1037,11 @@ class Comic(Media):
         """Return whether formatted_progress is rendering a percentage."""
         return _percentage_progress_text(self) is not None
 
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "percentage" if self.progress_is_percentage else "issues"
+
     def increase_progress(self):
         """Increase progress, respecting the percentage tracking preference."""
         _percentage_increase_progress(self)
@@ -1016,3 +1055,8 @@ class ComicIssue(Media):
     """Model for individual comic issues."""
 
     tracker = FieldTracker()
+
+    @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "pages"

--- a/src/app/models/music.py
+++ b/src/app/models/music.py
@@ -313,6 +313,11 @@ class Music(Media):
         return f"{plays} play{'s' if plays != 1 else ''}"
 
     @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "plays"
+
+    @property
     def formatted_aggregated_progress(self):
         """Return aggregated progress as play count."""
         plays = getattr(self, "aggregated_progress", None)

--- a/src/app/models/podcast.py
+++ b/src/app/models/podcast.py
@@ -193,6 +193,11 @@ class Podcast(Media):
         return f"{minutes}m"
 
     @property
+    def progress_unit(self):
+        """Return the unit `progress` is measured in."""
+        return "seconds"
+
+    @property
     def progress_percentage(self):
         """Return percent listened through the current episode (0-100), or None.
 

--- a/src/app/providers/igdb.py
+++ b/src/app/providers/igdb.py
@@ -16,7 +16,7 @@ from app.providers import services
 
 logger = logging.getLogger(__name__)
 base_url = "https://api.igdb.com/v4"
-IGDB_SEARCH_CACHE_VERSION = "v4"
+IGDB_SEARCH_CACHE_VERSION = "v5"
 TOKENIZED_SEARCH_MIN_TERMS = 2
 
 
@@ -221,6 +221,7 @@ def search(query, page):
                     "title": media["name"],
                     "image": get_image_url(media),
                     "year": get_release_year(media),
+                    "platforms": get_list(media, "platforms"),
                 }
                 for media in search_results
             ]
@@ -299,7 +300,7 @@ def _build_search_multiquery(query, page, *, tokenized=False):
 
     return (
         'query games "SearchResults" {'
-        "fields name,cover.image_id;"
+        "fields name,cover.image_id,platforms.name,first_release_date;"
         "sort total_rating_count desc;"
         f"limit {settings.PER_PAGE};"
         f"offset {offset};"


### PR DESCRIPTION
Agent feedback flagged that the API's generic `progress` field gives
clients no way to tell what unit it's in or whether it's per-entry vs.
aggregated, and that IGDB search results don't expose platform info up
front, forcing an extra detail fetch to disambiguate a title.

- Add `progress_unit` (minutes/episodes/plays/percentage/pages/chapters/
  issues/seconds, per media type) and `progress_scope` ("entry", since
  the API never returns aggregated progress) to the shared MediaSerializer
  response, additive alongside the existing `progress` field.
- Add `platforms` to IGDB search results, and fix `first_release_date`
  not being requested in the search field list (so `year` was always
  null).
- Document the new fields via an OpenAPI example on the search endpoint
  and docstring notes on the create-consumption endpoint.
- Clarify MCP tool docstrings (search_media, track_media, update_progress)
  so agents don't have to infer progress units or platform handling.

Deliberately left out: an atomic game-session endpoint and a
log_game_session MCP tool, since building those for games only would
undercut the consistency goal -- that needs a cross-media-type design
pass first.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Rzjqc4YEFACvHtaE8az4J