### PR TITLE
feat(config): support separate Redis service URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ The only universally required variable is `SECRET`. For Docker installs you shou
 - `WEB_CONCURRENCY` / `GUNICORN_THREADS` - optional web server concurrency overrides. Leave both unset to use the detected host profile, especially on small or swapless hosts. Total concurrent requests = workers x threads
 - `FLOPPY_RESOURCE_TIER` - `standard`, `constrained`, or `minimal`. Floppy normally detects this from the host's memory, swap and CPU and scales its process count, batch sizes and background task cadence to match, so you should not need to set it. Use it to force a tier if detection guesses wrong - for example `standard` on a host whose cgroup understates the memory actually available
 - `FLOPPY_REDIS_MAXMEMORY` - Redis memory ceiling Floppy applies at startup when Redis has none of its own, as bytes or a size like `256mb`. Set it to `0` to leave your Redis configuration completely untouched. Floppy never overrides a `maxmemory` you set yourself
+- `REDIS_CACHE_URL` - Redis service for the Django cache and cached sessions. The default is `REDIS_URL`
+- `CELERY_BROKER_URL` - Redis service for queued Celery work. The default is `REDIS_URL`
+- `CELERY_RESULT_BACKEND` - Redis service for Celery results. The default is `REDIS_URL`
+- `REDIS_ADMIN_URL` - Redis service that Floppy can tune with `CONFIG`. The default is `REDIS_CACHE_URL`, then `REDIS_URL`
 - `DEBUG` - leave unset or `False` in production; enabling it slows every request (debug toolbar, no template caching) and is only meant for troubleshooting
 - `REGISTRATION` - set to `True` to allow new signups (needed for your first account), then set to `False` afterward
 - `DEMO_ACCOUNT_ENABLED` - defaults to `True`, provisioning the built-in `demo` / `demodemo` account after migrations. The examples above set it to `False`; only turn it on if you want a shared demo login
@@ -322,6 +326,47 @@ LASTFM_API_KEY=LASTFM_API_KEY
 SECRET=SECRET
 DEBUG=False
 ```
+
+### Use separate Redis services
+
+The standard configuration needs only `REDIS_URL`. Use the role settings when
+cache data and Celery data must use separate Redis services.
+
+```bash
+REDIS_URL=redis://limiter:6379/0
+REDIS_CACHE_URL=redis://cache:6379/0
+CELERY_BROKER_URL=redis://broker:6379/0
+CELERY_RESULT_BACKEND=redis://results:6379/0
+REDIS_ADMIN_URL=redis://cache:6379/0
+```
+
+Floppy applies these rules:
+
+1. `REDIS_CACHE_URL` uses `REDIS_URL` when it is empty or not set.
+2. `CELERY_BROKER_URL` uses `REDIS_URL` when it is empty or not set.
+3. `CELERY_RESULT_BACKEND` uses `REDIS_URL` when it is empty or not set.
+4. `REDIS_ADMIN_URL` uses `REDIS_CACHE_URL`, then `REDIS_URL`.
+5. The provider rate limiter continues to use `REDIS_URL`.
+
+Use a `redis://` or `rediss://` URL for Redis administration. Floppy skips
+automatic tuning when `REDIS_ADMIN_URL` uses another scheme. Set
+`FLOPPY_REDIS_MAXMEMORY=0` to stop all automatic Redis tuning.
+
+Redis `CONFIG` changes the complete Redis server. A database number in a Redis
+URL does not isolate this change. `REDIS_ADMIN_URL` must normally select the
+cache Redis server. Grant `CONFIG` access only when you want Floppy to manage
+the memory limit. You can also configure the Redis server directly.
+
+Plan a service change before you select new URLs:
+
+1. Let queued work finish before you change `CELERY_BROKER_URL`. A new broker
+   does not receive queued or unacknowledged work from the old broker.
+2. Preserve results that you still need before you change
+   `CELERY_RESULT_BACKEND`. The new backend does not contain old results.
+3. Expect the new cache to start empty. This can invalidate cached sessions,
+   but it does not delete accounts from the database.
+4. Restart the web, worker, and beat processes together. This makes all
+   processes use the same configuration.
 
 ### Running on a small host
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ automatic tuning when `REDIS_ADMIN_URL` uses another scheme. Set
 Redis `CONFIG` changes the complete Redis server. A database number in a Redis
 URL does not isolate this change. `REDIS_ADMIN_URL` must normally select the
 cache Redis server. Grant `CONFIG` access only when you want Floppy to manage
-the memory limit. You can also configure the Redis server directly.
+the memory limit and change `appendfsync=always` to `everysec`. You can also
+configure the Redis server directly.
 
 Plan a service change before you select new URLs:
 
@@ -363,8 +364,8 @@ Plan a service change before you select new URLs:
    does not receive queued or unacknowledged work from the old broker.
 2. Preserve results that you still need before you change
    `CELERY_RESULT_BACKEND`. The new backend does not contain old results.
-3. Expect the new cache to start empty. This can invalidate cached sessions,
-   but it does not delete accounts from the database.
+3. Expect the new cache to start empty. Floppy reloads sessions from its
+   database after a cache miss. Accounts and active sessions remain present.
 4. Restart the web, worker, and beat processes together. This makes all
    processes use the same configuration.
 

--- a/src/app/apps.py
+++ b/src/app/apps.py
@@ -7,6 +7,8 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.core.cache import cache
 
+from app.log_safety import exception_summary
+
 logger = logging.getLogger(__name__)
 
 # Five whole-library sweeps used to be enqueued at startup within 30 seconds of
@@ -120,16 +122,23 @@ class AppConfig(AppConfig):
             self._schedule_igdb_rating_backfill_reconcile()
             self._schedule_provider_backfill_reconcile()
 
-    def _add_startup_cache_key(self, cache_key: str, timeout: int = 86400) -> bool:
+    def _add_startup_cache_key(
+        self,
+        cache_key: str,
+        timeout: int = 86400,
+        *,
+        fail_open: bool = False,
+    ) -> bool:
         """Return whether a once-per-period startup task can be scheduled."""
         try:
             return bool(cache.add(cache_key, 1, timeout=timeout))
-        except Exception:
+        except Exception as error:
             logger.debug(
-                "Cache not available, skipping startup scheduling for %s",
+                "Startup cache key write failed for %s (%s). Check REDIS_CACHE_URL.",
                 cache_key,
+                exception_summary(error),
             )
-            return False
+            return fail_open
 
     def _repair_celery_redis_bindings(self):
         """Normalize persisted Kombu Redis bindings after separator changes."""
@@ -158,15 +167,24 @@ class AppConfig(AppConfig):
         only one of the container's processes issues the CONFIG SET even though
         every one of them runs ready(). Redis restarting resets its config, so
         the key's TTL is short enough that the next process start re-applies it.
+        If the cache guard raises, tuning continues because CONFIG operations
+        are idempotent and the administration Redis can still be available.
         """
-        if not self._add_startup_cache_key("redis_tuning_applied", timeout=300):
+        if not self._add_startup_cache_key(
+            "redis_tuning_applied",
+            timeout=300,
+            fail_open=True,
+        ):
             return
         try:
             from app.redis_tuning import tune_redis
 
             tune_redis()
         except Exception as error:
-            logger.warning("Failed to tune Redis memory limits: %s", error)
+            logger.warning(
+                "Redis memory tuning failed (%s). Run manage.py tune_redis --dry-run.",
+                exception_summary(error),
+            )
 
     def _schedule_runtime_population(self):
         """Schedule runtime population task to run once on startup."""

--- a/src/app/apps.py
+++ b/src/app/apps.py
@@ -158,7 +158,10 @@ class AppConfig(AppConfig):
                     repair_summary["removed"],
                 )
         except Exception as error:
-            logger.warning("Failed to normalize Kombu Redis bindings: %s", error)
+            logger.warning(
+                "Failed to normalize Kombu Redis bindings: %s",
+                exception_summary(error),
+            )
 
     def _tune_redis(self):
         """Give Redis a memory ceiling if the operator hasn't set one.

--- a/src/app/celery_broker.py
+++ b/src/app/celery_broker.py
@@ -49,7 +49,11 @@ def repair_celery_redis_bindings() -> dict[str, int]:
 
     global_keyprefix = transport_options.get("global_keyprefix", "") or ""
     binding_match = f"{global_keyprefix}{KOMBU_REDIS_BINDING_KEY_PATTERN % '*'}"
-    client = redis.Redis.from_url(broker_url)
+    client = redis.Redis.from_url(
+        broker_url,
+        socket_timeout=transport_options.get("socket_timeout", 30),
+        socket_connect_timeout=transport_options.get("socket_connect_timeout", 10),
+    )
     summary = {"keys": 0, "members": 0, "repaired": 0, "removed": 0}
 
     for raw_key in client.scan_iter(match=binding_match):

--- a/src/app/redis_tuning.py
+++ b/src/app/redis_tuning.py
@@ -22,8 +22,8 @@ Two rules govern the whole module:
   actionable warning, not a failed boot.
 
 The policy is ``volatile-lru``, not ``allkeys-lru``, because ``maxmemory`` is
-server-wide and this same instance is the Celery broker. Kombu's keys - the
-queue lists, ``_kombu.binding.*``, ``unacked*`` - carry no TTL, so
+server-wide and the selected server can also be the Celery broker. Kombu's
+keys - the queue lists, ``_kombu.binding.*``, ``unacked*`` - carry no TTL, so
 ``volatile-lru`` cannot evict them, while every Django cache entry has one
 (``CACHES["default"]["TIMEOUT"]`` applies whenever ``cache.set`` omits a
 timeout) and Celery results have ``CELERY_RESULT_EXPIRES``. That scopes
@@ -40,6 +40,7 @@ import logging
 import redis
 from django.conf import settings
 
+from app.log_safety import exception_summary
 from config.runtime_profile import MIB, PROFILE
 
 logger = logging.getLogger(__name__)
@@ -128,6 +129,18 @@ def _config_get(client: redis.Redis, name: str) -> str | None:
     return str(value)
 
 
+def _record_error(
+    summary: dict,
+    operation: str,
+    error: Exception,
+    next_action: str,
+) -> str:
+    """Add and return an actionable error that does not expose Redis details."""
+    message = f"{operation} failed ({exception_summary(error)}). {next_action}"
+    summary["errors"].append(message)
+    return message
+
+
 def tune_redis(*, dry_run: bool = False) -> dict:
     """Apply a memory ceiling and eviction policy to Redis if it has none.
 
@@ -136,7 +149,7 @@ def tune_redis(*, dry_run: bool = False) -> dict:
     """
     summary: dict = {"applied": {}, "skipped": {}, "errors": []}
 
-    redis_url = getattr(settings, "REDIS_URL", "") or ""
+    redis_url = getattr(settings, "REDIS_ADMIN_URL", "") or ""
     if not redis_url.startswith(("redis://", "rediss://")):
         summary["skipped"]["reason"] = "not_a_redis_url"
         return summary
@@ -151,9 +164,14 @@ def tune_redis(*, dry_run: bool = False) -> dict:
         current_maxmemory = parse_size(_config_get(client, "maxmemory"))
     except Exception as error:
         # Redis being unreachable is not this function's problem to solve; the
-        # cache layer reports it, and the next restart tries again.
-        summary["errors"].append(f"unreachable: {error}")
-        logger.info("Skipping Redis memory tuning, server not reachable: %s", error)
+        # startup log reports it, and the next restart tries again.
+        message = _record_error(
+            summary,
+            "Redis administration maxmemory read",
+            error,
+            "Check REDIS_ADMIN_URL and server availability.",
+        )
+        logger.info("Skipping Redis memory tuning. %s", message)
         return summary
 
     if current_maxmemory:
@@ -168,7 +186,14 @@ def tune_redis(*, dry_run: bool = False) -> dict:
         current_policy = _config_get(client, "maxmemory-policy")
     except Exception as error:
         current_policy = None
-        summary["errors"].append(f"maxmemory-policy read failed: {error}")
+        message = _record_error(
+            summary,
+            "Redis maxmemory-policy read",
+            error,
+            "Grant CONFIG access, configure Redis directly, or set "
+            "FLOPPY_REDIS_MAXMEMORY=0.",
+        )
+        logger.warning("%s", message)
 
     if dry_run:
         summary["applied"]["maxmemory"] = budget
@@ -182,13 +207,19 @@ def tune_redis(*, dry_run: bool = False) -> dict:
         client.config_set("maxmemory", budget)
         summary["applied"]["maxmemory"] = budget
     except Exception as error:
-        summary["errors"].append(f"maxmemory: {error}")
+        message = _record_error(
+            summary,
+            "Redis maxmemory update",
+            error,
+            "Grant CONFIG access, configure Redis directly, or set "
+            "FLOPPY_REDIS_MAXMEMORY=0.",
+        )
         logger.warning(
-            "Could not set a Redis memory ceiling (%s). Redis will grow without "
+            "%s Redis will grow without "
             "bound and can exhaust the host. Add this to your redis service in "
             'docker-compose.yml: command: redis-server --appendonly yes --save "" '
             "--maxmemory %dmb --maxmemory-policy volatile-lru",
-            error,
+            message,
             budget // MIB,
         )
         return summary
@@ -200,11 +231,17 @@ def tune_redis(*, dry_run: bool = False) -> dict:
             client.config_set("maxmemory-policy", "volatile-lru")
             summary["applied"]["maxmemory-policy"] = "volatile-lru"
         except Exception as error:
-            summary["errors"].append(f"maxmemory-policy: {error}")
-            logger.warning(
-                "Set Redis maxmemory but could not set maxmemory-policy (%s); with "
-                "noeviction Redis will reject writes once full rather than evict",
+            message = _record_error(
+                summary,
+                "Redis maxmemory-policy update",
                 error,
+                "Grant CONFIG access, configure Redis directly, or set "
+                "FLOPPY_REDIS_MAXMEMORY=0.",
+            )
+            logger.warning(
+                "Set Redis maxmemory, but the policy update failed. %s With "
+                "noeviction Redis will reject writes once full rather than evict",
+                message,
             )
     else:
         summary["skipped"]["maxmemory-policy"] = current_policy
@@ -234,8 +271,14 @@ def _tune_persistence(client: redis.Redis, summary: dict) -> None:
         if _config_get(client, "appendfsync") != "always":
             return
         client.config_set("appendfsync", "everysec")
-    except Exception as error:  # pragma: no cover - best-effort tuning
-        summary["errors"].append(f"appendfsync: {error}")
+    except Exception as error:
+        message = _record_error(
+            summary,
+            "Redis persistence update",
+            error,
+            "Configure Redis persistence directly or set FLOPPY_REDIS_MAXMEMORY=0.",
+        )
+        logger.warning("%s", message)
         return
     summary["applied"]["appendfsync"] = "everysec"
     logger.info(

--- a/src/app/tests/test_app_startup.py
+++ b/src/app/tests/test_app_startup.py
@@ -353,3 +353,24 @@ class AppStartupTests(TestCase):
         self.assertNotIn(unsafe_error, rendered)
         self.assertNotIn("admin:password", rendered)
         self.assertNotIn("refused", rendered)
+
+    def test_celery_binding_repair_error_is_safe(self):
+        """Repair warnings must identify the error without exposing credentials."""
+        config = FloppyAppConfig("app", import_module("app"))
+        unsafe_error = "redis://broker:password@redis.example:6379/0 refused"
+
+        with (
+            patch(
+                "app.celery_broker.repair_celery_redis_bindings",
+                side_effect=RuntimeError(unsafe_error),
+            ),
+            self.assertLogs("app.apps", level="WARNING") as logs,
+        ):
+            config._repair_celery_redis_bindings()
+
+        rendered = " ".join(logs.output)
+        self.assertIn("Failed to normalize Kombu Redis bindings", rendered)
+        self.assertIn("RuntimeError", rendered)
+        self.assertNotIn(unsafe_error, rendered)
+        self.assertNotIn("broker:password", rendered)
+        self.assertNotIn("refused", rendered)

--- a/src/app/tests/test_app_startup.py
+++ b/src/app/tests/test_app_startup.py
@@ -303,3 +303,53 @@ class AppStartupTests(TestCase):
             schedule["options"]["priority"],
             settings.CELERY_TASK_PRIORITY_BACKGROUND,
         )
+
+    def test_startup_cache_failure_is_closed_by_default(self):
+        """Other startup work must still stop when the cache guard fails."""
+        config = FloppyAppConfig("app", import_module("app"))
+        unsafe_error = "redis://cache:password@redis.example:6379/0 refused"
+
+        with (
+            patch("app.apps.cache.add", side_effect=RuntimeError(unsafe_error)),
+            self.assertLogs("app.apps", level="DEBUG") as logs,
+        ):
+            self.assertFalse(config._add_startup_cache_key("test-key"))
+
+        rendered = " ".join(logs.output)
+        self.assertIn("RuntimeError", rendered)
+        self.assertNotIn(unsafe_error, rendered)
+        self.assertNotIn("cache:password", rendered)
+        self.assertNotIn("refused", rendered)
+
+    def test_redis_tuning_continues_when_the_cache_guard_fails(self):
+        """The administration Redis can work while the cache Redis is down."""
+        config = FloppyAppConfig("app", import_module("app"))
+
+        with (
+            patch("app.apps.cache.add", side_effect=RuntimeError("secret text")),
+            patch("app.redis_tuning.tune_redis") as mock_tune,
+        ):
+            config._tune_redis()
+
+        mock_tune.assert_called_once_with()
+
+    def test_redis_tuning_startup_error_is_safe(self):
+        """Startup logs must show the error type but not its raw message."""
+        config = FloppyAppConfig("app", import_module("app"))
+        unsafe_error = "redis://admin:password@redis.example:6379/0 refused"
+
+        with (
+            patch.object(config, "_add_startup_cache_key", return_value=True),
+            patch(
+                "app.redis_tuning.tune_redis",
+                side_effect=RuntimeError(unsafe_error),
+            ),
+            self.assertLogs("app.apps", level="WARNING") as logs,
+        ):
+            config._tune_redis()
+
+        rendered = " ".join(logs.output)
+        self.assertIn("RuntimeError", rendered)
+        self.assertNotIn(unsafe_error, rendered)
+        self.assertNotIn("admin:password", rendered)
+        self.assertNotIn("refused", rendered)

--- a/src/app/tests/test_celery_broker.py
+++ b/src/app/tests/test_celery_broker.py
@@ -124,9 +124,7 @@ class CeleryPriorityDrainOrderTests(SimpleTestCase):
             "interactive",
         )
 
-        priority_steps = settings.CELERY_BROKER_TRANSPORT_OPTIONS[
-            "priority_steps"
-        ]
+        priority_steps = settings.CELERY_BROKER_TRANSPORT_OPTIONS["priority_steps"]
         keys_by_ascending_priority = [priority_key(p) for p in priority_steps]
 
         first = client.brpop(keys_by_ascending_priority, timeout=1)
@@ -193,6 +191,31 @@ class CeleryBrokerRepairTests(SimpleTestCase):
         self.assertEqual(
             fake_client.data[key],
             {"reply.celery.pidbox::celery@worker.celery.pidbox"},
+        )
+        mock_from_url.assert_called_once_with(
+            "redis://example:6379/0",
+            socket_timeout=30,
+            socket_connect_timeout=10,
+        )
+
+    @override_settings(
+        CELERY_BROKER_URL="redis://example:6379/0",
+        CELERY_BROKER_TRANSPORT_OPTIONS={
+            "sep": ":",
+            "socket_timeout": 7,
+            "socket_connect_timeout": 3,
+        },
+    )
+    @patch("app.celery_broker.redis.Redis.from_url")
+    def test_repair_uses_bounded_broker_timeouts(self, mock_from_url):
+        mock_from_url.return_value.scan_iter.return_value = []
+
+        celery_broker.repair_celery_redis_bindings()
+
+        mock_from_url.assert_called_once_with(
+            "redis://example:6379/0",
+            socket_timeout=7,
+            socket_connect_timeout=3,
         )
 
     @override_settings(

--- a/src/app/tests/test_redis_settings.py
+++ b/src/app/tests/test_redis_settings.py
@@ -1,0 +1,124 @@
+"""Tests for Redis role configuration (issue #596)."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+
+class RedisSettingsTests(SimpleTestCase):
+    """Read production settings in an isolated process."""
+
+    settings_script = """
+import json
+from config import settings
+
+print(json.dumps({
+    "redis": settings.REDIS_URL,
+    "cache": settings.CACHES["default"]["LOCATION"],
+    "broker": settings.CELERY_BROKER_URL,
+    "result": settings.CELERY_RESULT_BACKEND,
+    "admin": settings.REDIS_ADMIN_URL,
+}))
+"""
+
+    def _read_settings(self, **overrides):
+        root = Path(__file__).resolve().parents[3]
+        env = os.environ.copy()
+        for name in (
+            "REDIS_URL",
+            "REDIS_CACHE_URL",
+            "CELERY_BROKER_URL",
+            "CELERY_RESULT_BACKEND",
+            "REDIS_ADMIN_URL",
+        ):
+            env.pop(name, None)
+        env.update(
+            {
+                "SECRET": "redis-settings-test-secret",
+                "PYTHONPATH": str(root / "src"),
+                **overrides,
+            },
+        )
+        completed = subprocess.run(  # noqa: S603 - fixed interpreter and script
+            [sys.executable, "-c", self.settings_script],
+            cwd=root,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(completed.stdout)
+
+    def test_redis_url_remains_the_compatibility_fallback(self):
+        """One REDIS_URL must keep the current deployment behavior."""
+        values = self._read_settings(REDIS_URL="redis://compatibility:6379/0")
+
+        self.assertEqual(set(values.values()), {"redis://compatibility:6379/0"})
+
+    def test_each_redis_role_accepts_a_separate_url(self):
+        """Each consumer must use its selected Redis service."""
+        values = self._read_settings(
+            REDIS_URL="redis://limiter:6379/0",
+            REDIS_CACHE_URL="redis://cache:6379/1",
+            CELERY_BROKER_URL="redis://broker:6379/2",
+            CELERY_RESULT_BACKEND="redis://results:6379/3",
+            REDIS_ADMIN_URL="redis://admin:6379/4",
+        )
+
+        self.assertEqual(
+            values,
+            {
+                "redis": "redis://limiter:6379/0",
+                "cache": "redis://cache:6379/1",
+                "broker": "redis://broker:6379/2",
+                "result": "redis://results:6379/3",
+                "admin": "redis://admin:6379/4",
+            },
+        )
+
+    def test_empty_overrides_use_the_documented_fallbacks(self):
+        """An empty role setting must not disable its compatibility fallback."""
+        values = self._read_settings(
+            REDIS_URL="redis://compatibility:6379/0",
+            REDIS_CACHE_URL="",
+            CELERY_BROKER_URL="",
+            CELERY_RESULT_BACKEND="",
+            REDIS_ADMIN_URL="",
+        )
+
+        self.assertEqual(set(values.values()), {"redis://compatibility:6379/0"})
+
+    def test_admin_defaults_to_the_cache_url(self):
+        """Automatic Redis tuning must normally target the cache server."""
+        values = self._read_settings(
+            REDIS_URL="redis://compatibility:6379/0",
+            REDIS_CACHE_URL="redis://cache:6379/1",
+        )
+
+        self.assertEqual(values["admin"], "redis://cache:6379/1")
+
+
+class ProviderLimiterRedisSettingsTests(SimpleTestCase):
+    """Keep provider rate limiting on the compatibility Redis URL."""
+
+    @override_settings(
+        TESTING=False,
+        REDIS_URL="redis://limiter:6379/0",
+        REDIS_CACHE_URL="redis://cache:6379/1",
+    )
+    @patch("app.providers.services.ConnectionPool.from_url")
+    def test_provider_limiter_keeps_using_redis_url(self, mock_from_url):
+        """Issue #596 must not change the provider limiter target."""
+        from app.providers.services import get_redis_pool
+
+        get_redis_pool()
+
+        mock_from_url.assert_called_once_with(
+            "redis://limiter:6379/0",
+            max_connections=8,
+        )

--- a/src/app/tests/test_redis_tuning.py
+++ b/src/app/tests/test_redis_tuning.py
@@ -112,13 +112,26 @@ class DeriveBudgetTests(SimpleTestCase):
             )
 
 
-@override_settings(REDIS_URL="redis://localhost:6379", FLOPPY_REDIS_MAXMEMORY="256mb")
+@override_settings(
+    REDIS_ADMIN_URL="redis://localhost:6379",
+    FLOPPY_REDIS_MAXMEMORY="256mb",
+)
 class TuneRedisTests(SimpleTestCase):
     """Applying the ceiling to a live server."""
+
+    unsafe_error = "redis://admin:password@redis.example:6379/0 refused"
 
     def _run(self, client, **kwargs):
         with mock.patch.object(redis.Redis, "from_url", return_value=client):
             return tune_redis(**kwargs)
+
+    def _assert_safe_error(self, summary, logs, operation, error_type):
+        rendered = f"{summary}\n{' '.join(logs.output)}"
+        self.assertIn(operation, rendered)
+        self.assertIn(error_type, rendered)
+        self.assertNotIn(self.unsafe_error, rendered)
+        self.assertNotIn("admin:password", rendered)
+        self.assertNotIn("refused", rendered)
 
     def test_sets_ceiling_and_policy_on_an_untouched_redis(self):
         """The default noeviction/unlimited config is what we're here to fix."""
@@ -152,26 +165,117 @@ class TuneRedisTests(SimpleTestCase):
         """Managed Redis and ACLs refuse CONFIG SET; that must not fail boot."""
         client = fake_client()
         client.config_set.side_effect = redis.exceptions.ResponseError(
-            "unknown command 'CONFIG'",
+            self.unsafe_error,
         )
 
-        summary = self._run(client)
+        with self.assertLogs("app.redis_tuning", level="WARNING") as logs:
+            summary = self._run(client)
 
         self.assertEqual(summary["applied"], {})
         self.assertTrue(summary["errors"])
-        self.assertIn("maxmemory", summary["errors"][0])
+        self._assert_safe_error(
+            summary,
+            logs,
+            "Redis maxmemory update",
+            "ResponseError",
+        )
 
     def test_unreachable_redis_is_not_an_error_worth_raising(self):
         """The cache layer reports connectivity; this just tries again later."""
-        with mock.patch.object(
-            redis.Redis,
-            "from_url",
-            side_effect=redis.exceptions.ConnectionError("refused"),
+        with (
+            self.assertLogs("app.redis_tuning", level="INFO") as logs,
+            mock.patch.object(
+                redis.Redis,
+                "from_url",
+                side_effect=redis.exceptions.ConnectionError(self.unsafe_error),
+            ),
         ):
             summary = tune_redis()
 
         self.assertEqual(summary["applied"], {})
         self.assertTrue(summary["errors"])
+        self._assert_safe_error(
+            summary,
+            logs,
+            "Redis administration maxmemory read",
+            "ConnectionError",
+        )
+
+    def test_policy_read_error_is_safe(self):
+        """A CONFIG read error must not expose Redis connection details."""
+        client = fake_client()
+        config_get = client.config_get.side_effect
+
+        def fail_policy_read(name):
+            if name == "maxmemory-policy":
+                raise redis.exceptions.ResponseError(self.unsafe_error)
+            return config_get(name)
+
+        client.config_get.side_effect = fail_policy_read
+        with self.assertLogs("app.redis_tuning", level="WARNING") as logs:
+            summary = self._run(client)
+
+        self._assert_safe_error(
+            summary,
+            logs,
+            "Redis maxmemory-policy read",
+            "ResponseError",
+        )
+
+    def test_policy_update_error_is_safe(self):
+        """A CONFIG policy error must not expose Redis connection details."""
+        client = fake_client()
+        config_set = client.config_set.side_effect
+
+        def fail_policy_update(name, value):
+            if name == "maxmemory-policy":
+                raise redis.exceptions.ResponseError(self.unsafe_error)
+            return config_set(name, value)
+
+        client.config_set.side_effect = fail_policy_update
+        with self.assertLogs("app.redis_tuning", level="WARNING") as logs:
+            summary = self._run(client)
+
+        self._assert_safe_error(
+            summary,
+            logs,
+            "Redis maxmemory-policy update",
+            "ResponseError",
+        )
+
+    def test_persistence_update_error_is_safe(self):
+        """A CONFIG persistence error must not expose Redis connection details."""
+        client = fake_client({"appendonly": "yes", "appendfsync": "always"})
+        config_set = client.config_set.side_effect
+
+        def fail_persistence_update(name, value):
+            if name == "appendfsync":
+                raise redis.exceptions.ResponseError(self.unsafe_error)
+            return config_set(name, value)
+
+        client.config_set.side_effect = fail_persistence_update
+        with self.assertLogs("app.redis_tuning", level="WARNING") as logs:
+            summary = self._run(client)
+
+        self._assert_safe_error(
+            summary,
+            logs,
+            "Redis persistence update",
+            "ResponseError",
+        )
+
+    @override_settings(REDIS_ADMIN_URL="redis://admin.example:6379/0")
+    def test_uses_the_administration_url(self):
+        """Redis CONFIG must use the administration target."""
+        client = fake_client()
+        with mock.patch.object(
+            redis.Redis,
+            "from_url",
+            return_value=client,
+        ) as from_url:
+            tune_redis()
+
+        from_url.assert_called_once_with("redis://admin.example:6379/0")
 
     def test_dry_run_changes_nothing(self):
         """--dry-run must report the plan without touching the server."""
@@ -200,7 +304,7 @@ class TuneRedisTests(SimpleTestCase):
                 self.assertNotIn("appendfsync", summary["applied"])
                 self.assertEqual(client.values["appendfsync"], current)
 
-    @override_settings(REDIS_URL="memory://")
+    @override_settings(REDIS_ADMIN_URL="memory://")
     def test_non_redis_url_is_skipped(self):
         """Nothing to configure when the cache isn't Redis."""
         summary = tune_redis()

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -428,6 +428,8 @@ else:
 # https://docs.djangoproject.com/en/stable/topics/cache/
 CACHE_TIMEOUT = 86400  # 24 hours
 REDIS_URL = config("REDIS_URL", default="redis://localhost:6379")
+REDIS_CACHE_URL = config("REDIS_CACHE_URL", default=None) or REDIS_URL
+REDIS_ADMIN_URL = config("REDIS_ADMIN_URL", default=None) or REDIS_CACHE_URL
 # Byte count or a redis.conf-style size ("256mb"). Unset means "derive one from
 # the host"; 0 means "never touch the operator's Redis". See app/redis_tuning.py.
 FLOPPY_REDIS_MAXMEMORY = config(
@@ -438,7 +440,7 @@ KEY_PREFIX = f"{REDIS_PREFIX}" if REDIS_PREFIX else ""
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": REDIS_URL,
+        "LOCATION": REDIS_CACHE_URL,
         "TIMEOUT": CACHE_TIMEOUT,
         "VERSION": 14,
         "KEY_PREFIX": KEY_PREFIX,
@@ -1161,7 +1163,7 @@ SELECT2_THEME = "tailwindcss-4"
 
 # Celery settings
 
-CELERY_BROKER_URL = REDIS_URL
+CELERY_BROKER_URL = config("CELERY_BROKER_URL", default=None) or REDIS_URL
 CELERY_TIMEZONE = TIME_ZONE
 
 CELERY_BROKER_TRANSPORT_OPTIONS = {
@@ -1257,7 +1259,7 @@ CELERY_TASK_DEFAULT_PRIORITY = 5
 CELERY_TASK_PRIORITY_BACKGROUND = 9
 
 CELERY_RESULT_EXTENDED = True
-CELERY_RESULT_BACKEND = REDIS_URL
+CELERY_RESULT_BACKEND = config("CELERY_RESULT_BACKEND", default=None) or REDIS_URL
 CELERY_CACHE_BACKEND = "default"
 CELERY_RESULT_EXPIRES = 60 * 60 * 24 * 7  # 7 days
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"

--- a/src/config/test_settings.py
+++ b/src/config/test_settings.py
@@ -5,7 +5,7 @@ from .settings import *  # noqa: F403
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": REDIS_URL,  # noqa: F405
+        "LOCATION": REDIS_CACHE_URL,  # noqa: F405
         "TIMEOUT": 18000,  # 5 hours
         "OPTIONS": {
             "CONNECTION_POOL_KWARGS": {"connection_class": FakeConnection},


### PR DESCRIPTION
## Summary

This change lets each Redis consumer use a separate service. It preserves
`REDIS_URL` as the compatibility fallback.

- `REDIS_CACHE_URL` selects the Django cache and cached-session service.
- `CELERY_BROKER_URL` selects the Celery broker.
- `CELERY_RESULT_BACKEND` selects the Celery result service.
- `REDIS_ADMIN_URL` selects the service that Floppy can tune with `CONFIG`.
- The provider rate limiter continues to use `REDIS_URL`.

## Why this replacement is required

PR #614 was merged into `test/export-csv-openlibrary-isolation`. Its merge
commit is not an ancestor of `latest`, so the documented feature is absent
from the released branch. A merged pull request cannot be reopened. This
replacement starts from the current `latest` branch and preserves #614 as
history.

## Changes

- Add independent cache, broker, result, and administration settings.
- Keep one-URL deployments unchanged through explicit fallback rules.
- Send automatic memory and persistence tuning to `REDIS_ADMIN_URL`.
- Continue tuning when the cache startup guard is unavailable.
- Apply the Celery broker connection and socket timeouts to startup binding
  repair.
- Log error types and operator actions without logging Redis credentials or
  raw connection details.
- Document fallback order, `CONFIG` and ACL behavior, the `appendfsync`
  adjustment, and a safe service-cutover procedure.

## Failure behavior

An unavailable cache does not prevent Floppy from trying the selected
administration service. An unavailable broker cannot hold web startup without
the configured connection and socket bounds. Managed Redis services can deny
`CONFIG`; Floppy reports the action and continues startup.

Database-backed sessions reload after a cache miss. Changing the cache service
does not delete accounts or active session records. The README also tells
operators to drain broker work and preserve required results before a cutover.

## Conflict resolution and rollback

If a service cutover fails, stop the web process, workers, and scheduler. Remove
the role-specific override that failed, or point it back to the current
`REDIS_URL`. Then restart one process at a time and verify cache, broker, result,
and administration connections before normal traffic resumes.

If this branch conflicts with a later `latest` change, update it from `latest`
and keep the explicit role fallback order. Do not replace the separate service
settings with direct consumer-specific parsing.

## Compatibility and future launchers

Existing deployments that set only `REDIS_URL` keep the current behavior.
Empty role overrides also use `REDIS_URL`.

A native launcher can provide Unix-socket or network URLs for each role. The
settings accept the launcher's existing `unix://` cache and `redis+socket://`
Celery URLs. Redis administration tuning skips a non-Redis administration URL,
so a launcher can manage its own embedded Redis limits.

## Upstream check

Yamtrack `dev` at `f97b0639e24c08a5b1de3b9234b8b81cf6abea93` has no
`REDIS_CACHE_URL` or `REDIS_ADMIN_URL` role split and no equivalent fix to port.

## Verification

- 51 focused settings, tuning, startup, broker, safety, and compatibility
  checks passed.
- Runtime probes confirmed every selected consumer and the `REDIS_URL`
  fallback.
- Runtime probes confirmed native Unix-socket launcher settings.
- Credential-bearing simulated errors did not enter logs.
- Configured and fallback broker timeouts reached the direct Redis client.
- Ruff, format checks, and `git diff --check` passed.
- The fast suite passed all 3,524 tests in 504.828 seconds.
- Hosted `test (3.12)` passed in 24m35s.
- Hosted lint, CodeQL, image restart smoke, and multi-architecture build checks
  passed.
- Independent code review: READY; no remaining findings.

This change has no user-interface output. Screenshots would not add useful
evidence.

## Relationships

Fixes #596

Replaces #614

Related to #521

## AI Assistance

The `gpt-5` Codex agent investigated, implemented, tested, and documented this
change. Independent review agents checked the final commits.

## Human Review

- [ ] Pending human review.
- [x] Completed by the repository maintainer through merge.

## Gstack QA

- [ ] Pending `/gstack-qa`.
- [x] Completed. This configuration-only branch passed all 3,524 tests. It does
  not change the rendered interface.

## Migration Sync Gate

Not applicable. This pull request does not synchronize `upstream` to `latest`.
