### PR TITLE
fix(tv): persist trustworthy episode release dates

### DIFF
--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -330,8 +330,6 @@ def season_details(
         and source != Sources.MANUAL.value
         and season_metadata.get("episodes")
     ):
-        from datetime import UTC, datetime
-
         raw_episodes = season_metadata["episodes"]
         current_datetime = timezone.now()
         episodes_to_update = []
@@ -365,30 +363,20 @@ def season_details(
             # (that's the only other code path that extracts it), so an
             # episode created here from a page view stays permanently NULL
             # even once the provider does have its air date.
-            #
-            # Anchored to UTC, not the server's configured TIME_ZONE: a
-            # provider air date is a calendar date with no real-world
-            # timezone attached, and interpreting it as server-local
-            # midnight shifted it by the server's UTC offset (e.g. +2h under
-            # Europe/Berlin in summer), which can flip the calendar date a
-            # user sees depending on deployment timezone.
-            air_date_dt = None
             raw_air_date = episode.get("air_date")
-            if raw_air_date:
-                try:
-                    if isinstance(raw_air_date, str):
-                        date_obj = datetime.strptime(raw_air_date, "%Y-%m-%d")  # noqa: DTZ007  # date-only value; no timezone applies
-                        air_date_dt = date_obj.replace(tzinfo=UTC)
-                    elif hasattr(raw_air_date, "year"):
-                        air_date_dt = (
-                            raw_air_date
-                            if timezone.is_aware(raw_air_date)
-                            else raw_air_date.replace(tzinfo=UTC)
-                        )
-                except (ValueError, TypeError):
-                    air_date_dt = None
-                if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
-                    air_date_dt = None
+            # Episode provider dates are calendar dates, even when a provider
+            # has already wrapped one in a datetime. Persist UTC midnight so a
+            # shared Item does not depend on the timezone of the first viewer.
+            normalized_air_date = (
+                raw_air_date.date().isoformat()
+                if isinstance(raw_air_date, timezone.datetime)
+                else raw_air_date
+            )
+            air_date_dt = helpers.extract_release_datetime(
+                {"release_date": normalized_air_date},
+            )
+            if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
+                air_date_dt = None
 
             parsed_episodes.append((episode, episode_number, air_date_dt))
             episode_numbers.append(episode_number)

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_not_required
+from django.db.models import Case, DateTimeField, Value, When
 from django.shortcuts import render
 from django.utils import timezone
 from django.views.decorators.http import require_GET
@@ -335,6 +336,7 @@ def season_details(
         raw_episodes = season_metadata["episodes"]
         current_datetime = timezone.now()
         episodes_to_update = []
+        release_datetime_updates = []
         episode_library_media_type = (
             parent_media_type
             if parent_media_type == MediaTypes.ANIME.value
@@ -487,9 +489,9 @@ def season_details(
                 episode_item.provider_rating = score
                 episode_item.provider_rating_count = score_count
             if release_datetime_changed:
-                episode_item.release_datetime = air_date_dt
+                release_datetime_updates.append((episode_item.pk, air_date_dt))
 
-            if runtime_changed or rating_changed or release_datetime_changed:
+            if runtime_changed or rating_changed:
                 episodes_to_update.append(episode_item)
 
         if episodes_to_update:
@@ -499,10 +501,28 @@ def season_details(
                     "runtime_minutes",
                     "provider_rating",
                     "provider_rating_count",
-                    "release_datetime",
                 ],
                 batch_size=100,
             )
+
+        for batch_start in range(0, len(release_datetime_updates), 100):
+            release_datetime_batch = release_datetime_updates[
+                batch_start : batch_start + 100
+            ]
+            Item.objects.filter(
+                pk__in=[item_id for item_id, _ in release_datetime_batch],
+                release_datetime__isnull=True,
+            ).update(
+                release_datetime=Case(
+                    *(
+                        When(pk=item_id, then=Value(release_datetime))
+                        for item_id, release_datetime in release_datetime_batch
+                    ),
+                    output_field=DateTimeField(),
+                ),
+            )
+
+        if episodes_to_update or release_datetime_updates:
             # Invalidate time_left + media_list cache for all users
             from app.cache_utils import (
                 clear_media_list_cache_for_user,

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_not_required
@@ -54,6 +55,7 @@ from lists.models import CustomList
 logger = logging.getLogger(__name__)
 
 MIN_PLAUSIBLE_YEAR = 1900
+UNKNOWN_RELEASE_YEAR = 9999
 
 
 @login_not_required
@@ -369,13 +371,16 @@ def season_details(
             # shared Item does not depend on the timezone of the first viewer.
             normalized_air_date = (
                 raw_air_date.date().isoformat()
-                if isinstance(raw_air_date, timezone.datetime)
+                if isinstance(raw_air_date, datetime)
                 else raw_air_date
             )
             air_date_dt = helpers.extract_release_datetime(
                 {"release_date": normalized_air_date},
             )
-            if air_date_dt and air_date_dt.year <= MIN_PLAUSIBLE_YEAR:
+            if air_date_dt and (
+                air_date_dt.year <= MIN_PLAUSIBLE_YEAR
+                or air_date_dt.year == UNKNOWN_RELEASE_YEAR
+            ):
                 air_date_dt = None
 
             parsed_episodes.append((episode, episode_number, air_date_dt))

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5440,7 +5440,7 @@ class MediaDetailsViewTests(TestCase):
         """
         tv_item = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.TV.value,
             title="Test TV Show",
             image="http://example.com/show.jpg",
@@ -5452,7 +5452,7 @@ class MediaDetailsViewTests(TestCase):
         )
         season_item = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.SEASON.value,
             title="Test TV Show",
             image="http://example.com/show.jpg",
@@ -5469,7 +5469,7 @@ class MediaDetailsViewTests(TestCase):
         # clobbered by a differing value from the live payload.
         already_dated_episode = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.EPISODE.value,
             title="No Shortcuts",
             image=settings.IMG_NONE,
@@ -5481,7 +5481,7 @@ class MediaDetailsViewTests(TestCase):
         # air date was known) but was never given a release_datetime.
         stale_episode = Item.objects.create(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.EPISODE.value,
             title="Test TV Show",
             image=settings.IMG_NONE,
@@ -5493,7 +5493,7 @@ class MediaDetailsViewTests(TestCase):
         mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
             "title": "Test TV Show",
             "media_id": "1668",
-            "source": Sources.TMDB.value,
+            "source": Sources.TVDB.value,
             "media_type": MediaTypes.TV.value,
             "image": "http://example.com/image.jpg",
             "season/1": {
@@ -5513,7 +5513,14 @@ class MediaDetailsViewTests(TestCase):
                     {
                         "episode_number": 2,
                         "name": "Episode 2",
-                        "air_date": "2023-01-08",
+                        # TVDB normalizes its date-only value to an aware
+                        # datetime before this view receives it.
+                        "air_date": datetime(
+                            2023,
+                            1,
+                            8,
+                            tzinfo=timezone.get_fixed_timezone(840),
+                        ),
                         "runtime": 42,
                     },
                     {
@@ -5522,23 +5529,33 @@ class MediaDetailsViewTests(TestCase):
                         "air_date": "2023-01-15",
                         "runtime": 44,
                     },
+                    {
+                        "episode_number": 4,
+                        "name": "Episode 4",
+                        "air_date": "0001-01-01",
+                        "runtime": 45,
+                    },
                 ],
             },
         }
         mock_process_episodes.return_value = []
 
-        response = self.client.get(
-            reverse(
-                "season_details",
-                kwargs={
-                    "source": Sources.TMDB.value,
-                    "media_id": "1668",
-                    "title": "test-tv-show",
-                    "season_number": 1,
-                },
-            ),
-            {"fragment": "secondary"},
-        )
+        with (
+            patch("app.providers.trakt.is_configured", return_value=False),
+            timezone.override("Pacific/Kiritimati"),
+        ):
+            response = self.client.get(
+                reverse(
+                    "season_details",
+                    kwargs={
+                        "source": Sources.TVDB.value,
+                        "media_id": "1668",
+                        "title": "test-tv-show",
+                        "season_number": 1,
+                    },
+                ),
+                {"fragment": "secondary"},
+            )
 
         self.assertEqual(response.status_code, 200)
 
@@ -5552,21 +5569,31 @@ class MediaDetailsViewTests(TestCase):
         stale_episode.refresh_from_db()
         self.assertEqual(
             stale_episode.release_datetime,
-            timezone.make_aware(datetime(2023, 1, 8)),
+            datetime(2023, 1, 8, tzinfo=UTC),
             "a NULL release_datetime must self-heal from the live payload",
         )
 
         new_episode = Item.objects.get(
             media_id="1668",
-            source=Sources.TMDB.value,
+            source=Sources.TVDB.value,
             media_type=MediaTypes.EPISODE.value,
             season_number=1,
             episode_number=3,
         )
         self.assertEqual(
             new_episode.release_datetime,
-            timezone.make_aware(datetime(2023, 1, 15)),
+            datetime(2023, 1, 15, tzinfo=UTC),
             "a newly created episode must get release_datetime from the same payload",
+        )
+        self.assertIsNone(
+            Item.objects.get(
+                media_id="1668",
+                source=Sources.TVDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                season_number=1,
+                episode_number=4,
+            ).release_datetime,
+            "unknown-date sentinels must remain NULL",
         )
 
     @override_settings(TIME_ZONE="Europe/Berlin")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5489,6 +5489,17 @@ class MediaDetailsViewTests(TestCase):
             episode_number=2,
             release_datetime=None,
         )
+        concurrent_episode = Item.objects.create(
+            media_id="1668",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Test TV Show",
+            image=settings.IMG_NONE,
+            season_number=1,
+            episode_number=6,
+            release_datetime=None,
+        )
+        concurrent_trusted_date = datetime(2024, 2, 2, tzinfo=UTC)
 
         mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
             "title": "Test TV Show",
@@ -5541,12 +5552,31 @@ class MediaDetailsViewTests(TestCase):
                         "air_date": "9999-12-31",
                         "runtime": 46,
                     },
+                    {
+                        "episode_number": 6,
+                        "name": "Episode 6",
+                        "air_date": "2023-01-22",
+                        "runtime": 47,
+                    },
                 ],
             },
         }
         mock_process_episodes.return_value = []
 
+        original_bulk_update = Item.objects.bulk_update
+
+        def bulk_update_after_concurrent_date(objects, fields, batch_size=None):
+            Item.objects.filter(pk=concurrent_episode.pk).update(
+                release_datetime=concurrent_trusted_date,
+            )
+            return original_bulk_update(objects, fields, batch_size=batch_size)
+
         with (
+            patch.object(
+                Item.objects,
+                "bulk_update",
+                side_effect=bulk_update_after_concurrent_date,
+            ),
             patch("app.providers.trakt.is_configured", return_value=False),
             timezone.override("Pacific/Kiritimati"),
         ):
@@ -5610,6 +5640,12 @@ class MediaDetailsViewTests(TestCase):
                 episode_number=5,
             ).release_datetime,
             "year-9999 unknown-date sentinels must remain NULL",
+        )
+        concurrent_episode.refresh_from_db()
+        self.assertEqual(
+            concurrent_episode.release_datetime,
+            concurrent_trusted_date,
+            "an intervening trusted date must survive the metadata batch update",
         )
 
     @override_settings(TIME_ZONE="Europe/Berlin")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5535,6 +5535,12 @@ class MediaDetailsViewTests(TestCase):
                         "air_date": "0001-01-01",
                         "runtime": 45,
                     },
+                    {
+                        "episode_number": 5,
+                        "name": "Episode 5",
+                        "air_date": "9999-12-31",
+                        "runtime": 46,
+                    },
                 ],
             },
         }
@@ -5594,6 +5600,16 @@ class MediaDetailsViewTests(TestCase):
                 episode_number=4,
             ).release_datetime,
             "unknown-date sentinels must remain NULL",
+        )
+        self.assertIsNone(
+            Item.objects.get(
+                media_id="1668",
+                source=Sources.TVDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                season_number=1,
+                episode_number=5,
+            ).release_datetime,
+            "year-9999 unknown-date sentinels must remain NULL",
         )
 
     @override_settings(TIME_ZONE="Europe/Berlin")


### PR DESCRIPTION
## Summary

- Keep @daften's merged #686 behavior and attribution through the current `latest` base.
- Normalize provider calendar dates to UTC midnight through the existing release-date parser.
- Keep legacy minimum and maximum unknown-date sentinels as `NULL`.
- Never overwrite an existing trusted release date during a concurrent season refresh.
- Preserve current bulk episode creation/runtime batching.

## Conflict resolution

Successor to #696. GitHub would not reopen that PR after its stale head was rebuilt. The old stack conflicted because #686 and later season batching had already landed on `latest`. This branch now contains only the three remediation commits on top of current #685; it does not replay the contributor commit.

## Validation

- focused release-date/sentinel/concurrency regression: passed
- Ruff on both changed files: passed
- `git diff --check`: passed
- browser QA: pending fresh rerun
- hosted App Tests: pending fresh run

## Attribution

Original implementation: Dieter Blomme / @daften via merged PR #686.

Refs #696.