### PR TITLE
fix(sqlite): repair migration-blocking orphaned credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ services:
 ```
 
 Use a dedicated parent directory when `FLOPPY_DB_PATH` is outside
-`FLOPPY_DATA_DIR`. At startup, Floppy can change ownership recursively inside
-`FLOPPY_DATA_DIR`. It changes only the external database parent and the
-SQLite files when the database is outside that directory.
+`FLOPPY_DATA_DIR`. At startup, Floppy changes ownership only on the selected
+data, database, and log directory entries and on Floppy's generated key,
+SQLite files, and current log file. It does not change unrelated files inside
+those directories.
 
 Use local storage or block storage for SQLite. Do not use NFS, SMB/CIFS, or
 another network filesystem.
@@ -246,7 +247,9 @@ is missing, existing sessions and signed data can become invalid.
 
 ### PostgreSQL
 
-Floppy uses PostgreSQL only when `DB_HOST` is set. Without it, it uses SQLite at `/floppy/db/db.sqlite3`. `DATABASE_URL` is not supported — set the individual `DB_*` variables.
+Floppy uses PostgreSQL only when `DB_HOST` is set. Without it, it uses
+`FLOPPY_DB_PATH`; the container default is `/floppy/db/db.sqlite3`.
+`DATABASE_URL` is not supported — set the individual `DB_*` variables.
 
 ```yaml
 services:

--- a/README.md
+++ b/README.md
@@ -500,6 +500,26 @@ upgrades matter.
 - Redis stores sessions and background-task state; resetting Redis can log users out, but it should not delete accounts if the database is persisted.
 - Do not assume `DATABASE_URL` enables PostgreSQL. Floppy uses Postgres only when `DB_HOST` is set.
 
+### SQLite startup recovery
+
+Floppy checks SQLite storage and relationships before it runs migrations.
+If the check finds an album artist credit whose album or artist no longer
+exists, Floppy removes only that invalid credit and checks the database again.
+The startup log gives the number of rows that it removed.
+
+Floppy does not repair other relationship errors. It stops before migrations
+and lists each table, row, and missing parent. Use this procedure:
+
+1. Stop all Floppy processes that use the database.
+2. Back up the SQLite file and its `-wal` and `-shm` files, if they exist.
+3. Read each relationship error in the startup log.
+4. Restore a known-good backup or correct the named rows with a SQLite tool.
+5. Start Floppy and confirm that the relationship check passes.
+
+If the log says that the database is busy, another process still holds a
+write lock. Stop that process, then restart Floppy. Do not delete the database
+or its lock files to resolve this conflict.
+
 ### Trakt private profile import (OAuth)
 
 If you import from a private Trakt profile, configure OAuth first:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,79 @@ Floppy exposes a REST API at `/api/v1` and ships an [MCP server](mcp_server/). I
 
 ## Configuration and deployment
 
+### SQLite data paths
+
+Floppy uses these rules when `DB_HOST` is not set:
+
+1. `FLOPPY_DB_PATH` selects the SQLite file.
+2. If `FLOPPY_DB_PATH` is not set, Floppy uses
+   `FLOPPY_DATA_DIR/db.sqlite3`.
+3. If neither variable is set, Floppy uses
+   `/floppy/db/db.sqlite3` in the container.
+
+An empty value does not override a path. A relative path starts from the
+process working directory. Use absolute paths so that each process uses the
+same location.
+
+If `SECRET` and `SECRET_FILE` are not set, the container stores its generated
+`secret_key` in `FLOPPY_DATA_DIR`. Floppy stores logs and backups in `LOG_DIR`
+and `BACKUP_DIR`. `FLOPPY_DATA_DIR` does not change those settings.
+
+This example stores the SQLite file and the generated key in one mounted
+directory:
+
+```yaml
+services:
+  floppy:
+    image: ghcr.io/dannyvfilms/floppy:latest
+    environment:
+      FLOPPY_DATA_DIR: /data/floppy
+    volumes:
+      - ./floppy-data:/data/floppy
+    ports:
+      - "8000:8000"
+```
+
+This example stores the SQLite file in a separate mounted directory:
+
+```yaml
+services:
+  floppy:
+    image: ghcr.io/dannyvfilms/floppy:latest
+    environment:
+      FLOPPY_DATA_DIR: /data/floppy
+      FLOPPY_DB_PATH: /database/floppy/db.sqlite3
+    volumes:
+      - ./floppy-data:/data/floppy
+      - ./floppy-database:/database/floppy
+    ports:
+      - "8000:8000"
+```
+
+Use a dedicated parent directory when `FLOPPY_DB_PATH` is outside
+`FLOPPY_DATA_DIR`. At startup, Floppy can change ownership recursively inside
+`FLOPPY_DATA_DIR`. It changes only the external database parent and the
+SQLite files when the database is outside that directory.
+
+Use local storage or block storage for SQLite. Do not use NFS, SMB/CIFS, or
+another network filesystem.
+
+Floppy does not move existing data when you set these variables. Use this
+procedure to change a path:
+
+1. Stop the Floppy container.
+2. Back up the current SQLite file.
+3. Copy the SQLite file to the new path. Copy its `-wal` and `-shm` companion
+   files if they are present.
+4. Copy the generated `secret_key` to the new data directory. You can set
+   `SECRET` instead if you already manage the key outside the data directory.
+5. Set the new path variables and mount each selected directory.
+6. Start Floppy and confirm that the existing library is present.
+
+If the database file is missing, Floppy creates an empty database. The
+deployment can then appear to have lost its library. If the old generated key
+is missing, existing sessions and signed data can become invalid.
+
 ### PostgreSQL
 
 Floppy uses PostgreSQL only when `DB_HOST` is set. Without it, it uses SQLite at `/floppy/db/db.sqlite3`. `DATABASE_URL` is not supported — set the individual `DB_*` variables.
@@ -412,8 +485,14 @@ upgrades matter.
 
 ### Persistence checklist
 
-- SQLite stores the app database at `/floppy/db/db.sqlite3`; persist `/floppy/db`. (Pre-rename `/yamtrack/db` mounts still resolve, so existing setups keep working.)
-- **Do not put `/floppy/db` on a network filesystem** (NFS, SMB/CIFS, or a NAS "share" mounted into Docker). Floppy's SQLite database uses WAL mode, which [SQLite's own documentation](https://sqlite.org/wal.html) warns is unsafe over network filesystems because they don't reliably support the locking it depends on - this can corrupt the database under normal concurrent use. Use local/block storage for `/floppy/db`, or set `DB_HOST` to use PostgreSQL if only network storage is available.
+- SQLite stores the app database at `/floppy/db/db.sqlite3` by default. Persist
+  `/floppy/db`, or persist each configured SQLite data path. Pre-rename
+  `/yamtrack/db` mounts still resolve, so existing setups keep working.
+- **Do not put the SQLite file on a network filesystem** such as NFS, SMB/CIFS,
+  or a NAS share that is mounted into Docker. Floppy uses SQLite WAL mode.
+  [SQLite documents](https://sqlite.org/wal.html) that WAL does not work over a
+  network filesystem. Use local storage or block storage. Set `DB_HOST` to use
+  PostgreSQL if only network storage is available.
 - PostgreSQL stores its database files at `/var/lib/postgresql/data`; persist that path on the Postgres container.
 - Redis stores sessions and background-task state; resetting Redis can log users out, but it should not delete accounts if the database is persisted.
 - Do not assume `DATABASE_URL` enables PostgreSQL. Floppy uses Postgres only when `DB_HOST` is set.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,18 +28,20 @@ if [ -z "$DB_HOST" ]; then
 
     reject_unsafe_managed_directory FLOPPY_DB_PATH "$DB_PARENT"
 
-    # Fail fast with a clear message if the SQLite file is already corrupt.
-    # This avoids repeated migration failures (issues #508 and #593).
+    # Fail fast when SQLite storage or relationships are invalid. Repair only
+    # the known orphaned album credit conflict (issues #508, #593, and #731).
     if [ -f "$DB_FILE" ]; then
-        echo "[entrypoint] Checking SQLite integrity for ${DB_FILE} (PRAGMA quick_check)" >&2
+        echo "[entrypoint] Checking SQLite storage and relationships for ${DB_FILE}" >&2
         python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
         integrity_pid=$!
 
         # Report bytes read so large databases show visible progress.
         elapsed=0
+        integrity_timed_out=0
         while kill -0 "$integrity_pid" 2>/dev/null; do
             if [ "$elapsed" -ge 600 ]; then
-                echo "[entrypoint] WARNING: SQLite integrity check exceeded 600s (slow storage?); continuing" >&2
+                echo "[entrypoint] ERROR: SQLite integrity check exceeded 600s; stopping startup" >&2
+                integrity_timed_out=1
                 kill "$integrity_pid" 2>/dev/null
                 break
             fi
@@ -55,10 +57,7 @@ if [ -z "$DB_HOST" ]; then
 
         integrity_status=0
         wait "$integrity_pid" || integrity_status=$?
-        if [ "$elapsed" -ge 600 ] && [ "$integrity_status" -ne 0 ]; then
-            integrity_status=124
-        fi
-        if [ "$integrity_status" -ne 0 ] && [ "$integrity_status" -ne 124 ]; then
+        if [ "$integrity_timed_out" -eq 1 ] || [ "$integrity_status" -ne 0 ]; then
             exit 1
         fi
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,23 +2,31 @@
 
 set -e
 
+reject_unsafe_managed_directory() {
+    managed_name=$1
+    managed_dir=$2
+    case "$managed_dir" in
+        /|/bin|/boot|/dev|/etc|/home|/lib|/lib32|/lib64|/libx32|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/var|/usr/bin|/usr/include|/usr/lib|/usr/lib32|/usr/lib64|/usr/libx32|/usr/local|/usr/sbin|/usr/share|/usr/src|/var/backups|/var/cache|/var/lib|/var/local|/var/lock|/var/log|/var/mail|/var/opt|/var/spool|/var/tmp)
+            echo "[entrypoint] ${managed_name} must resolve to a dedicated directory, not system directory ${managed_dir}." >&2
+            exit 1
+            ;;
+    esac
+}
+
 DATA_DIR_INPUT=${FLOPPY_DATA_DIR:-/floppy/db}
 DATA_DIR=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DATA_DIR_INPUT")
+LOG_DIR_INPUT=${LOG_DIR:-/floppy/logs}
+LOG_DIR_PATH=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$LOG_DIR_INPUT")
 
-if [ "$DATA_DIR" = / ]; then
-    echo "[entrypoint] FLOPPY_DATA_DIR must resolve to a directory below /." >&2
-    exit 1
-fi
+reject_unsafe_managed_directory FLOPPY_DATA_DIR "$DATA_DIR"
+reject_unsafe_managed_directory LOG_DIR "$LOG_DIR_PATH"
 
 if [ -z "$DB_HOST" ]; then
     DB_FILE_INPUT=${FLOPPY_DB_PATH:-"${DATA_DIR_INPUT}/db.sqlite3"}
     DB_FILE=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DB_FILE_INPUT")
     DB_PARENT=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).parent)' "$DB_FILE")
 
-    if [ "$DB_PARENT" = / ]; then
-        echo "[entrypoint] FLOPPY_DB_PATH must use a database directory below /." >&2
-        exit 1
-    fi
+    reject_unsafe_managed_directory FLOPPY_DB_PATH "$DB_PARENT"
 
     # Fail fast with a clear message if the SQLite file is already corrupt.
     # This avoids repeated migration failures (issues #508 and #593).
@@ -86,23 +94,30 @@ usermod -o -u "$PUID" abc
 
 chown abc:abc -- /floppy
 
-if [ -e "$DATA_DIR" ] && ! timeout 600 chown -R abc:abc -- "$DATA_DIR"; then
+if [ -e "$DATA_DIR" ] && ! timeout 600 chown abc:abc -- "$DATA_DIR"; then
     echo "[entrypoint] Cannot set ownership for FLOPPY_DATA_DIR ${DATA_DIR} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
     exit 1
 fi
 
+SECRET_FILE="${DATA_DIR}/secret_key"
+if { [ -e "$SECRET_FILE" ] || [ -L "$SECRET_FILE" ]; } && \
+   ! timeout 600 chown -h abc:abc -- "$SECRET_FILE"; then
+    echo "[entrypoint] Cannot set ownership for generated secret ${SECRET_FILE} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+    exit 1
+fi
+
 if [ -z "$DB_HOST" ]; then
-    case "${DB_PARENT}/" in
-        "${DATA_DIR}/"*) ;;
-        *)
-            for path in "$DB_PARENT" "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"; do
-                if [ -e "$path" ] && ! timeout 600 chown abc:abc -- "$path"; then
-                    echo "[entrypoint] Cannot set ownership for FLOPPY_DB_PATH parent ${DB_PARENT} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
-                    exit 1
-                fi
-            done
-            ;;
-    esac
+    if [ -e "$DB_PARENT" ] && ! timeout 600 chown abc:abc -- "$DB_PARENT"; then
+        echo "[entrypoint] Cannot set ownership for FLOPPY_DB_PATH parent ${DB_PARENT} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+        exit 1
+    fi
+    for path in "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"; do
+        if { [ -e "$path" ] || [ -L "$path" ]; } && \
+           ! timeout 600 chown -h abc:abc -- "$path"; then
+            echo "[entrypoint] Cannot set ownership for SQLite file ${path} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+            exit 1
+        fi
+    done
 fi
 
 # "logs" holds the rotating file handler every process configures at import time
@@ -111,9 +126,20 @@ fi
 # process then dies with "Unable to configure handler 'file'" -- taking gunicorn
 # with it, so the container serves 502s while reporting healthy.
 #
-# Bound each recursive chown: a stalled bind mount (e.g. network storage)
-# must degrade to a warning instead of hanging the boot silently (issue #341).
-for dir in "${LOG_DIR:-/floppy/logs}" /floppy/staticfiles /var/log/nginx /var/lib/nginx; do
+# The log directory can be an operator-selected mount. Change only that
+# directory entry and Floppy's current log file, never unrelated content.
+if [ -e "$LOG_DIR_PATH" ] && ! timeout 600 chown abc:abc -- "$LOG_DIR_PATH"; then
+    echo "[entrypoint] WARNING: chown of ${LOG_DIR_PATH} failed or timed out (stalled mount?); continuing" >&2
+fi
+LOG_FILE="${LOG_DIR_PATH}/floppy.log"
+if { [ -e "$LOG_FILE" ] || [ -L "$LOG_FILE" ]; } && \
+   ! timeout 600 chown -h abc:abc -- "$LOG_FILE"; then
+    echo "[entrypoint] WARNING: chown of ${LOG_FILE} failed or timed out (stalled mount?); continuing" >&2
+fi
+
+# Bound recursive ownership fixes for the image-managed service directories: a
+# stalled bind mount must degrade to a warning instead of hanging boot (#341).
+for dir in /floppy/staticfiles /var/log/nginx /var/lib/nginx; do
     echo "[entrypoint] Chowning ${dir}" >&2
     timeout 600 chown -R abc:abc -- "$dir" || \
         echo "[entrypoint] WARNING: chown of ${dir} failed or timed out (stalled mount?); continuing" >&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,45 +2,57 @@
 
 set -e
 
-# Fail fast with a clear message if the SQLite file is already corrupt,
-# instead of burning through the migrate retry loop below to arrive at an
-# opaque "file is not a database" traceback (issue #508). Corruption here
-# often means the db directory sits on a network filesystem that doesn't
-# support SQLite's WAL locking - see README's SQLite persistence note.
-# Rejects a non-"ok" quick_check result even when SQLite doesn't raise an
-# exception for it (issue #593).
-if [ -z "$DB_HOST" ] && [ -f /floppy/db/db.sqlite3 ]; then
-    echo "[entrypoint] Checking SQLite integrity (PRAGMA quick_check)" >&2
-    python -c "from config.sqlite_integrity import check_database_integrity; check_database_integrity('/floppy/db/db.sqlite3')" &
-    integrity_pid=$!
+DATA_DIR_INPUT=${FLOPPY_DATA_DIR:-/floppy/db}
+DATA_DIR=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DATA_DIR_INPUT")
 
-    # Report actual bytes read from /proc rather than a bare "still going" -
-    # cheap to read (no python instrumentation needed) and gives the user
-    # something concrete instead of a repeating, uninformative message.
-    elapsed=0
-    while kill -0 "$integrity_pid" 2>/dev/null; do
-        if [ "$elapsed" -ge 600 ]; then
-            echo "[entrypoint] WARNING: SQLite integrity check exceeded 600s (slow storage?); continuing" >&2
-            kill "$integrity_pid" 2>/dev/null
-            break
-        fi
-        sleep 30
-        elapsed=$((elapsed + 30))
-        read_mb=$(awk '/^rchar:/ {printf "%.0f", $2/1048576}' "/proc/${integrity_pid}/io" 2>/dev/null) || read_mb=""
-        if [ -n "$read_mb" ]; then
-            echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed, ~${read_mb}MB read so far)" >&2
-        else
-            echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed)" >&2
-        fi
-    done
+if [ "$DATA_DIR" = / ]; then
+    echo "[entrypoint] FLOPPY_DATA_DIR must resolve to a directory below /." >&2
+    exit 1
+fi
 
-    integrity_status=0
-    wait "$integrity_pid" || integrity_status=$?
-    if [ "$elapsed" -ge 600 ] && [ "$integrity_status" -ne 0 ]; then
-        integrity_status=124
-    fi
-    if [ "$integrity_status" -ne 0 ] && [ "$integrity_status" -ne 124 ]; then
+if [ -z "$DB_HOST" ]; then
+    DB_FILE_INPUT=${FLOPPY_DB_PATH:-"${DATA_DIR_INPUT}/db.sqlite3"}
+    DB_FILE=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$DB_FILE_INPUT")
+    DB_PARENT=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).parent)' "$DB_FILE")
+
+    if [ "$DB_PARENT" = / ]; then
+        echo "[entrypoint] FLOPPY_DB_PATH must use a database directory below /." >&2
         exit 1
+    fi
+
+    # Fail fast with a clear message if the SQLite file is already corrupt.
+    # This avoids repeated migration failures (issues #508 and #593).
+    if [ -f "$DB_FILE" ]; then
+        echo "[entrypoint] Checking SQLite integrity for ${DB_FILE} (PRAGMA quick_check)" >&2
+        python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+        integrity_pid=$!
+
+        # Report bytes read so large databases show visible progress.
+        elapsed=0
+        while kill -0 "$integrity_pid" 2>/dev/null; do
+            if [ "$elapsed" -ge 600 ]; then
+                echo "[entrypoint] WARNING: SQLite integrity check exceeded 600s (slow storage?); continuing" >&2
+                kill "$integrity_pid" 2>/dev/null
+                break
+            fi
+            sleep 30
+            elapsed=$((elapsed + 30))
+            read_mb=$(awk '/^rchar:/ {printf "%.0f", $2/1048576}' "/proc/${integrity_pid}/io" 2>/dev/null) || read_mb=""
+            if [ -n "$read_mb" ]; then
+                echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed, ~${read_mb}MB read so far)" >&2
+            else
+                echo "[entrypoint] Still checking SQLite integrity (${elapsed}s elapsed)" >&2
+            fi
+        done
+
+        integrity_status=0
+        wait "$integrity_pid" || integrity_status=$?
+        if [ "$elapsed" -ge 600 ] && [ "$integrity_status" -ne 0 ]; then
+            integrity_status=124
+        fi
+        if [ "$integrity_status" -ne 0 ] && [ "$integrity_status" -ne 124 ]; then
+            exit 1
+        fi
     fi
 fi
 
@@ -72,7 +84,26 @@ echo "[entrypoint] Fixing file ownership (PUID=${PUID} PGID=${PGID})" >&2
 groupmod -o -g "$PGID" abc
 usermod -o -u "$PUID" abc
 
-chown abc:abc /floppy
+chown abc:abc -- /floppy
+
+if [ -e "$DATA_DIR" ] && ! timeout 600 chown -R abc:abc -- "$DATA_DIR"; then
+    echo "[entrypoint] Cannot set ownership for FLOPPY_DATA_DIR ${DATA_DIR} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+    exit 1
+fi
+
+if [ -z "$DB_HOST" ]; then
+    case "${DB_PARENT}/" in
+        "${DATA_DIR}/"*) ;;
+        *)
+            for path in "$DB_PARENT" "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"; do
+                if [ -e "$path" ] && ! timeout 600 chown abc:abc -- "$path"; then
+                    echo "[entrypoint] Cannot set ownership for FLOPPY_DB_PATH parent ${DB_PARENT} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+                    exit 1
+                fi
+            done
+            ;;
+    esac
+fi
 
 # "logs" holds the rotating file handler every process configures at import time
 # (settings.LOG_FILE). settings.py creates the directory, so whichever process
@@ -82,9 +113,9 @@ chown abc:abc /floppy
 #
 # Bound each recursive chown: a stalled bind mount (e.g. network storage)
 # must degrade to a warning instead of hanging the boot silently (issue #341).
-for dir in db logs staticfiles /var/log/nginx /var/lib/nginx; do
+for dir in "${LOG_DIR:-/floppy/logs}" /floppy/staticfiles /var/log/nginx /var/lib/nginx; do
     echo "[entrypoint] Chowning ${dir}" >&2
-    timeout 600 chown -R abc:abc "$dir" || \
+    timeout 600 chown -R abc:abc -- "$dir" || \
         echo "[entrypoint] WARNING: chown of ${dir} failed or timed out (stalled mount?); continuing" >&2
 done
 

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -1,0 +1,401 @@
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+
+from config import settings as project_settings
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+ENTRYPOINT = ROOT / "entrypoint.sh"
+
+SETTINGS_PROBE = """
+import json
+from config import settings
+
+print(json.dumps({
+    "data_dir": str(settings.FLOPPY_DATA_DIR),
+    "database_name": str(settings.DATABASES["default"]["NAME"]),
+    "database_engine": settings.DATABASES["default"]["ENGINE"],
+}))
+"""
+
+DOCKER_SECRET_PROBE = """
+from pathlib import Path
+from unittest.mock import patch
+
+real_exists = Path.exists
+
+def exists(path):
+    if path == Path("/.dockerenv"):
+        return True
+    return real_exists(path)
+
+with patch.object(Path, "exists", exists):
+    from config import settings
+    print(settings.SECRET_KEY)
+"""
+
+
+class DataPathSettingsTests(SimpleTestCase):
+    def run_settings(self, *, cwd, python_path=SRC, **overrides):
+        environment = {
+            "PATH": os.environ["PATH"],
+            "PYTHONPATH": str(python_path),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "SECRET": "data-path-test-secret",
+            "LOG_DIR": str(Path(cwd) / "logs"),
+        }
+        environment.update(overrides)
+        result = subprocess.run(  # noqa: S603 - test-controlled executable
+            [sys.executable, "-c", SETTINGS_PROBE],
+            cwd=cwd,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def test_defaults_and_empty_overrides_use_the_existing_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for overrides in ({}, {"FLOPPY_DATA_DIR": "", "FLOPPY_DB_PATH": ""}):
+                with self.subTest(overrides=overrides):
+                    settings = self.run_settings(cwd=temp_dir, **overrides)
+
+                self.assertEqual(settings["data_dir"], str(SRC / "db"))
+                self.assertEqual(settings["database_name"], str(SRC / "db/db.sqlite3"))
+
+    def test_data_directory_and_database_file_have_independent_overrides(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            external_database = root / "database" / "floppy.sqlite3"
+
+            data_settings = self.run_settings(
+                cwd=root,
+                FLOPPY_DATA_DIR=str(data_dir),
+            )
+            database_settings = self.run_settings(
+                cwd=root,
+                FLOPPY_DATA_DIR=str(data_dir),
+                FLOPPY_DB_PATH=str(external_database),
+            )
+
+            self.assertEqual(data_settings["data_dir"], str(data_dir))
+            self.assertEqual(
+                data_settings["database_name"],
+                str(data_dir / "db.sqlite3"),
+            )
+            self.assertEqual(database_settings["data_dir"], str(data_dir))
+            self.assertEqual(
+                database_settings["database_name"],
+                str(external_database),
+            )
+            self.assertTrue(external_database.parent.is_dir())
+
+    def test_read_only_source_uses_external_writable_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            read_only_source = root / "source"
+            shutil.copytree(SRC / "config", read_only_source / "config")
+            read_only_directories = [
+                read_only_source,
+                *(path for path in read_only_source.rglob("*") if path.is_dir()),
+            ]
+            for path in read_only_source.rglob("*"):
+                path.chmod(0o555 if path.is_dir() else 0o444)
+            read_only_source.chmod(0o555)
+            data_dir = root / "data"
+            database_path = root / "database" / "db.sqlite3"
+            log_dir = root / "logs"
+            try:
+                settings = self.run_settings(
+                    cwd=root,
+                    python_path=read_only_source,
+                    FLOPPY_DATA_DIR=str(data_dir),
+                    FLOPPY_DB_PATH=str(database_path),
+                    LOG_DIR=str(log_dir),
+                )
+            finally:
+                for directory in read_only_directories:
+                    directory.chmod(0o755)
+
+            self.assertEqual(settings["database_name"], str(database_path))
+            self.assertTrue(database_path.parent.is_dir())
+            self.assertTrue(log_dir.is_dir())
+            self.assertFalse((read_only_source / "db").exists())
+
+    def test_postgresql_does_not_touch_sqlite_override_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            protected = root / "protected"
+            protected.mkdir()
+            protected.chmod(0o555)
+            data_dir = protected / "data"
+            database_path = protected / "database" / "db.sqlite3"
+            try:
+                settings = self.run_settings(
+                    cwd=root,
+                    FLOPPY_DATA_DIR=str(data_dir),
+                    FLOPPY_DB_PATH=str(database_path),
+                    DB_HOST="postgres",
+                    DB_NAME="floppy",
+                    DB_USER="floppy",
+                    DB_PASSWORD="password",
+                    DB_PORT="5432",
+                )
+            finally:
+                protected.chmod(0o755)
+
+            self.assertEqual(
+                settings["database_engine"],
+                "django.db.backends.postgresql",
+            )
+            self.assertFalse(data_dir.exists())
+            self.assertFalse(database_path.parent.exists())
+
+    def test_generated_secret_is_created_and_corrected_to_mode_0600(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / "data" / "secret_key"
+
+            value, created = project_settings._load_or_create_docker_secret(
+                secret_path,
+            )
+            self.assertTrue(created)
+            self.assertEqual(secret_path.read_text(encoding="utf-8"), value)
+            self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+            secret_path.chmod(0o644)
+            same_value, created = project_settings._load_or_create_docker_secret(
+                secret_path,
+            )
+            self.assertFalse(created)
+            self.assertEqual(same_value, value)
+            self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+    def test_generated_secret_uses_the_configured_data_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "configured data"
+            environment = {
+                "PATH": os.environ["PATH"],
+                "PYTHONPATH": str(SRC),
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "FLOPPY_DATA_DIR": str(data_dir),
+                "LOG_DIR": str(root / "logs"),
+            }
+
+            result = subprocess.run(  # noqa: S603 - test-controlled executable
+                [sys.executable, "-c", DOCKER_SECRET_PROBE],
+                cwd=root,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            secret_path = data_dir / "secret_key"
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip().splitlines()[-1],
+                secret_path.read_text(encoding="utf-8"),
+            )
+            self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+    def test_generated_secret_failure_names_the_path_and_next_action(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            blocked_parent = Path(temp_dir) / "not-a-directory"
+            blocked_parent.write_text("keep", encoding="utf-8")
+            secret_path = blocked_parent / "secret_key"
+
+            with self.assertRaisesRegex(
+                ImproperlyConfigured,
+                rf"{secret_path}.*Make FLOPPY_DATA_DIR writable or set SECRET",
+            ):
+                project_settings._load_or_create_docker_secret(secret_path)
+
+            self.assertEqual(blocked_parent.read_text(encoding="utf-8"), "keep")
+
+
+class EntrypointDataPathTests(SimpleTestCase):
+    def run_entrypoint(self, root, **overrides):
+        fake_bin = root / "bin"
+        fake_bin.mkdir(exist_ok=True)
+        log_path = root / "commands.log"
+        log_path.unlink(missing_ok=True)
+        script_path = root / "entrypoint.sh"
+        script_path.write_text(
+            ENTRYPOINT.read_text(encoding="utf-8").replace(
+                "exec /usr/local/bin/supervisord -c /etc/supervisord.conf",
+                "exec supervisord -c /etc/supervisord.conf",
+            ),
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+
+        self.write_command(
+            fake_bin / "python",
+            f"""#!/bin/sh
+if [ "$1" = "-c" ]; then
+    exec {sys.executable} "$@"
+fi
+{{ printf 'python'; printf ' <%s>' "$@"; printf '\n'; }} >> "$FAKE_LOG"
+exit 0
+""",
+        )
+        self.write_command(
+            fake_bin / "timeout",
+            """#!/bin/sh
+shift
+exec "$@"
+""",
+        )
+        self.write_command(
+            fake_bin / "sleep",
+            """#!/bin/sh
+exec /bin/sleep 0.05
+""",
+        )
+        self.write_command(
+            fake_bin / "chown",
+            """#!/bin/sh
+{ printf 'chown'; printf ' <%s>' "$@"; printf '\n'; } >> "$FAKE_LOG"
+last=""
+for argument in "$@"; do last=$argument; done
+if [ -n "$FAIL_CHOWN_PATH" ] && [ "$last" = "$FAIL_CHOWN_PATH" ]; then
+    exit 1
+fi
+""",
+        )
+        for command in ("groupmod", "usermod", "supervisord"):
+            self.write_command(
+                fake_bin / command,
+                f"""#!/bin/sh
+{{ printf '{command}'; printf ' <%s>' "$@"; printf '\n'; }} >> "$FAKE_LOG"
+""",
+            )
+
+        environment = {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "PYTHONPATH": str(SRC),
+            "FAKE_LOG": str(log_path),
+            "SECRET": "entrypoint-test-secret",
+            "LOG_DIR": str(root / "logs"),
+        }
+        environment.update(overrides)
+        result = subprocess.run(  # noqa: S603 - test-controlled script
+            [str(script_path)],
+            cwd=root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        commands = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        return result, commands
+
+    @staticmethod
+    def write_command(path, content):
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    def test_paths_with_spaces_and_leading_dash_remain_single_arguments(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "-managed data"
+            database_parent = root / "external data"
+            database_path = database_parent / "-db.sqlite3"
+            data_dir.mkdir()
+            database_parent.mkdir()
+            database_path.touch()
+            (database_parent / "unrelated").mkdir()
+
+            result, commands = self.run_entrypoint(
+                root,
+                FLOPPY_DATA_DIR="-managed data",
+                FLOPPY_DB_PATH=str(database_path),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(
+                f"Checking SQLite integrity for {database_path}", result.stderr
+            )
+            self.assertIn(f"chown <-R> <abc:abc> <--> <{data_dir}>", commands)
+            self.assertIn(f"chown <abc:abc> <--> <{database_parent}>", commands)
+            self.assertNotIn(str(database_parent / "unrelated"), commands)
+
+    def test_root_and_root_symlink_paths_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            root_link = root / "root-link"
+            root_link.symlink_to("/")
+            safe_data = root / "data"
+            safe_data.mkdir()
+
+            cases = (
+                ({"FLOPPY_DATA_DIR": "/"}, "FLOPPY_DATA_DIR"),
+                ({"FLOPPY_DATA_DIR": str(root_link)}, "FLOPPY_DATA_DIR"),
+                (
+                    {
+                        "FLOPPY_DATA_DIR": str(safe_data),
+                        "FLOPPY_DB_PATH": "/db.sqlite3",
+                    },
+                    "FLOPPY_DB_PATH",
+                ),
+            )
+            for environment, setting_name in cases:
+                with self.subTest(environment=environment):
+                    result, commands = self.run_entrypoint(root, **environment)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(setting_name, result.stderr)
+                self.assertNotIn("supervisord", commands)
+
+    def test_external_database_parent_ownership_failure_stops_startup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            database_parent = root / "database"
+            database_path = database_parent / "db.sqlite3"
+            data_dir.mkdir()
+            database_parent.mkdir()
+            database_path.touch()
+
+            result, commands = self.run_entrypoint(
+                root,
+                FLOPPY_DATA_DIR=str(data_dir),
+                FLOPPY_DB_PATH=str(database_path),
+                FAIL_CHOWN_PATH=str(database_parent),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Cannot set ownership for FLOPPY_DB_PATH parent", result.stderr
+            )
+            self.assertNotIn("supervisord", commands)
+
+    def test_postgresql_does_not_resolve_or_own_the_sqlite_override(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            data_dir.mkdir()
+
+            result, commands = self.run_entrypoint(
+                root,
+                DB_HOST="postgres",
+                FLOPPY_DATA_DIR=str(data_dir),
+                FLOPPY_DB_PATH="/db.sqlite3",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("FLOPPY_DB_PATH", result.stderr)
+            self.assertNotIn("/db.sqlite3", commands)

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -5,7 +5,10 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
@@ -225,6 +228,71 @@ class DataPathSettingsTests(SimpleTestCase):
 
             self.assertEqual(blocked_parent.read_text(encoding="utf-8"), "keep")
 
+    def test_generated_secret_rejects_symlink_without_touching_its_target(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "operator-secret"
+            target.write_text("do-not-read", encoding="utf-8")
+            target.chmod(0o644)
+            secret_path = root / "data" / "secret_key"
+            secret_path.parent.mkdir()
+            secret_path.symlink_to(target)
+
+            with self.assertRaisesRegex(ImproperlyConfigured, rf"{secret_path}"):
+                project_settings._load_or_create_docker_secret(secret_path)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "do-not-read")
+            self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o644)
+
+    def test_generated_secret_rejects_non_regular_and_empty_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for name, create in (
+                ("directory", lambda path: path.mkdir()),
+                ("empty", lambda path: path.touch()),
+            ):
+                with self.subTest(name=name):
+                    secret_path = root / name
+                    create(secret_path)
+                    with self.assertRaisesRegex(
+                        ImproperlyConfigured,
+                        rf"{secret_path}",
+                    ):
+                        project_settings._load_or_create_docker_secret(secret_path)
+
+    def test_generated_secret_is_published_complete_under_concurrency(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = Path(temp_dir) / "data" / "secret_key"
+            barrier = threading.Barrier(2)
+            real_link = os.link
+
+            def synchronized_link(*args, **kwargs):
+                barrier.wait(timeout=5)
+                return real_link(*args, **kwargs)
+
+            with (
+                mock.patch.object(
+                    project_settings.os,
+                    "link",
+                    side_effect=synchronized_link,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                results = list(
+                    executor.map(
+                        project_settings._load_or_create_docker_secret,
+                        (secret_path, secret_path),
+                    )
+                )
+
+            values = {value for value, _created in results}
+            self.assertEqual(len(values), 1)
+            self.assertNotEqual(values, {""})
+            self.assertEqual(
+                sorted(created for _value, created in results), [False, True]
+            )
+            self.assertEqual(secret_path.read_text(encoding="utf-8"), values.pop())
+
 
 class EntrypointDataPathTests(SimpleTestCase):
     def run_entrypoint(self, root, **overrides):
@@ -317,7 +385,18 @@ fi
             data_dir.mkdir()
             database_parent.mkdir()
             database_path.touch()
+            database_wal_path = Path(f"{database_path}-wal")
+            database_wal_path.touch()
+            database_shm_path = Path(f"{database_path}-shm")
+            database_shm_path.touch()
             (database_parent / "unrelated").mkdir()
+            secret_path = data_dir / "secret_key"
+            secret_path.touch()
+            log_dir = root / "logs"
+            log_dir.mkdir()
+            log_file = log_dir / "floppy.log"
+            log_file.touch()
+            (log_dir / "unrelated.log").touch()
 
             result, commands = self.run_entrypoint(
                 root,
@@ -329,25 +408,47 @@ fi
             self.assertIn(
                 f"Checking SQLite integrity for {database_path}", result.stderr
             )
-            self.assertIn(f"chown <-R> <abc:abc> <--> <{data_dir}>", commands)
+            self.assertIn(f"chown <abc:abc> <--> <{data_dir}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{secret_path}>", commands)
             self.assertIn(f"chown <abc:abc> <--> <{database_parent}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{database_path}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{database_wal_path}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{database_shm_path}>", commands)
+            self.assertIn(f"chown <abc:abc> <--> <{log_dir}>", commands)
+            self.assertIn(f"chown <-h> <abc:abc> <--> <{log_file}>", commands)
+            self.assertNotIn(f"chown <-R> <abc:abc> <--> <{data_dir}>", commands)
+            self.assertNotIn(f"chown <-R> <abc:abc> <--> <{log_dir}>", commands)
             self.assertNotIn(str(database_parent / "unrelated"), commands)
+            self.assertNotIn(str(log_dir / "unrelated.log"), commands)
 
-    def test_root_and_root_symlink_paths_are_rejected(self):
+    def test_system_root_and_symlink_paths_are_rejected(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             root_link = root / "root-link"
             root_link.symlink_to("/")
+            system_link = root / "system-link"
+            system_link.symlink_to("/etc")
             safe_data = root / "data"
             safe_data.mkdir()
 
             cases = (
                 ({"FLOPPY_DATA_DIR": "/"}, "FLOPPY_DATA_DIR"),
                 ({"FLOPPY_DATA_DIR": str(root_link)}, "FLOPPY_DATA_DIR"),
+                ({"FLOPPY_DATA_DIR": "/etc"}, "FLOPPY_DATA_DIR"),
+                ({"LOG_DIR": "/"}, "LOG_DIR"),
+                ({"LOG_DIR": str(root_link)}, "LOG_DIR"),
+                ({"LOG_DIR": str(system_link)}, "LOG_DIR"),
                 (
                     {
                         "FLOPPY_DATA_DIR": str(safe_data),
                         "FLOPPY_DB_PATH": "/db.sqlite3",
+                    },
+                    "FLOPPY_DB_PATH",
+                ),
+                (
+                    {
+                        "FLOPPY_DATA_DIR": str(safe_data),
+                        "FLOPPY_DB_PATH": "/etc/db.sqlite3",
                     },
                     "FLOPPY_DB_PATH",
                 ),
@@ -359,6 +460,18 @@ fi
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(setting_name, result.stderr)
                 self.assertNotIn("supervisord", commands)
+
+    def test_dedicated_directory_below_system_root_is_allowed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result, commands = self.run_entrypoint(
+                Path(temp_dir),
+                FLOPPY_DATA_DIR="/var/lib/floppy",
+                FLOPPY_DB_PATH="/var/lib/floppy/db.sqlite3",
+                LOG_DIR="/var/log/floppy",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("supervisord", commands)
 
     def test_external_database_parent_ownership_failure_stops_startup(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -406,7 +406,8 @@ fi
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn(
-                f"Checking SQLite integrity for {database_path}", result.stderr
+                f"Checking SQLite storage and relationships for {database_path}",
+                result.stderr,
             )
             self.assertIn(f"chown <abc:abc> <--> <{data_dir}>", commands)
             self.assertIn(f"chown <-h> <abc:abc> <--> <{secret_path}>", commands)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import json
 import os
+import secrets
 import subprocess
 import sys
 import warnings
@@ -21,6 +22,7 @@ from decouple import (
     undefined,
 )
 from django.core.cache import CacheKeyWarning
+from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.signals import connection_created
 
 from config.runtime_profile import (
@@ -47,6 +49,14 @@ REDIS_PREFIX = config("REDIS_PREFIX", default=None)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+_data_dir_override = config("FLOPPY_DATA_DIR", default=None)
+FLOPPY_DATA_DIR = Path(_data_dir_override) if _data_dir_override else BASE_DIR / "db"
+_database_path_override = config("FLOPPY_DB_PATH", default=None)
+FLOPPY_DB_PATH = (
+    Path(_database_path_override)
+    if _database_path_override
+    else FLOPPY_DATA_DIR / "db.sqlite3"
+)
 DOCKER_SECRETS_DIR = Path("/run/secrets")
 
 
@@ -79,6 +89,37 @@ def secret(key, default=undefined, **kwargs):
     return secret_value
 
 
+def _load_or_create_docker_secret(path):
+    try:
+        if path.exists():
+            path.chmod(0o600)
+            return path.read_text(encoding="utf-8").strip(), False
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        value = secrets.token_urlsafe(50)
+        try:
+            secret_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            path.chmod(0o600)
+            return path.read_text(encoding="utf-8").strip(), False
+
+        try:
+            with os.fdopen(secret_fd, "w", encoding="utf-8") as secret_file:
+                secret_file.write(value)
+            path.chmod(0o600)
+        except OSError:
+            path.unlink(missing_ok=True)
+            raise
+        else:
+            return value, True
+    except (OSError, UnicodeError) as err:
+        msg = (
+            f"Cannot create or read the generated secret key at {path}. "
+            "Make FLOPPY_DATA_DIR writable or set SECRET."
+        )
+        raise ImproperlyConfigured(msg) from err
+
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/stable/howto/deployment/checklist/
 
@@ -96,16 +137,9 @@ if not SECRET_KEY:
     if Path("/.dockerenv").exists():
         # Docker container: auto-generate and persist to the db volume so the
         # key survives container restarts without user intervention.
-        import secrets as _secrets
-        import warnings
-
-        _secret_file = BASE_DIR / "db" / "secret_key"
-        if _secret_file.exists():
-            SECRET_KEY = _secret_file.read_text().strip()
-        else:
-            SECRET_KEY = _secrets.token_urlsafe(50)
-            _secret_file.parent.mkdir(parents=True, exist_ok=True)
-            _secret_file.write_text(SECRET_KEY)
+        _secret_file = FLOPPY_DATA_DIR / "secret_key"
+        SECRET_KEY, secret_created = _load_or_create_docker_secret(_secret_file)
+        if secret_created:
             warnings.warn(
                 "SECRET env var is not set. A random key has been generated and "
                 f"saved to {_secret_file}. For production, set SECRET explicitly "
@@ -113,8 +147,6 @@ if not SECRET_KEY:
                 stacklevel=2,
             )
     else:
-        from django.core.exceptions import ImproperlyConfigured
-
         msg = (
             "SECRET env var is not set. To fix, run:\n\n"
             '  python -c "'
@@ -309,9 +341,6 @@ WSGI_APPLICATION = "config.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/stable/ref/settings/#databases
 
-# create db folder if it doesn't exist
-Path(BASE_DIR / "db").mkdir(parents=True, exist_ok=True)
-
 DB_HOST = config("DB_HOST", default=None)
 USING_SQLITE_DATABASE = not bool(DB_HOST)
 
@@ -361,6 +390,7 @@ if DB_HOST:
         DATABASES["default"]["OPTIONS"]["sslcertmode"] = sslcertmode
 
 else:
+    FLOPPY_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     SQLITE_BUSY_TIMEOUT_SECONDS = config(
         "SQLITE_BUSY_TIMEOUT_SECONDS",
         default=30,
@@ -372,7 +402,7 @@ else:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db" / "db.sqlite3",
+            "NAME": FLOPPY_DB_PATH,
             "OPTIONS": {
                 "timeout": SQLITE_BUSY_TIMEOUT_SECONDS,
             },

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,8 +5,10 @@ import hashlib
 import json
 import os
 import secrets
+import stat
 import subprocess
 import sys
+import tempfile
 import warnings
 import zoneinfo
 from pathlib import Path
@@ -89,27 +91,51 @@ def secret(key, default=undefined, **kwargs):
     return secret_value
 
 
-def _load_or_create_docker_secret(path):
+def _read_docker_secret(path):
+    secret_fd = os.open(
+        path,
+        os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+    )
     try:
-        if path.exists():
-            path.chmod(0o600)
-            return path.read_text(encoding="utf-8").strip(), False
+        if not stat.S_ISREG(os.fstat(secret_fd).st_mode):
+            raise OSError(path)
+        os.fchmod(secret_fd, 0o600)
+        with os.fdopen(secret_fd, "r", encoding="utf-8") as secret_file:
+            secret_fd = None
+            value = secret_file.read().strip()
+        if not value:
+            raise OSError(path)
+        return value
+    finally:
+        if secret_fd is not None:
+            os.close(secret_fd)
 
+
+def _load_or_create_docker_secret(path):
+    temp_fd = None
+    temp_path = None
+    try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        value = secrets.token_urlsafe(50)
         try:
-            secret_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileExistsError:
-            path.chmod(0o600)
-            return path.read_text(encoding="utf-8").strip(), False
+            return _read_docker_secret(path), False
+        except FileNotFoundError:
+            pass
+
+        value = secrets.token_urlsafe(50)
+        temp_fd, temp_path = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            dir=path.parent,
+        )
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as secret_file:
+            temp_fd = None
+            secret_file.write(value)
+            secret_file.flush()
+            os.fsync(secret_file.fileno())
 
         try:
-            with os.fdopen(secret_fd, "w", encoding="utf-8") as secret_file:
-                secret_file.write(value)
-            path.chmod(0o600)
-        except OSError:
-            path.unlink(missing_ok=True)
-            raise
+            os.link(temp_path, path, follow_symlinks=False)
+        except FileExistsError:
+            return _read_docker_secret(path), False
         else:
             return value, True
     except (OSError, UnicodeError) as err:
@@ -118,6 +144,11 @@ def _load_or_create_docker_secret(path):
             "Make FLOPPY_DATA_DIR writable or set SECRET."
         )
         raise ImproperlyConfigured(msg) from err
+    finally:
+        if temp_fd is not None:
+            os.close(temp_fd)
+        if temp_path is not None:
+            Path(temp_path).unlink(missing_ok=True)
 
 
 # Quick-start development settings - unsuitable for production

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -11,6 +11,10 @@ _RELATIONSHIP_HINT = (
     "[entrypoint] Back up the SQLite file, then inspect these relationship "
     "errors before you restart"
 )
+_BUSY_HINT = (
+    "[entrypoint] The SQLite database is busy. Stop other Floppy processes, "
+    "then restart"
+)
 _ALBUM_ARTIST_TABLE = "app_albumartist"
 
 
@@ -25,11 +29,10 @@ def _check_foreign_keys(conn: sqlite3.Connection) -> None:
         row_ids = {violation[1] for violation in violations}
         if None not in row_ids:
             row_ids = sorted(row_ids)
-            placeholders = ", ".join("?" for _ in row_ids)
-            conn.execute(
+            conn.executemany(
                 f"DELETE FROM {_ALBUM_ARTIST_TABLE} "  # noqa: S608  # fixed table name
-                f"WHERE rowid IN ({placeholders})",
-                row_ids,
+                "WHERE rowid = ?",
+                ((row_id,) for row_id in row_ids),
             )
             violations = list(conn.execute("PRAGMA foreign_key_check").fetchall())
             if not violations:
@@ -71,7 +74,13 @@ def check_database_integrity(db_path: str) -> None:
         _check_foreign_keys(conn)
     except sqlite3.DatabaseError as e:
         print(f"[entrypoint] Database integrity check failed: {e}", file=sys.stderr)  # noqa: T201
-        print(_CORRUPTION_HINT, file=sys.stderr)  # noqa: T201
+        hint = (
+            _BUSY_HINT
+            if getattr(e, "sqlite_errorcode", None)
+            in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED}
+            else _CORRUPTION_HINT
+        )
+        print(hint, file=sys.stderr)  # noqa: T201
         sys.exit(1)
     finally:
         if conn is not None:

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -7,14 +7,61 @@ _CORRUPTION_HINT = (
     "[entrypoint] The SQLite file may be corrupt (see README: SQLite "
     "network filesystem caveat)"
 )
+_ALBUM_ARTIST_TABLE = "app_albumartist"
+
+
+def _check_foreign_keys(conn: sqlite3.Connection) -> None:
+    violations = list(conn.execute("PRAGMA foreign_key_check").fetchall())
+    if not violations:
+        return
+
+    if {violation[0] for violation in violations} == {_ALBUM_ARTIST_TABLE}:
+        row_ids = {violation[1] for violation in violations}
+        if None not in row_ids:
+            row_ids = sorted(row_ids)
+            placeholders = ", ".join("?" for _ in row_ids)
+            with conn:
+                conn.execute(
+                    f"DELETE FROM {_ALBUM_ARTIST_TABLE} "  # noqa: S608  # fixed table name
+                    f"WHERE rowid IN ({placeholders})",
+                    row_ids,
+                )
+            print(  # noqa: T201
+                f"[entrypoint] Removed {len(row_ids)} orphaned album artist "
+                "credit row(s) before migrations",
+                file=sys.stderr,
+            )
+            violations = list(conn.execute("PRAGMA foreign_key_check").fetchall())
+            if not violations:
+                return
+
+    for table, row_id, parent, _foreign_key_id in violations[:10]:
+        print(  # noqa: T201
+            "[entrypoint] Database foreign key check failed: "
+            f"table={table!r}, row={row_id!r}, parent={parent!r}",
+            file=sys.stderr,
+        )
+    print(_CORRUPTION_HINT, file=sys.stderr)  # noqa: T201
+    sys.exit(1)
 
 
 def check_database_integrity(db_path: str) -> None:
-    """Run PRAGMA quick_check and exit(1) if the database is not OK."""
+    """Check SQLite storage and foreign keys before migrations."""
     conn = None
     try:
         conn = sqlite3.connect(db_path)
         result = conn.execute("PRAGMA quick_check").fetchone()
+        status = result[0] if result else None
+        if status != "ok":
+            print(  # noqa: T201
+                "[entrypoint] Database integrity check failed: "
+                f"quick_check returned {status!r}",
+                file=sys.stderr,
+            )
+            print(_CORRUPTION_HINT, file=sys.stderr)  # noqa: T201
+            sys.exit(1)
+
+        _check_foreign_keys(conn)
     except sqlite3.DatabaseError as e:
         print(f"[entrypoint] Database integrity check failed: {e}", file=sys.stderr)  # noqa: T201
         print(_CORRUPTION_HINT, file=sys.stderr)  # noqa: T201
@@ -22,12 +69,3 @@ def check_database_integrity(db_path: str) -> None:
     finally:
         if conn is not None:
             conn.close()
-
-    status = result[0] if result else None
-    if status != "ok":
-        print(  # noqa: T201
-            f"[entrypoint] Database integrity check failed: quick_check returned {status!r}",
-            file=sys.stderr,
-        )
-        print(_CORRUPTION_HINT, file=sys.stderr)  # noqa: T201
-        sys.exit(1)

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -7,12 +7,18 @@ _CORRUPTION_HINT = (
     "[entrypoint] The SQLite file may be corrupt (see README: SQLite "
     "network filesystem caveat)"
 )
+_RELATIONSHIP_HINT = (
+    "[entrypoint] Back up the SQLite file, then inspect these relationship "
+    "errors before you restart"
+)
 _ALBUM_ARTIST_TABLE = "app_albumartist"
 
 
 def _check_foreign_keys(conn: sqlite3.Connection) -> None:
+    conn.execute("BEGIN IMMEDIATE")
     violations = list(conn.execute("PRAGMA foreign_key_check").fetchall())
     if not violations:
+        conn.commit()
         return
 
     if {violation[0] for violation in violations} == {_ALBUM_ARTIST_TABLE}:
@@ -20,28 +26,29 @@ def _check_foreign_keys(conn: sqlite3.Connection) -> None:
         if None not in row_ids:
             row_ids = sorted(row_ids)
             placeholders = ", ".join("?" for _ in row_ids)
-            with conn:
-                conn.execute(
-                    f"DELETE FROM {_ALBUM_ARTIST_TABLE} "  # noqa: S608  # fixed table name
-                    f"WHERE rowid IN ({placeholders})",
-                    row_ids,
-                )
-            print(  # noqa: T201
-                f"[entrypoint] Removed {len(row_ids)} orphaned album artist "
-                "credit row(s) before migrations",
-                file=sys.stderr,
+            conn.execute(
+                f"DELETE FROM {_ALBUM_ARTIST_TABLE} "  # noqa: S608  # fixed table name
+                f"WHERE rowid IN ({placeholders})",
+                row_ids,
             )
             violations = list(conn.execute("PRAGMA foreign_key_check").fetchall())
             if not violations:
+                conn.commit()
+                print(  # noqa: T201
+                    f"[entrypoint] Removed {len(row_ids)} orphaned album artist "
+                    "credit row(s) before migrations",
+                    file=sys.stderr,
+                )
                 return
 
-    for table, row_id, parent, _foreign_key_id in violations[:10]:
+    conn.rollback()
+    for table, row_id, parent, _foreign_key_id in violations:
         print(  # noqa: T201
             "[entrypoint] Database foreign key check failed: "
             f"table={table!r}, row={row_id!r}, parent={parent!r}",
             file=sys.stderr,
         )
-    print(_CORRUPTION_HINT, file=sys.stderr)  # noqa: T201
+    print(_RELATIONSHIP_HINT, file=sys.stderr)  # noqa: T201
     sys.exit(1)
 
 

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -1,5 +1,6 @@
 """Tests for the SQLite startup integrity guard (issue #593)."""
 
+import io
 import sqlite3
 import tempfile
 from pathlib import Path
@@ -8,6 +9,8 @@ from unittest import mock
 from django.test import SimpleTestCase
 
 from config.sqlite_integrity import check_database_integrity
+
+ENTRYPOINT = Path(__file__).resolve().parents[3] / "entrypoint.sh"
 
 
 class SqliteIntegrityTests(SimpleTestCase):
@@ -60,8 +63,11 @@ class SqliteIntegrityTests(SimpleTestCase):
                     parent_id INTEGER NOT NULL REFERENCES parent(id)
                 );
                 INSERT INTO parent VALUES (1);
-                INSERT INTO child VALUES (1, 1);
                 """
+            )
+            conn.executemany(
+                "INSERT INTO child VALUES (?, 1)",
+                ((row_id,) for row_id in range(1, 13)),
             )
             conn.commit()
             conn.execute("PRAGMA foreign_keys=OFF")
@@ -71,16 +77,66 @@ class SqliteIntegrityTests(SimpleTestCase):
 
             with (
                 self.assertRaises(SystemExit) as ctx,
-                mock.patch("sys.stderr"),
+                mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
                 check_database_integrity(db_path)
 
             self.assertEqual(ctx.exception.code, 1)
+            output = stderr.getvalue()
+            self.assertEqual(output.count("foreign key check failed"), 12)
+            self.assertIn("table='child', row=12, parent='parent'", output)
+            self.assertIn("Back up the SQLite file", output)
             conn = sqlite3.connect(db_path)
             self.assertEqual(
-                conn.execute("SELECT COUNT(*) FROM child").fetchone()[0], 1
+                conn.execute("SELECT COUNT(*) FROM child").fetchone()[0], 12
             )
             conn.close()
+
+    def test_repair_holds_write_lock_from_check_through_delete(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            setup = sqlite3.connect(db_path)
+            setup.executescript(
+                """
+                CREATE TABLE app_album (id INTEGER PRIMARY KEY);
+                CREATE TABLE app_artist (id INTEGER PRIMARY KEY);
+                CREATE TABLE app_albumartist (
+                    id INTEGER PRIMARY KEY,
+                    album_id INTEGER NOT NULL REFERENCES app_album(id),
+                    artist_id INTEGER NOT NULL REFERENCES app_artist(id)
+                );
+                INSERT INTO app_artist VALUES (12);
+                INSERT INTO app_albumartist VALUES (1, 345, 12);
+                """
+            )
+            setup.commit()
+            setup.close()
+
+            check_conn = sqlite3.connect(db_path)
+            competing_conn = sqlite3.connect(db_path, timeout=0)
+            competing_result = []
+
+            def attempt_competing_repair(statement):
+                if not statement.startswith("DELETE FROM app_albumartist"):
+                    return
+                try:
+                    competing_conn.execute("INSERT INTO app_album VALUES (345)")
+                    competing_conn.commit()
+                except sqlite3.OperationalError as error:
+                    competing_result.append(str(error))
+
+            check_conn.set_trace_callback(attempt_competing_repair)
+            with (
+                mock.patch(
+                    "config.sqlite_integrity.sqlite3.connect",
+                    return_value=check_conn,
+                ),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_integrity(db_path)
+
+            self.assertEqual(competing_result, ["database is locked"])
+            competing_conn.close()
 
     def test_healthy_database_passes(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -140,3 +196,13 @@ class SqliteIntegrityTests(SimpleTestCase):
             check_database_integrity("irrelevant.sqlite3")
 
         fake_conn.close.assert_called_once()
+
+    def test_entrypoint_stops_when_integrity_check_times_out(self):
+        script = ENTRYPOINT.read_text()
+        timeout = "integrity_timed_out=1"
+        stop = (
+            'if [ "$integrity_timed_out" -eq 1 ] || [ "$integrity_status" -ne 0 ]; then'
+        )
+
+        self.assertLess(script.index(timeout), script.index(stop))
+        self.assertIn("exit 1", script[script.index(stop) : script.index(stop) + 150])

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -11,6 +11,77 @@ from config.sqlite_integrity import check_database_integrity
 
 
 class SqliteIntegrityTests(SimpleTestCase):
+    def test_orphaned_album_artist_credit_is_removed(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            conn = sqlite3.connect(db_path)
+            conn.executescript(
+                """
+                PRAGMA foreign_keys=ON;
+                CREATE TABLE app_album (id INTEGER PRIMARY KEY);
+                CREATE TABLE app_artist (id INTEGER PRIMARY KEY);
+                CREATE TABLE app_albumartist (
+                    id INTEGER PRIMARY KEY,
+                    album_id INTEGER NOT NULL REFERENCES app_album(id),
+                    artist_id INTEGER NOT NULL REFERENCES app_artist(id)
+                );
+                INSERT INTO app_album VALUES (345);
+                INSERT INTO app_artist VALUES (12);
+                INSERT INTO app_albumartist VALUES (1, 345, 12);
+                """
+            )
+            conn.commit()
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute("DELETE FROM app_album WHERE id = 345")
+            conn.commit()
+            conn.close()
+
+            with mock.patch("sys.stderr"):
+                check_database_integrity(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0],
+                0,
+            )
+            self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
+            conn.close()
+
+    def test_unknown_foreign_key_violation_stops_startup(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            conn = sqlite3.connect(db_path)
+            conn.executescript(
+                """
+                PRAGMA foreign_keys=ON;
+                CREATE TABLE parent (id INTEGER PRIMARY KEY);
+                CREATE TABLE child (
+                    id INTEGER PRIMARY KEY,
+                    parent_id INTEGER NOT NULL REFERENCES parent(id)
+                );
+                INSERT INTO parent VALUES (1);
+                INSERT INTO child VALUES (1, 1);
+                """
+            )
+            conn.commit()
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute("DELETE FROM parent WHERE id = 1")
+            conn.commit()
+            conn.close()
+
+            with (
+                self.assertRaises(SystemExit) as ctx,
+                mock.patch("sys.stderr"),
+            ):
+                check_database_integrity(db_path)
+
+            self.assertEqual(ctx.exception.code, 1)
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM child").fetchone()[0], 1
+            )
+            conn.close()
+
     def test_healthy_database_passes(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = str(Path(tmp_dir) / "db.sqlite3")

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -138,6 +138,62 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(competing_result, ["database is locked"])
             competing_conn.close()
 
+    def test_repair_stays_below_sqlite_variable_limit(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            setup = sqlite3.connect(db_path)
+            setup.executescript(
+                """
+                CREATE TABLE app_album (id INTEGER PRIMARY KEY);
+                CREATE TABLE app_artist (id INTEGER PRIMARY KEY);
+                CREATE TABLE app_albumartist (
+                    id INTEGER PRIMARY KEY,
+                    album_id INTEGER NOT NULL REFERENCES app_album(id),
+                    artist_id INTEGER NOT NULL REFERENCES app_artist(id)
+                );
+                INSERT INTO app_artist VALUES (12);
+                """
+            )
+            setup.executemany(
+                "INSERT INTO app_albumartist VALUES (?, ?, 12)",
+                ((row_id, row_id) for row_id in range(1, 7)),
+            )
+            setup.commit()
+            setup.close()
+
+            check_conn = sqlite3.connect(db_path)
+            check_conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 5)
+            with (
+                mock.patch(
+                    "config.sqlite_integrity.sqlite3.connect",
+                    return_value=check_conn,
+                ),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_integrity(db_path)
+
+            verify = sqlite3.connect(db_path)
+            self.assertEqual(
+                verify.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0],
+                0,
+            )
+            verify.close()
+
+    def test_busy_database_reports_lock_action(self):
+        error = sqlite3.OperationalError("database is locked")
+        error.sqlite_errorcode = sqlite3.SQLITE_BUSY
+
+        with (
+            mock.patch("sqlite3.connect", side_effect=error),
+            self.assertRaises(SystemExit) as ctx,
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            check_database_integrity("irrelevant.sqlite3")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Stop other Floppy processes", stderr.getvalue())
+        self.assertNotIn("corrupt", stderr.getvalue())
+
     def test_healthy_database_passes(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = str(Path(tmp_dir) / "db.sqlite3")


### PR DESCRIPTION
## Summary

This change resolves the SQLite migration loop reported in #731. Floppy now
checks relationship integrity before it runs migrations.

If every relationship error is an orphaned `app_albumartist` row, Floppy
removes only those unusable credit rows, checks the database again, and then
runs migrations. Any other relationship error stops startup without changing
data and lists the table, row, and missing parent.

This pull request used replacement PR #734 because the startup check must use
the configured SQLite file. Both changes are now on `latest`. The merged
history preserves the configured path contract and the recovery rules.

## Post-mortem

### Impact

A container redeployment could enter the migration retry loop. The database
file remained readable, but each migration attempt ended with Django's foreign
key validation error. The application did not start.

### Root cause

Startup ran `PRAGMA quick_check`. That command checks SQLite file and page
structure. It does not check relationships. An `app_albumartist` row could
reference an album or artist that no longer existed while `quick_check` still
returned `ok`.

Django checks all SQLite foreign keys when a schema edit finishes. Migration
`app.0122_album_implied_genres` therefore exposed the old orphan and failed.
Retrying the migration could not change the invalid data, so every retry failed
in the same place.

### Why the fix is narrow

An album artist credit has no useful meaning when its album or artist is gone.
Floppy repairs only that known conflict. It does not guess how to repair other
tables. Unsupported conflicts remain present and stop startup with complete
evidence.

## Changes

- Run `PRAGMA foreign_key_check` after `PRAGMA quick_check`.
- Take an immediate SQLite write lock before the relationship scan.
- Keep the lock through deletion, verification, and commit.
- Remove known orphaned album artist credits with one bound value per
  statement, so SQLite's parameter limit cannot block a large repair.
- Roll back if any conflict remains.
- Stop startup when the integrity check reaches its 600-second bound.
- Distinguish a busy database from file corruption and give a direct action.
- Report every unsupported table, row, and parent conflict.
- Run the checker against the SQLite file selected by the #595 path contract.
- Document automatic repair, manual conflict resolution, backups, and lock
  handling.

## Conflict resolution and data safety

The write transaction prevents another process from making an orphan valid
between the scan and delete. A competing writer waits or receives a busy
result; Floppy never deletes a row from a stale scan.

If the database is busy, startup tells the operator to stop other Floppy
processes and restart. It does not call a healthy database corrupt. For an
unsupported relationship error, the README tells the operator to stop Floppy,
back up the database and its WAL files, inspect the listed rows, restore or
correct them, and verify the next startup. It warns against deleting database
or lock files.

## Compatibility and future launchers

PostgreSQL startup is unchanged. Healthy SQLite databases continue without a
repair. The checker receives the selected SQLite file, so a native launcher can
choose its application-data path without bypassing recovery.

## Upstream check

Yamtrack `dev` at `f97b0639e24c08a5b1de3b9234b8b81cf6abea93` has no
`AlbumArtist` model and no `foreign_key_check` startup recovery. There is no
equivalent upstream fix to port.

## Verification

- Reproduced the reported state: `quick_check` returned `ok`,
  `foreign_key_check` found the orphan, and `app.0122` failed.
- After repair, `foreign_key_check` returned no rows and `app.0122` completed.
- A 100,000-row repair completed with no remaining rows or conflicts.
- A competing writer could not change a parent during repair.
- Mixed known and unsupported conflicts stopped startup and preserved both
  rows.
- A busy database stopped with the correct operator action.
- 26 combined path and recovery checks plus 12 subtests passed.
- Ruff, format checks, `sh -n entrypoint.sh`, migration hygiene, and
  `git diff --check` passed.
- Browser QA covered nine routes, desktop and 375 by 812 mobile layouts, health
  and service-worker endpoints, and the browser console. It found no
  branch-related defect.
- Hosted `test (3.12)` passed in 15m35s. Hosted lint and workflow guards passed.
- Final independent stacked review: READY; no critical or important findings.
- The reviewer noted one non-blocking test-strength gap: the committed timeout
  test inspects shell text. An executed shell harness also confirmed that the
  timeout stops startup with exit status 1.

Browser screenshots are part of the local QA record. This backend change does
not alter the rendered interface. The visual pass still checked clear grouping,
readable actions, responsive layout, keyboard-visible controls, and calm empty
states. One pre-existing Discover accessible-name issue remains outside this
database change.

## Relationships

Fixes #731

Delivered with #734.

Related to #593 and #595

## AI Assistance

The `gpt-5` Codex agent investigated, implemented, tested, and documented this
change. Independent review agents checked the final stacked commits.

## Human Review

- [ ] Pending human review.
- [x] Completed by the repository maintainer through merge.

## Gstack QA

- [ ] Pending `/gstack-qa`.
- [x] Completed. Health score: 99/100. Nine routes, desktop and mobile layouts,
  the service worker, the health endpoint, and the browser console passed. One
  pre-existing Discover accessible-name issue remains outside this change.

## Migration Sync Gate

Not applicable. This pull request does not synchronize `upstream` to `latest`.
