### PR TITLE
feat(config): make SQLite data paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ services:
 ```
 
 Use a dedicated parent directory when `FLOPPY_DB_PATH` is outside
-`FLOPPY_DATA_DIR`. At startup, Floppy can change ownership recursively inside
-`FLOPPY_DATA_DIR`. It changes only the external database parent and the
-SQLite files when the database is outside that directory.
+`FLOPPY_DATA_DIR`. At startup, Floppy changes ownership only on the selected
+data, database, and log directory entries and on Floppy's generated key,
+SQLite files, and current log file. It does not change unrelated files inside
+those directories.
 
 Use local storage or block storage for SQLite. Do not use NFS, SMB/CIFS, or
 another network filesystem.
@@ -246,7 +247,9 @@ is missing, existing sessions and signed data can become invalid.
 
 ### PostgreSQL
 
-Floppy uses PostgreSQL only when `DB_HOST` is set. Without it, it uses SQLite at `/floppy/db/db.sqlite3`. `DATABASE_URL` is not supported — set the individual `DB_*` variables.
+Floppy uses PostgreSQL only when `DB_HOST` is set. Without it, it uses
+`FLOPPY_DB_PATH`; the container default is `/floppy/db/db.sqlite3`.
+`DATABASE_URL` is not supported — set the individual `DB_*` variables.
 
 ```yaml
 services:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,79 @@ Floppy exposes a REST API at `/api/v1` and ships an [MCP server](mcp_server/). I
 
 ## Configuration and deployment
 
+### SQLite data paths
+
+Floppy uses these rules when `DB_HOST` is not set:
+
+1. `FLOPPY_DB_PATH` selects the SQLite file.
+2. If `FLOPPY_DB_PATH` is not set, Floppy uses
+   `FLOPPY_DATA_DIR/db.sqlite3`.
+3. If neither variable is set, Floppy uses
+   `/floppy/db/db.sqlite3` in the container.
+
+An empty value does not override a path. A relative path starts from the
+process working directory. Use absolute paths so that each process uses the
+same location.
+
+If `SECRET` and `SECRET_FILE` are not set, the container stores its generated
+`secret_key` in `FLOPPY_DATA_DIR`. Floppy stores logs and backups in `LOG_DIR`
+and `BACKUP_DIR`. `FLOPPY_DATA_DIR` does not change those settings.
+
+This example stores the SQLite file and the generated key in one mounted
+directory:
+
+```yaml
+services:
+  floppy:
+    image: ghcr.io/dannyvfilms/floppy:latest
+    environment:
+      FLOPPY_DATA_DIR: /data/floppy
+    volumes:
+      - ./floppy-data:/data/floppy
+    ports:
+      - "8000:8000"
+```
+
+This example stores the SQLite file in a separate mounted directory:
+
+```yaml
+services:
+  floppy:
+    image: ghcr.io/dannyvfilms/floppy:latest
+    environment:
+      FLOPPY_DATA_DIR: /data/floppy
+      FLOPPY_DB_PATH: /database/floppy/db.sqlite3
+    volumes:
+      - ./floppy-data:/data/floppy
+      - ./floppy-database:/database/floppy
+    ports:
+      - "8000:8000"
+```
+
+Use a dedicated parent directory when `FLOPPY_DB_PATH` is outside
+`FLOPPY_DATA_DIR`. At startup, Floppy can change ownership recursively inside
+`FLOPPY_DATA_DIR`. It changes only the external database parent and the
+SQLite files when the database is outside that directory.
+
+Use local storage or block storage for SQLite. Do not use NFS, SMB/CIFS, or
+another network filesystem.
+
+Floppy does not move existing data when you set these variables. Use this
+procedure to change a path:
+
+1. Stop the Floppy container.
+2. Back up the current SQLite file.
+3. Copy the SQLite file to the new path. Copy its `-wal` and `-shm` companion
+   files if they are present.
+4. Copy the generated `secret_key` to the new data directory. You can set
+   `SECRET` instead if you already manage the key outside the data directory.
+5. Set the new path variables and mount each selected directory.
+6. Start Floppy and confirm that the existing library is present.
+
+If the database file is missing, Floppy creates an empty database. The
+deployment can then appear to have lost its library. If the old generated key
+is missing, existing sessions and signed data can become invalid.
+
 ### PostgreSQL
 
 Floppy uses PostgreSQL only when `DB_HOST` is set. Without it, it uses SQLite at `/floppy/db/db.sqlite3`. `DATABASE_URL` is not supported — set the individual `DB_*` variables.
@@ -412,8 +485,14 @@ upgrades matter.
 
 ### Persistence checklist
 
-- SQLite stores the app database at `/floppy/db/db.sqlite3`; persist `/floppy/db`. (Pre-rename `/yamtrack/db` mounts still resolve, so existing setups keep working.)
-- **Do not put `/floppy/db` on a network filesystem** (NFS, SMB/CIFS, or a NAS "share" mounted into Docker). Floppy's SQLite database uses WAL mode, which [SQLite's own documentation](https://sqlite.org/wal.html) warns is unsafe over network filesystems because they don't reliably support the locking it depends on - this can corrupt the database under normal concurrent use. Use local/block storage for `/floppy/db`, or set `DB_HOST` to use PostgreSQL if only network storage is available.
+- SQLite stores the app database at `/floppy/db/db.sqlite3` by default. Persist
+  `/floppy/db`, or persist each configured SQLite data path. Pre-rename
+  `/yamtrack/db` mounts still resolve, so existing setups keep working.
+- **Do not put the SQLite file on a network filesystem** such as NFS, SMB/CIFS,
+  or a NAS share that is mounted into Docker. Floppy uses SQLite WAL mode.
+  [SQLite documents](https://sqlite.org/wal.html) that WAL does not work over a
+  network filesystem. Use local storage or block storage. Set `DB_HOST` to use
+  PostgreSQL if only network storage is available.
 - PostgreSQL stores its database files at `/var/lib/postgresql/data`; persist that path on the Postgres container.
 - Redis stores sessions and background-task state; resetting Redis can log users out, but it should not delete accounts if the database is persisted.
 - Do not assume `DATABASE_URL` enables PostgreSQL. Floppy uses Postgres only when `DB_HOST` is set.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,23 +2,31 @@
 
 set -e
 
+reject_unsafe_managed_directory() {
+    managed_name=$1
+    managed_dir=$2
+    case "$managed_dir" in
+        /|/bin|/boot|/dev|/etc|/home|/lib|/lib32|/lib64|/libx32|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/var|/usr/bin|/usr/include|/usr/lib|/usr/lib32|/usr/lib64|/usr/libx32|/usr/local|/usr/sbin|/usr/share|/usr/src|/var/backups|/var/cache|/var/lib|/var/local|/var/lock|/var/log|/var/mail|/var/opt|/var/spool|/var/tmp)
+            echo "[entrypoint] ${managed_name} must resolve to a dedicated directory, not system directory ${managed_dir}." >&2
+            exit 1
+            ;;
+    esac
+}
+
 DATA_DIR_INPUT=${FLOPPY_DATA_DIR:-/floppy/db}
 DATA_DIR=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DATA_DIR_INPUT")
+LOG_DIR_INPUT=${LOG_DIR:-/floppy/logs}
+LOG_DIR_PATH=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$LOG_DIR_INPUT")
 
-if [ "$DATA_DIR" = / ]; then
-    echo "[entrypoint] FLOPPY_DATA_DIR must resolve to a directory below /." >&2
-    exit 1
-fi
+reject_unsafe_managed_directory FLOPPY_DATA_DIR "$DATA_DIR"
+reject_unsafe_managed_directory LOG_DIR "$LOG_DIR_PATH"
 
 if [ -z "$DB_HOST" ]; then
     DB_FILE_INPUT=${FLOPPY_DB_PATH:-"${DATA_DIR_INPUT}/db.sqlite3"}
     DB_FILE=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DB_FILE_INPUT")
     DB_PARENT=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).parent)' "$DB_FILE")
 
-    if [ "$DB_PARENT" = / ]; then
-        echo "[entrypoint] FLOPPY_DB_PATH must use a database directory below /." >&2
-        exit 1
-    fi
+    reject_unsafe_managed_directory FLOPPY_DB_PATH "$DB_PARENT"
 
     # Fail fast with a clear message if the SQLite file is already corrupt.
     # This avoids repeated migration failures (issues #508 and #593).
@@ -86,23 +94,30 @@ usermod -o -u "$PUID" abc
 
 chown abc:abc -- /floppy
 
-if [ -e "$DATA_DIR" ] && ! timeout 600 chown -R abc:abc -- "$DATA_DIR"; then
+if [ -e "$DATA_DIR" ] && ! timeout 600 chown abc:abc -- "$DATA_DIR"; then
     echo "[entrypoint] Cannot set ownership for FLOPPY_DATA_DIR ${DATA_DIR} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
     exit 1
 fi
 
+SECRET_FILE="${DATA_DIR}/secret_key"
+if { [ -e "$SECRET_FILE" ] || [ -L "$SECRET_FILE" ]; } && \
+   ! timeout 600 chown -h abc:abc -- "$SECRET_FILE"; then
+    echo "[entrypoint] Cannot set ownership for generated secret ${SECRET_FILE} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+    exit 1
+fi
+
 if [ -z "$DB_HOST" ]; then
-    case "${DB_PARENT}/" in
-        "${DATA_DIR}/"*) ;;
-        *)
-            for path in "$DB_PARENT" "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"; do
-                if [ -e "$path" ] && ! timeout 600 chown abc:abc -- "$path"; then
-                    echo "[entrypoint] Cannot set ownership for FLOPPY_DB_PATH parent ${DB_PARENT} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
-                    exit 1
-                fi
-            done
-            ;;
-    esac
+    if [ -e "$DB_PARENT" ] && ! timeout 600 chown abc:abc -- "$DB_PARENT"; then
+        echo "[entrypoint] Cannot set ownership for FLOPPY_DB_PATH parent ${DB_PARENT} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+        exit 1
+    fi
+    for path in "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"; do
+        if { [ -e "$path" ] || [ -L "$path" ]; } && \
+           ! timeout 600 chown -h abc:abc -- "$path"; then
+            echo "[entrypoint] Cannot set ownership for SQLite file ${path} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+            exit 1
+        fi
+    done
 fi
 
 # "logs" holds the rotating file handler every process configures at import time
@@ -111,9 +126,20 @@ fi
 # process then dies with "Unable to configure handler 'file'" -- taking gunicorn
 # with it, so the container serves 502s while reporting healthy.
 #
-# Bound each recursive chown: a stalled bind mount (e.g. network storage)
-# must degrade to a warning instead of hanging the boot silently (issue #341).
-for dir in "${LOG_DIR:-/floppy/logs}" /floppy/staticfiles /var/log/nginx /var/lib/nginx; do
+# The log directory can be an operator-selected mount. Change only that
+# directory entry and Floppy's current log file, never unrelated content.
+if [ -e "$LOG_DIR_PATH" ] && ! timeout 600 chown abc:abc -- "$LOG_DIR_PATH"; then
+    echo "[entrypoint] WARNING: chown of ${LOG_DIR_PATH} failed or timed out (stalled mount?); continuing" >&2
+fi
+LOG_FILE="${LOG_DIR_PATH}/floppy.log"
+if { [ -e "$LOG_FILE" ] || [ -L "$LOG_FILE" ]; } && \
+   ! timeout 600 chown -h abc:abc -- "$LOG_FILE"; then
+    echo "[entrypoint] WARNING: chown of ${LOG_FILE} failed or timed out (stalled mount?); continuing" >&2
+fi
+
+# Bound recursive ownership fixes for the image-managed service directories: a
+# stalled bind mount must degrade to a warning instead of hanging boot (#341).
+for dir in /floppy/staticfiles /var/log/nginx /var/lib/nginx; do
     echo "[entrypoint] Chowning ${dir}" >&2
     timeout 600 chown -R abc:abc -- "$dir" || \
         echo "[entrypoint] WARNING: chown of ${dir} failed or timed out (stalled mount?); continuing" >&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,45 +2,57 @@
 
 set -e
 
-# Fail fast with a clear message if the SQLite file is already corrupt,
-# instead of burning through the migrate retry loop below to arrive at an
-# opaque "file is not a database" traceback (issue #508). Corruption here
-# often means the db directory sits on a network filesystem that doesn't
-# support SQLite's WAL locking - see README's SQLite persistence note.
-# Rejects a non-"ok" quick_check result even when SQLite doesn't raise an
-# exception for it (issue #593).
-if [ -z "$DB_HOST" ] && [ -f /floppy/db/db.sqlite3 ]; then
-    echo "[entrypoint] Checking SQLite integrity (PRAGMA quick_check)" >&2
-    python -c "from config.sqlite_integrity import check_database_integrity; check_database_integrity('/floppy/db/db.sqlite3')" &
-    integrity_pid=$!
+DATA_DIR_INPUT=${FLOPPY_DATA_DIR:-/floppy/db}
+DATA_DIR=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DATA_DIR_INPUT")
 
-    # Report actual bytes read from /proc rather than a bare "still going" -
-    # cheap to read (no python instrumentation needed) and gives the user
-    # something concrete instead of a repeating, uninformative message.
-    elapsed=0
-    while kill -0 "$integrity_pid" 2>/dev/null; do
-        if [ "$elapsed" -ge 600 ]; then
-            echo "[entrypoint] WARNING: SQLite integrity check exceeded 600s (slow storage?); continuing" >&2
-            kill "$integrity_pid" 2>/dev/null
-            break
-        fi
-        sleep 30
-        elapsed=$((elapsed + 30))
-        read_mb=$(awk '/^rchar:/ {printf "%.0f", $2/1048576}' "/proc/${integrity_pid}/io" 2>/dev/null) || read_mb=""
-        if [ -n "$read_mb" ]; then
-            echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed, ~${read_mb}MB read so far)" >&2
-        else
-            echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed)" >&2
-        fi
-    done
+if [ "$DATA_DIR" = / ]; then
+    echo "[entrypoint] FLOPPY_DATA_DIR must resolve to a directory below /." >&2
+    exit 1
+fi
 
-    integrity_status=0
-    wait "$integrity_pid" || integrity_status=$?
-    if [ "$elapsed" -ge 600 ] && [ "$integrity_status" -ne 0 ]; then
-        integrity_status=124
-    fi
-    if [ "$integrity_status" -ne 0 ] && [ "$integrity_status" -ne 124 ]; then
+if [ -z "$DB_HOST" ]; then
+    DB_FILE_INPUT=${FLOPPY_DB_PATH:-"${DATA_DIR_INPUT}/db.sqlite3"}
+    DB_FILE=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DB_FILE_INPUT")
+    DB_PARENT=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).parent)' "$DB_FILE")
+
+    if [ "$DB_PARENT" = / ]; then
+        echo "[entrypoint] FLOPPY_DB_PATH must use a database directory below /." >&2
         exit 1
+    fi
+
+    # Fail fast with a clear message if the SQLite file is already corrupt.
+    # This avoids repeated migration failures (issues #508 and #593).
+    if [ -f "$DB_FILE" ]; then
+        echo "[entrypoint] Checking SQLite integrity for ${DB_FILE} (PRAGMA quick_check)" >&2
+        python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+        integrity_pid=$!
+
+        # Report bytes read so large databases show visible progress.
+        elapsed=0
+        while kill -0 "$integrity_pid" 2>/dev/null; do
+            if [ "$elapsed" -ge 600 ]; then
+                echo "[entrypoint] WARNING: SQLite integrity check exceeded 600s (slow storage?); continuing" >&2
+                kill "$integrity_pid" 2>/dev/null
+                break
+            fi
+            sleep 30
+            elapsed=$((elapsed + 30))
+            read_mb=$(awk '/^rchar:/ {printf "%.0f", $2/1048576}' "/proc/${integrity_pid}/io" 2>/dev/null) || read_mb=""
+            if [ -n "$read_mb" ]; then
+                echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed, ~${read_mb}MB read so far)" >&2
+            else
+                echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed)" >&2
+            fi
+        done
+
+        integrity_status=0
+        wait "$integrity_pid" || integrity_status=$?
+        if [ "$elapsed" -ge 600 ] && [ "$integrity_status" -ne 0 ]; then
+            integrity_status=124
+        fi
+        if [ "$integrity_status" -ne 0 ] && [ "$integrity_status" -ne 124 ]; then
+            exit 1
+        fi
     fi
 fi
 
@@ -72,7 +84,26 @@ echo "[entrypoint] Fixing file ownership (PUID=${PUID} PGID=${PGID})" >&2
 groupmod -o -g "$PGID" abc
 usermod -o -u "$PUID" abc
 
-chown abc:abc /floppy
+chown abc:abc -- /floppy
+
+if [ -e "$DATA_DIR" ] && ! timeout 600 chown -R abc:abc -- "$DATA_DIR"; then
+    echo "[entrypoint] Cannot set ownership for FLOPPY_DATA_DIR ${DATA_DIR} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+    exit 1
+fi
+
+if [ -z "$DB_HOST" ]; then
+    case "${DB_PARENT}/" in
+        "${DATA_DIR}/"*) ;;
+        *)
+            for path in "$DB_PARENT" "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"; do
+                if [ -e "$path" ] && ! timeout 600 chown abc:abc -- "$path"; then
+                    echo "[entrypoint] Cannot set ownership for FLOPPY_DB_PATH parent ${DB_PARENT} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+                    exit 1
+                fi
+            done
+            ;;
+    esac
+fi
 
 # "logs" holds the rotating file handler every process configures at import time
 # (settings.LOG_FILE). settings.py creates the directory, so whichever process
@@ -82,9 +113,9 @@ chown abc:abc /floppy
 #
 # Bound each recursive chown: a stalled bind mount (e.g. network storage)
 # must degrade to a warning instead of hanging the boot silently (issue #341).
-for dir in db logs staticfiles /var/log/nginx /var/lib/nginx; do
+for dir in "${LOG_DIR:-/floppy/logs}" /floppy/staticfiles /var/log/nginx /var/lib/nginx; do
     echo "[entrypoint] Chowning ${dir}" >&2
-    timeout 600 chown -R abc:abc "$dir" || \
+    timeout 600 chown -R abc:abc -- "$dir" || \
         echo "[entrypoint] WARNING: chown of ${dir} failed or timed out (stalled mount?); continuing" >&2
 done
 

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -1,0 +1,401 @@
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+
+from config import settings as project_settings
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+ENTRYPOINT = ROOT / "entrypoint.sh"
+
+SETTINGS_PROBE = """
+import json
+from config import settings
+
+print(json.dumps({
+    "data_dir": str(settings.FLOPPY_DATA_DIR),
+    "database_name": str(settings.DATABASES["default"]["NAME"]),
+    "database_engine": settings.DATABASES["default"]["ENGINE"],
+}))
+"""
+
+DOCKER_SECRET_PROBE = """
+from pathlib import Path
+from unittest.mock import patch
+
+real_exists = Path.exists
+
+def exists(path):
+    if path == Path("/.dockerenv"):
+        return True
+    return real_exists(path)
+
+with patch.object(Path, "exists", exists):
+    from config import settings
+    print(settings.SECRET_KEY)
+"""
+
+
+class DataPathSettingsTests(SimpleTestCase):
+    def run_settings(self, *, cwd, python_path=SRC, **overrides):
+        environment = {
+            "PATH": os.environ["PATH"],
+            "PYTHONPATH": str(python_path),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "SECRET": "data-path-test-secret",
+            "LOG_DIR": str(Path(cwd) / "logs"),
+        }
+        environment.update(overrides)
+        result = subprocess.run(  # noqa: S603 - test-controlled executable
+            [sys.executable, "-c", SETTINGS_PROBE],
+            cwd=cwd,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def test_defaults_and_empty_overrides_use_the_existing_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for overrides in ({}, {"FLOPPY_DATA_DIR": "", "FLOPPY_DB_PATH": ""}):
+                with self.subTest(overrides=overrides):
+                    settings = self.run_settings(cwd=temp_dir, **overrides)
+
+                self.assertEqual(settings["data_dir"], str(SRC / "db"))
+                self.assertEqual(settings["database_name"], str(SRC / "db/db.sqlite3"))
+
+    def test_data_directory_and_database_file_have_independent_overrides(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            external_database = root / "database" / "floppy.sqlite3"
+
+            data_settings = self.run_settings(
+                cwd=root,
+                FLOPPY_DATA_DIR=str(data_dir),
+            )
+            database_settings = self.run_settings(
+                cwd=root,
+                FLOPPY_DATA_DIR=str(data_dir),
+                FLOPPY_DB_PATH=str(external_database),
+            )
+
+            self.assertEqual(data_settings["data_dir"], str(data_dir))
+            self.assertEqual(
+                data_settings["database_name"],
+                str(data_dir / "db.sqlite3"),
+            )
+            self.assertEqual(database_settings["data_dir"], str(data_dir))
+            self.assertEqual(
+                database_settings["database_name"],
+                str(external_database),
+            )
+            self.assertTrue(external_database.parent.is_dir())
+
+    def test_read_only_source_uses_external_writable_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            read_only_source = root / "source"
+            shutil.copytree(SRC / "config", read_only_source / "config")
+            read_only_directories = [
+                read_only_source,
+                *(path for path in read_only_source.rglob("*") if path.is_dir()),
+            ]
+            for path in read_only_source.rglob("*"):
+                path.chmod(0o555 if path.is_dir() else 0o444)
+            read_only_source.chmod(0o555)
+            data_dir = root / "data"
+            database_path = root / "database" / "db.sqlite3"
+            log_dir = root / "logs"
+            try:
+                settings = self.run_settings(
+                    cwd=root,
+                    python_path=read_only_source,
+                    FLOPPY_DATA_DIR=str(data_dir),
+                    FLOPPY_DB_PATH=str(database_path),
+                    LOG_DIR=str(log_dir),
+                )
+            finally:
+                for directory in read_only_directories:
+                    directory.chmod(0o755)
+
+            self.assertEqual(settings["database_name"], str(database_path))
+            self.assertTrue(database_path.parent.is_dir())
+            self.assertTrue(log_dir.is_dir())
+            self.assertFalse((read_only_source / "db").exists())
+
+    def test_postgresql_does_not_touch_sqlite_override_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            protected = root / "protected"
+            protected.mkdir()
+            protected.chmod(0o555)
+            data_dir = protected / "data"
+            database_path = protected / "database" / "db.sqlite3"
+            try:
+                settings = self.run_settings(
+                    cwd=root,
+                    FLOPPY_DATA_DIR=str(data_dir),
+                    FLOPPY_DB_PATH=str(database_path),
+                    DB_HOST="postgres",
+                    DB_NAME="floppy",
+                    DB_USER="floppy",
+                    DB_PASSWORD="password",
+                    DB_PORT="5432",
+                )
+            finally:
+                protected.chmod(0o755)
+
+            self.assertEqual(
+                settings["database_engine"],
+                "django.db.backends.postgresql",
+            )
+            self.assertFalse(data_dir.exists())
+            self.assertFalse(database_path.parent.exists())
+
+    def test_generated_secret_is_created_and_corrected_to_mode_0600(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / "data" / "secret_key"
+
+            value, created = project_settings._load_or_create_docker_secret(
+                secret_path,
+            )
+            self.assertTrue(created)
+            self.assertEqual(secret_path.read_text(encoding="utf-8"), value)
+            self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+            secret_path.chmod(0o644)
+            same_value, created = project_settings._load_or_create_docker_secret(
+                secret_path,
+            )
+            self.assertFalse(created)
+            self.assertEqual(same_value, value)
+            self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+    def test_generated_secret_uses_the_configured_data_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "configured data"
+            environment = {
+                "PATH": os.environ["PATH"],
+                "PYTHONPATH": str(SRC),
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "FLOPPY_DATA_DIR": str(data_dir),
+                "LOG_DIR": str(root / "logs"),
+            }
+
+            result = subprocess.run(  # noqa: S603 - test-controlled executable
+                [sys.executable, "-c", DOCKER_SECRET_PROBE],
+                cwd=root,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            secret_path = data_dir / "secret_key"
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip().splitlines()[-1],
+                secret_path.read_text(encoding="utf-8"),
+            )
+            self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+    def test_generated_secret_failure_names_the_path_and_next_action(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            blocked_parent = Path(temp_dir) / "not-a-directory"
+            blocked_parent.write_text("keep", encoding="utf-8")
+            secret_path = blocked_parent / "secret_key"
+
+            with self.assertRaisesRegex(
+                ImproperlyConfigured,
+                rf"{secret_path}.*Make FLOPPY_DATA_DIR writable or set SECRET",
+            ):
+                project_settings._load_or_create_docker_secret(secret_path)
+
+            self.assertEqual(blocked_parent.read_text(encoding="utf-8"), "keep")
+
+
+class EntrypointDataPathTests(SimpleTestCase):
+    def run_entrypoint(self, root, **overrides):
+        fake_bin = root / "bin"
+        fake_bin.mkdir(exist_ok=True)
+        log_path = root / "commands.log"
+        log_path.unlink(missing_ok=True)
+        script_path = root / "entrypoint.sh"
+        script_path.write_text(
+            ENTRYPOINT.read_text(encoding="utf-8").replace(
+                "exec /usr/local/bin/supervisord -c /etc/supervisord.conf",
+                "exec supervisord -c /etc/supervisord.conf",
+            ),
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+
+        self.write_command(
+            fake_bin / "python",
+            f"""#!/bin/sh
+if [ "$1" = "-c" ]; then
+    exec {sys.executable} "$@"
+fi
+{{ printf 'python'; printf ' <%s>' "$@"; printf '\n'; }} >> "$FAKE_LOG"
+exit 0
+""",
+        )
+        self.write_command(
+            fake_bin / "timeout",
+            """#!/bin/sh
+shift
+exec "$@"
+""",
+        )
+        self.write_command(
+            fake_bin / "sleep",
+            """#!/bin/sh
+exec /bin/sleep 0.05
+""",
+        )
+        self.write_command(
+            fake_bin / "chown",
+            """#!/bin/sh
+{ printf 'chown'; printf ' <%s>' "$@"; printf '\n'; } >> "$FAKE_LOG"
+last=""
+for argument in "$@"; do last=$argument; done
+if [ -n "$FAIL_CHOWN_PATH" ] && [ "$last" = "$FAIL_CHOWN_PATH" ]; then
+    exit 1
+fi
+""",
+        )
+        for command in ("groupmod", "usermod", "supervisord"):
+            self.write_command(
+                fake_bin / command,
+                f"""#!/bin/sh
+{{ printf '{command}'; printf ' <%s>' "$@"; printf '\n'; }} >> "$FAKE_LOG"
+""",
+            )
+
+        environment = {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "PYTHONPATH": str(SRC),
+            "FAKE_LOG": str(log_path),
+            "SECRET": "entrypoint-test-secret",
+            "LOG_DIR": str(root / "logs"),
+        }
+        environment.update(overrides)
+        result = subprocess.run(  # noqa: S603 - test-controlled script
+            [str(script_path)],
+            cwd=root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        commands = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        return result, commands
+
+    @staticmethod
+    def write_command(path, content):
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    def test_paths_with_spaces_and_leading_dash_remain_single_arguments(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "-managed data"
+            database_parent = root / "external data"
+            database_path = database_parent / "-db.sqlite3"
+            data_dir.mkdir()
+            database_parent.mkdir()
+            database_path.touch()
+            (database_parent / "unrelated").mkdir()
+
+            result, commands = self.run_entrypoint(
+                root,
+                FLOPPY_DATA_DIR="-managed data",
+                FLOPPY_DB_PATH=str(database_path),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(
+                f"Checking SQLite integrity for {database_path}", result.stderr
+            )
+            self.assertIn(f"chown <-R> <abc:abc> <--> <{data_dir}>", commands)
+            self.assertIn(f"chown <abc:abc> <--> <{database_parent}>", commands)
+            self.assertNotIn(str(database_parent / "unrelated"), commands)
+
+    def test_root_and_root_symlink_paths_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            root_link = root / "root-link"
+            root_link.symlink_to("/")
+            safe_data = root / "data"
+            safe_data.mkdir()
+
+            cases = (
+                ({"FLOPPY_DATA_DIR": "/"}, "FLOPPY_DATA_DIR"),
+                ({"FLOPPY_DATA_DIR": str(root_link)}, "FLOPPY_DATA_DIR"),
+                (
+                    {
+                        "FLOPPY_DATA_DIR": str(safe_data),
+                        "FLOPPY_DB_PATH": "/db.sqlite3",
+                    },
+                    "FLOPPY_DB_PATH",
+                ),
+            )
+            for environment, setting_name in cases:
+                with self.subTest(environment=environment):
+                    result, commands = self.run_entrypoint(root, **environment)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(setting_name, result.stderr)
+                self.assertNotIn("supervisord", commands)
+
+    def test_external_database_parent_ownership_failure_stops_startup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            database_parent = root / "database"
+            database_path = database_parent / "db.sqlite3"
+            data_dir.mkdir()
+            database_parent.mkdir()
+            database_path.touch()
+
+            result, commands = self.run_entrypoint(
+                root,
+                FLOPPY_DATA_DIR=str(data_dir),
+                FLOPPY_DB_PATH=str(database_path),
+                FAIL_CHOWN_PATH=str(database_parent),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Cannot set ownership for FLOPPY_DB_PATH parent", result.stderr
+            )
+            self.assertNotIn("supervisord", commands)
+
+    def test_postgresql_does_not_resolve_or_own_the_sqlite_override(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            data_dir.mkdir()
+
+            result, commands = self.run_entrypoint(
+                root,
+                DB_HOST="postgres",
+                FLOPPY_DATA_DIR=str(data_dir),
+                FLOPPY_DB_PATH="/db.sqlite3",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("FLOPPY_DB_PATH", result.stderr)
+            self.assertNotIn("/db.sqlite3", commands)

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -5,7 +5,10 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
@@ -225,6 +228,71 @@ class DataPathSettingsTests(SimpleTestCase):
 
             self.assertEqual(blocked_parent.read_text(encoding="utf-8"), "keep")
 
+    def test_generated_secret_rejects_symlink_without_touching_its_target(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "operator-secret"
+            target.write_text("do-not-read", encoding="utf-8")
+            target.chmod(0o644)
+            secret_path = root / "data" / "secret_key"
+            secret_path.parent.mkdir()
+            secret_path.symlink_to(target)
+
+            with self.assertRaisesRegex(ImproperlyConfigured, rf"{secret_path}"):
+                project_settings._load_or_create_docker_secret(secret_path)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "do-not-read")
+            self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o644)
+
+    def test_generated_secret_rejects_non_regular_and_empty_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for name, create in (
+                ("directory", lambda path: path.mkdir()),
+                ("empty", lambda path: path.touch()),
+            ):
+                with self.subTest(name=name):
+                    secret_path = root / name
+                    create(secret_path)
+                    with self.assertRaisesRegex(
+                        ImproperlyConfigured,
+                        rf"{secret_path}",
+                    ):
+                        project_settings._load_or_create_docker_secret(secret_path)
+
+    def test_generated_secret_is_published_complete_under_concurrency(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / "data" / "secret_key"
+            barrier = threading.Barrier(2)
+            real_link = os.link
+
+            def synchronized_link(*args, **kwargs):
+                barrier.wait(timeout=5)
+                return real_link(*args, **kwargs)
+
+            with (
+                mock.patch.object(
+                    project_settings.os,
+                    "link",
+                    side_effect=synchronized_link,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                results = list(
+                    executor.map(
+                        project_settings._load_or_create_docker_secret,
+                        (secret_path, secret_path),
+                    )
+                )
+
+            values = {value for value, _created in results}
+            self.assertEqual(len(values), 1)
+            self.assertNotEqual(values, {""})
+            self.assertEqual(
+                sorted(created for _value, created in results), [False, True]
+            )
+            self.assertEqual(secret_path.read_text(encoding="utf-8"), values.pop())
+
 
 class EntrypointDataPathTests(SimpleTestCase):
     def run_entrypoint(self, root, **overrides):
@@ -317,7 +385,18 @@ fi
             data_dir.mkdir()
             database_parent.mkdir()
             database_path.touch()
+            database_wal_path = Path(f"{database_path}-wal")
+            database_wal_path.touch()
+            database_shm_path = Path(f"{database_path}-shm")
+            database_shm_path.touch()
             (database_parent / "unrelated").mkdir()
+            secret_path = data_dir / "secret_key"
+            secret_path.touch()
+            log_dir = root / "logs"
+            log_dir.mkdir()
+            log_file = log_dir / "floppy.log"
+            log_file.touch()
+            (log_dir / "unrelated.log").touch()
 
             result, commands = self.run_entrypoint(
                 root,
@@ -329,25 +408,47 @@ fi
             self.assertIn(
                 f"Checking SQLite integrity for {database_path}", result.stderr
             )
-            self.assertIn(f"chown <-R> <abc:abc> <--> <{data_dir}>", commands)
+            self.assertIn(f"chown <abc:abc> <--> <{data_dir}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{secret_path}>", commands)
             self.assertIn(f"chown <abc:abc> <--> <{database_parent}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{database_path}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{database_wal_path}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{database_shm_path}>", commands)
+            self.assertIn(f"chown <abc:abc> <--> <{log_dir}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{log_file}>", commands)
+            self.assertNotIn(f"chown <-R> <abc:abc> <--> <{data_dir}>", commands)
+            self.assertNotIn(f"chown <-R> <abc:abc> <--> <{log_dir}>", commands)
             self.assertNotIn(str(database_parent / "unrelated"), commands)
+            self.assertNotIn(str(log_dir / "unrelated.log"), commands)
 
-    def test_root_and_root_symlink_paths_are_rejected(self):
+    def test_system_root_and_symlink_paths_are_rejected(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             root_link = root / "root-link"
             root_link.symlink_to("/")
+            system_link = root / "system-link"
+            system_link.symlink_to("/etc")
             safe_data = root / "data"
             safe_data.mkdir()
 
             cases = (
                 ({"FLOPPY_DATA_DIR": "/"}, "FLOPPY_DATA_DIR"),
                 ({"FLOPPY_DATA_DIR": str(root_link)}, "FLOPPY_DATA_DIR"),
+                ({"FLOPPY_DATA_DIR": "/etc"}, "FLOPPY_DATA_DIR"),
+                ({"LOG_DIR": "/"}, "LOG_DIR"),
+                ({"LOG_DIR": str(root_link)}, "LOG_DIR"),
+                ({"LOG_DIR": str(system_link)}, "LOG_DIR"),
                 (
                     {
                         "FLOPPY_DATA_DIR": str(safe_data),
                         "FLOPPY_DB_PATH": "/db.sqlite3",
+                    },
+                    "FLOPPY_DB_PATH",
+                ),
+                (
+                    {
+                        "FLOPPY_DATA_DIR": str(safe_data),
+                        "FLOPPY_DB_PATH": "/etc/db.sqlite3",
                     },
                     "FLOPPY_DB_PATH",
                 ),
@@ -359,6 +460,18 @@ fi
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(setting_name, result.stderr)
                 self.assertNotIn("supervisord", commands)
+
+    def test_dedicated_directory_below_system_root_is_allowed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result, commands = self.run_entrypoint(
+                Path(temp_dir),
+                FLOPPY_DATA_DIR="/var/lib/floppy",
+                FLOPPY_DB_PATH="/var/lib/floppy/db.sqlite3",
+                LOG_DIR="/var/log/floppy",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("supervisord", commands)
 
     def test_external_database_parent_ownership_failure_stops_startup(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import json
 import os
+import secrets
 import subprocess
 import sys
 import warnings
@@ -21,6 +22,7 @@ from decouple import (
     undefined,
 )
 from django.core.cache import CacheKeyWarning
+from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.signals import connection_created
 
 from config.runtime_profile import (
@@ -47,6 +49,14 @@ REDIS_PREFIX = config("REDIS_PREFIX", default=None)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+_data_dir_override = config("FLOPPY_DATA_DIR", default=None)
+FLOPPY_DATA_DIR = Path(_data_dir_override) if _data_dir_override else BASE_DIR / "db"
+_database_path_override = config("FLOPPY_DB_PATH", default=None)
+FLOPPY_DB_PATH = (
+    Path(_database_path_override)
+    if _database_path_override
+    else FLOPPY_DATA_DIR / "db.sqlite3"
+)
 DOCKER_SECRETS_DIR = Path("/run/secrets")
 
 
@@ -79,6 +89,37 @@ def secret(key, default=undefined, **kwargs):
     return secret_value
 
 
+def _load_or_create_docker_secret(path):
+    try:
+        if path.exists():
+            path.chmod(0o600)
+            return path.read_text(encoding="utf-8").strip(), False
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        value = secrets.token_urlsafe(50)
+        try:
+            secret_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            path.chmod(0o600)
+            return path.read_text(encoding="utf-8").strip(), False
+
+        try:
+            with os.fdopen(secret_fd, "w", encoding="utf-8") as secret_file:
+                secret_file.write(value)
+            path.chmod(0o600)
+        except OSError:
+            path.unlink(missing_ok=True)
+            raise
+        else:
+            return value, True
+    except (OSError, UnicodeError) as err:
+        msg = (
+            f"Cannot create or read the generated secret key at {path}. "
+            "Make FLOPPY_DATA_DIR writable or set SECRET."
+        )
+        raise ImproperlyConfigured(msg) from err
+
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/stable/howto/deployment/checklist/
 
@@ -96,16 +137,9 @@ if not SECRET_KEY:
     if Path("/.dockerenv").exists():
         # Docker container: auto-generate and persist to the db volume so the
         # key survives container restarts without user intervention.
-        import secrets as _secrets
-        import warnings
-
-        _secret_file = BASE_DIR / "db" / "secret_key"
-        if _secret_file.exists():
-            SECRET_KEY = _secret_file.read_text().strip()
-        else:
-            SECRET_KEY = _secrets.token_urlsafe(50)
-            _secret_file.parent.mkdir(parents=True, exist_ok=True)
-            _secret_file.write_text(SECRET_KEY)
+        _secret_file = FLOPPY_DATA_DIR / "secret_key"
+        SECRET_KEY, secret_created = _load_or_create_docker_secret(_secret_file)
+        if secret_created:
             warnings.warn(
                 "SECRET env var is not set. A random key has been generated and "
                 f"saved to {_secret_file}. For production, set SECRET explicitly "
@@ -113,8 +147,6 @@ if not SECRET_KEY:
                 stacklevel=2,
             )
     else:
-        from django.core.exceptions import ImproperlyConfigured
-
         msg = (
             "SECRET env var is not set. To fix, run:\n\n"
             '  python -c "'
@@ -309,9 +341,6 @@ WSGI_APPLICATION = "config.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/stable/ref/settings/#databases
 
-# create db folder if it doesn't exist
-Path(BASE_DIR / "db").mkdir(parents=True, exist_ok=True)
-
 DB_HOST = config("DB_HOST", default=None)
 USING_SQLITE_DATABASE = not bool(DB_HOST)
 
@@ -361,6 +390,7 @@ if DB_HOST:
         DATABASES["default"]["OPTIONS"]["sslcertmode"] = sslcertmode
 
 else:
+    FLOPPY_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     SQLITE_BUSY_TIMEOUT_SECONDS = config(
         "SQLITE_BUSY_TIMEOUT_SECONDS",
         default=30,
@@ -372,7 +402,7 @@ else:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db" / "db.sqlite3",
+            "NAME": FLOPPY_DB_PATH,
             "OPTIONS": {
                 "timeout": SQLITE_BUSY_TIMEOUT_SECONDS,
             },

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,8 +5,10 @@ import hashlib
 import json
 import os
 import secrets
+import stat
 import subprocess
 import sys
+import tempfile
 import warnings
 import zoneinfo
 from pathlib import Path
@@ -89,27 +91,51 @@ def secret(key, default=undefined, **kwargs):
     return secret_value
 
 
-def _load_or_create_docker_secret(path):
+def _read_docker_secret(path):
+    secret_fd = os.open(
+        path,
+        os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+    )
     try:
-        if path.exists():
-            path.chmod(0o600)
-            return path.read_text(encoding="utf-8").strip(), False
+        if not stat.S_ISREG(os.fstat(secret_fd).st_mode):
+            raise OSError(path)
+        os.fchmod(secret_fd, 0o600)
+        with os.fdopen(secret_fd, "r", encoding="utf-8") as secret_file:
+            secret_fd = None
+            value = secret_file.read().strip()
+        if not value:
+            raise OSError(path)
+        return value
+    finally:
+        if secret_fd is not None:
+            os.close(secret_fd)
 
+
+def _load_or_create_docker_secret(path):
+    temp_fd = None
+    temp_path = None
+    try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        value = secrets.token_urlsafe(50)
         try:
-            secret_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileExistsError:
-            path.chmod(0o600)
-            return path.read_text(encoding="utf-8").strip(), False
+            return _read_docker_secret(path), False
+        except FileNotFoundError:
+            pass
+
+        value = secrets.token_urlsafe(50)
+        temp_fd, temp_path = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            dir=path.parent,
+        )
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as secret_file:
+            temp_fd = None
+            secret_file.write(value)
+            secret_file.flush()
+            os.fsync(secret_file.fileno())
 
         try:
-            with os.fdopen(secret_fd, "w", encoding="utf-8") as secret_file:
-                secret_file.write(value)
-            path.chmod(0o600)
-        except OSError:
-            path.unlink(missing_ok=True)
-            raise
+            os.link(temp_path, path, follow_symlinks=False)
+        except FileExistsError:
+            return _read_docker_secret(path), False
         else:
             return value, True
     except (OSError, UnicodeError) as err:
@@ -118,6 +144,11 @@ def _load_or_create_docker_secret(path):
             "Make FLOPPY_DATA_DIR writable or set SECRET."
         )
         raise ImproperlyConfigured(msg) from err
+    finally:
+        if temp_fd is not None:
+            os.close(temp_fd)
+        if temp_path is not None:
+            Path(temp_path).unlink(missing_ok=True)
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
## Summary

This change makes the SQLite data directory and database file configurable.
It preserves the current container defaults.

- `FLOPPY_DATA_DIR` selects the directory for generated Floppy data.
- `FLOPPY_DB_PATH` selects the SQLite database file.
- `FLOPPY_DB_PATH` takes precedence over `FLOPPY_DATA_DIR/db.sqlite3`.
- An empty value uses the existing default.
- PostgreSQL ignores the SQLite file override.

## Why this replacement is required

PR #615 was merged into `test/export-csv-openlibrary-isolation`. Its merge
commit is not an ancestor of `latest`, so the documented feature is absent
from the released branch. A merged pull request cannot be reopened. This
replacement starts from the current `latest` branch and preserves #615 as
history.

## Changes

- Route Django's SQLite setting through the selected path.
- Route the startup integrity check through the same selected path.
- Store the generated container secret in the selected data directory.
- Preserve the existing `/floppy/db/db.sqlite3` default.
- Reject data, database, and log paths that resolve to system directories.
- Change ownership only on selected directory entries and known Floppy files.
- Keep recursive ownership changes limited to image-managed service paths.
- Read an existing generated secret without following symlinks.
- Reject non-regular and empty generated secret files.
- Publish a complete generated secret atomically when first starts race.
- Document precedence, mounts, storage requirements, move steps, ownership,
  generated secrets, and PostgreSQL behavior.

## Conflict resolution and safety

The startup script resolves relative paths before it changes ownership. It
stops if a selected path resolves to `/`, `/etc`, or another system directory.
It does not recursively change ownership inside operator-selected mounts.

Concurrent first starts create separate temporary secret files. One complete
file wins an atomic publication step. Every other process reads the same final
value. A partial or empty final secret is not accepted.

Floppy does not move an existing database. The README gives a stop, back up,
copy, configure, and verify procedure.

## Compatibility and future launchers

Existing deployments need no change. The current path remains
`/floppy/db/db.sqlite3` unless an operator sets an override.

A native launcher can select its application-data and database locations with
environment variables. It does not need to patch Django settings or the
container startup script. The SQLite startup check uses the same selected
database path.

## Upstream check

Yamtrack `dev` at `f97b0639e24c08a5b1de3b9234b8b81cf6abea93` has no
`FLOPPY_DATA_DIR` or `FLOPPY_DB_PATH` contract and no equivalent fix to port.

## Verification

- 23 focused path, secret, startup, integrity, and PostgreSQL-setting checks
  passed in the final independent review.
- Concurrent publication produced one secret value, one creator, and no
  errors across twelve processes.
- The `/etc` and `/` ownership probes stopped before any unsafe `chown`.
- A fresh SQLite check and complete migration chain passed.
- Ruff, format checks, `sh -n entrypoint.sh`, and `git diff --check` passed.
- The stacked fast suite passed all 3,525 tests in 516.086 seconds.
- Independent code review: READY; no remaining findings.

### Hosted CI follow-up

The required hosted test job was not stable after this pull request merged.
The first attempt failed one game-progress browser test. The same exact test
passed when it ran alone on this branch. The retry failed three CSV export
tests while fixture creation waited for live book-provider requests.

PR #685 contains the focused provider and wall-clock fixture isolation for
these failures. Its hosted test suite is green. The same path commits also
passed the hosted test suite as part of PR #737. These results do not identify
a failure in the configurable-path change, but the failed #734 check remains
part of its delivery record.

This change has no user-interface output. Screenshots would not add useful
evidence. Browser QA for the dependent SQLite recovery branch covers desktop
and mobile application startup with this path contract.

## Relationships

Fixes #595

Replaces #615

Related to #593, #731, and #685

## AI Assistance

The `gpt-5` Codex agent investigated, implemented, tested, and documented this
change. Independent review agents checked the final commits.

## Human Review

- [ ] Pending human review.
- [x] Completed by the repository maintainer through merge.

## Gstack QA

- [ ] Pending `/gstack-qa`.
- [x] Completed. The dependent #731 stack passed browser QA on nine routes,
  desktop and mobile layouts, and the browser console. No branch-related defect
  was found.

## Migration Sync Gate

Not applicable. This pull request does not synchronize `upstream` to `latest`.
