### PR TITLE
Make grouped anime migration atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,19 @@ If the log says that the database is busy, another process still holds a
 write lock. Stop that process, then restart Floppy. Do not delete the database
 or its lock files to resolve this conflict.
 
+### Grouped anime migration diagnostics
+
+Grouped anime conversion validates provider data before it writes and commits
+the grouped show, seasons, episode history, provider links, preference, and old
+MAL-row markers together. A retry after a successful conversion is a no-op.
+
+If Floppy reports `ANIME-MIGRATION-STALE-001`, reload the page and try again so
+it can validate the current source row. For `ANIME-MIGRATION-PARTIAL-001` or
+`ANIME-MIGRATION-AMBIGUOUS-001`, leave the existing rows unchanged, back up the
+database, and include the code when asking for support. Floppy deliberately
+does not guess whether coexisting episode rows are migration residue or a
+legitimate rewatch.
+
 ### Trakt private profile import (OAuth)
 
 If you import from a private Trakt profile, configure OAuth first:

--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -639,9 +639,12 @@ def episode_save(request):
             episode_number=episode_number,
             next_path=next_path,
         )
+        next_watch_operation_id = str(uuid4())
         response["HX-Trigger"] = json.dumps(
             {
-                "closeModal": {},
+                "closeModal": {
+                    "watchOperationId": next_watch_operation_id,
+                },
                 "showToast": {
                     "message": (
                         f"Updated episode {episode_number}."

--- a/src/app/services/anime_migration.py
+++ b/src/app/services/anime_migration.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from types import MappingProxyType
 from typing import Any
 
-from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
 from simple_history.utils import bulk_create_with_history, bulk_update_with_history
@@ -28,6 +28,7 @@ from app.models import (
 )
 from app.providers import services
 from app.services.bulk_episode_tracking import distribute_timestamps
+from app.services.tracking_hydration import ensure_item_metadata
 from app.signals import suppress_media_change_side_effects
 from integrations import anime_mapping
 
@@ -209,8 +210,6 @@ def _mapped_entries(anime_entries: list[Anime], provider: str, series_id: str):
 def _completed_target(
     user_id: int,
     mapped_entries: list[tuple[Anime, dict]],
-    provider: str,
-    series_id: str,
 ) -> Item | None:
     marked = [
         anime
@@ -235,15 +234,13 @@ def _completed_target(
     target_ids = {anime.migrated_to_item_id for anime in marked}
     if len(target_ids) != 1:
         raise _migration_error(
-            AnimeMigrationState.PROVABLY_PARTIAL,
-            PARTIAL_CODE,
-            "Migration markers reference conflicting grouped targets.",
+            AnimeMigrationState.AMBIGUOUS,
+            AMBIGUOUS_CODE,
+            "Migrated source rows reference different grouped targets.",
         )
     target = Item.objects.filter(pk=target_ids.pop()).first()
     target_is_valid = target is not None and (
-        target.media_id == series_id
-        and target.source == provider
-        and target.media_type == MediaTypes.TV.value
+        target.media_type == MediaTypes.TV.value
         and target.library_media_type == MediaTypes.ANIME.value
     )
     if not target_is_valid or not TV.objects.filter(
@@ -333,8 +330,6 @@ def preflight_flat_anime_to_grouped(
     completed_target = _completed_target(
         user.id,
         mapped_entries,
-        provider,
-        provider_series_id,
     )
     if completed_target is not None:
         entries = tuple(
@@ -465,9 +460,9 @@ def _completed_result(
     target_ids = {anime.migrated_to_item_id for anime in anime_rows}
     if len(target_ids) != 1:
         raise _migration_error(
-            AnimeMigrationState.PROVABLY_PARTIAL,
-            PARTIAL_CODE,
-            "Migration markers reference conflicting grouped targets.",
+            AnimeMigrationState.AMBIGUOUS,
+            AMBIGUOUS_CODE,
+            "Migrated source rows reference different grouped targets.",
         )
     grouped_tv = (
         TV.objects.select_related("item")
@@ -475,9 +470,7 @@ def _completed_result(
         .first()
     )
     if grouped_tv is None or not (
-        grouped_tv.item.media_id == preflight.provider_series_id
-        and grouped_tv.item.source == preflight.provider
-        and grouped_tv.item.media_type == MediaTypes.TV.value
+        grouped_tv.item.media_type == MediaTypes.TV.value
         and grouped_tv.item.library_media_type == MediaTypes.ANIME.value
     ):
         raise _migration_error(
@@ -520,38 +513,30 @@ def _upsert_provider_link(
 
 def _grouped_item(preflight: AnimeMigrationPreflight) -> Item:
     metadata = _thaw(preflight.series_metadata)
-    title_fields = Item.title_fields_from_metadata(
-        metadata,
-        fallback_title=preflight.entries[0].item_title,
-    )
-    item, created = Item.objects.get_or_create(
-        media_id=preflight.provider_series_id,
-        source=preflight.provider,
-        media_type=MediaTypes.TV.value,
+    return ensure_item_metadata(
+        get_user_model().objects.get(pk=preflight.user_id),
+        MediaTypes.ANIME.value,
+        preflight.provider_series_id,
+        preflight.provider,
+        identity_media_type=MediaTypes.TV.value,
         library_media_type=MediaTypes.ANIME.value,
-        defaults={
-            **title_fields,
-            "image": metadata.get("image") or settings.IMG_NONE,
-            "metadata_fetched_at": timezone.now(),
-        },
-    )
-    if not created:
-        update_fields = []
-        for field_name, value in title_fields.items():
-            if value and getattr(item, field_name) != value:
-                setattr(item, field_name, value)
-                update_fields.append(field_name)
-        if item.image == settings.IMG_NONE and metadata.get("image"):
-            item.image = metadata["image"]
-            update_fields.append("image")
-        if update_fields:
-            item.save(update_fields=update_fields)
-    _upsert_provider_link(
-        item,
-        provider=preflight.provider,
-        series_id=preflight.provider_series_id,
-    )
-    return item
+        fallback_title=preflight.entries[0].item_title,
+        prefetched_metadata=metadata,
+        provider_link_retry_max_retries=0,
+    ).item
+
+
+def _reconcile_committed_migration(
+    user_id: int,
+    item_ids: tuple[int, ...],
+    history_days: tuple[str, ...],
+) -> None:
+    """Run skipped cache and smart-list effects once after commit."""
+    signals._clear_media_runtime_caches(user_id, MediaTypes.EPISODE.value)
+    signals._invalidate_episode_history_changes({user_id: list(history_days)})
+    owner = get_user_model().objects.filter(pk=user_id).first()
+    items = list(Item.objects.filter(pk__in=item_ids).order_by("id"))
+    signals._sync_owner_smart_lists_for_items(owner, items)
 
 
 def _season_tracker(
@@ -709,6 +694,7 @@ def _persist_preflight_once(
         latest_notes_entry = None
         created_seasons: dict[int, Season] = {}
         history_days = set()
+        smart_list_item_ids = {grouped_item.id, *(anime.item_id for anime in locked_rows)}
         for entry in preflight.entries:
             source_item = by_id[entry.anime_id].item
             _upsert_provider_link(
@@ -726,6 +712,7 @@ def _persist_preflight_once(
             if season is None:
                 season = _season_tracker(preflight, grouped_tv, entry)
                 created_seasons[entry.season_number] = season
+                smart_list_item_ids.add(season.item_id)
             created_episodes = _create_migration_episodes(season, entry)
             history_days.update(
                 day_key
@@ -807,11 +794,14 @@ def _persist_preflight_once(
             item=grouped_item,
             defaults={"provider": preflight.provider},
         )
-        committed_changes = {preflight.user_id: sorted(history_days)}
+        committed_item_ids = tuple(sorted(smart_list_item_ids))
+        committed_history_days = tuple(sorted(history_days))
         transaction.on_commit(
-            lambda changes=committed_changes: signals._invalidate_episode_history_changes(
-                changes
-            )
+            lambda: _reconcile_committed_migration(
+                preflight.user_id,
+                committed_item_ids,
+                committed_history_days,
+            ),
         )
         return AnimeMigrationResult(
             grouped_tv=grouped_tv,

--- a/src/app/services/anime_migration.py
+++ b/src/app/services/anime_migration.py
@@ -3,28 +3,59 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
 
+from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
+from simple_history.utils import bulk_create_with_history, bulk_update_with_history
 
+from app import history_cache, providers, signals
+from app.db_retry import run_retryable_db_operation
 from app.models import (
     TV,
     Anime,
     Episode,
     Item,
+    ItemProviderLink,
     MediaTypes,
     MetadataProviderPreference,
     Season,
+    Sources,
     Status,
 )
 from app.providers import services
 from app.services.bulk_episode_tracking import distribute_timestamps
-from app.services.metadata_resolution import upsert_provider_links
-from app.services.tracking_hydration import ensure_item_metadata
+from app.signals import suppress_media_change_side_effects
 from integrations import anime_mapping
+
+
+class AnimeMigrationState(StrEnum):
+    """Stable forward-migration states used by diagnostics and tests."""
+
+    READY = "ready"
+    COMPLETE = "complete"
+    PROVABLY_PARTIAL = "provably_partial"
+    AMBIGUOUS = "ambiguous"
+    STALE = "stale"
 
 
 class AnimeMigrationError(Exception):
     """Raised when grouped-anime migration cannot be completed safely."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        state: AnimeMigrationState | None = None,
+        code: str | None = None,
+    ):
+        """Create a safe error with optional stable state and diagnostic code."""
+        self.state = state
+        self.code = code
+        super().__init__(f"{code}: {message}" if code else message)
 
 
 @dataclass(slots=True)
@@ -35,8 +66,73 @@ class AnimeMigrationResult:
     migrated_entries: list[Anime]
 
 
+@dataclass(frozen=True, slots=True)
+class AnimeEntryPayload:
+    """Read-only source row and mapping data consumed by persistence."""
+
+    anime_id: int
+    item_id: int
+    item_media_id: str
+    item_title: str
+    progress: int
+    status: str
+    score: Any
+    notes: str
+    start_date: Any
+    end_date: Any
+    progressed_at: Any
+    created_at: Any
+    migrated_to_item_id: int | None
+    migrated_at: Any
+    season_number: int
+    episode_offset: int
+    season_metadata: MappingProxyType
+
+
+@dataclass(frozen=True, slots=True)
+class AnimeMigrationPreflight:
+    """Immutable, provider-complete input for the database-only phase."""
+
+    state: AnimeMigrationState
+    user_id: int
+    provider: str
+    provider_series_id: str
+    entries: tuple[AnimeEntryPayload, ...]
+    series_metadata: MappingProxyType
+    completed_target_item_id: int | None = None
+
+
+PARTIAL_CODE = "ANIME-MIGRATION-PARTIAL-001"
+AMBIGUOUS_CODE = "ANIME-MIGRATION-AMBIGUOUS-001"
+STALE_CODE = "ANIME-MIGRATION-STALE-001"
+
+
+def _migration_error(
+    state: AnimeMigrationState,
+    code: str,
+    message: str,
+) -> AnimeMigrationError:
+    return AnimeMigrationError(message, state=state, code=code)
+
+
+def _freeze(value):
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _thaw(value):
+    if isinstance(value, MappingProxyType):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
 def _provider_series_id(entry: dict, provider: str) -> str | None:
-    if provider == "tvdb":
+    if provider == Sources.TVDB.value:
         value = entry.get("tvdb_id")
         return str(value) if value not in (None, "") else None
     for key in ("tmdb_show_id", "tmdb_id", "tmdb_tv_id"):
@@ -49,7 +145,7 @@ def _provider_series_id(entry: dict, provider: str) -> str | None:
 def _provider_season_number(entry: dict, provider: str) -> int | None:
     keys = (
         ["tvdb_season"]
-        if provider == "tvdb"
+        if provider == Sources.TVDB.value
         else ["tmdb_season", "tvdb_season", "season"]
     )
     for key in keys:
@@ -65,7 +161,9 @@ def _provider_season_number(entry: dict, provider: str) -> int | None:
 
 def _provider_episode_offset(entry: dict, provider: str) -> int:
     keys = (
-        ["tvdb_epoffset"] if provider == "tvdb" else ["tmdb_epoffset", "tvdb_epoffset"]
+        ["tvdb_epoffset"]
+        if provider == Sources.TVDB.value
+        else ["tmdb_epoffset", "tvdb_epoffset"]
     )
     for key in keys:
         value = entry.get(key)
@@ -78,18 +176,20 @@ def _provider_episode_offset(entry: dict, provider: str) -> int:
     return 0
 
 
-def _distribution_timestamps(anime: Anime, total_episodes: int) -> list:
+def _distribution_timestamps(entry: AnimeEntryPayload) -> list:
     return distribute_timestamps(
-        anime.start_date,
-        anime.end_date,
-        total_episodes,
-        fallback_dt=anime.progressed_at or anime.created_at or timezone.now(),
+        entry.start_date,
+        entry.end_date,
+        entry.progress,
+        fallback_dt=entry.progressed_at or entry.created_at or timezone.now(),
     )
 
 
-def _entries_for_provider_series(
-    anime_entries: list[Anime], provider: str, series_id: str
-) -> list[tuple[Anime, dict]]:
+def _entry_activity_datetime(entry: AnimeEntryPayload):
+    return entry.end_date or entry.progressed_at or entry.created_at or timezone.now()
+
+
+def _mapped_entries(anime_entries: list[Anime], provider: str, series_id: str):
     matches: list[tuple[Anime, dict]] = []
     for anime in anime_entries:
         mapping_entries = anime_mapping.find_entries_for_mal_id(anime.item.media_id)
@@ -100,24 +200,116 @@ def _entries_for_provider_series(
         ]
         if len(provider_entries) > 1:
             msg = f'Ambiguous mapping for "{anime.item.title}" on {provider.upper()}.'
-            raise AnimeMigrationError(
-                msg,
-            )
+            raise AnimeMigrationError(msg)
         if provider_entries:
             matches.append((anime, provider_entries[0]))
     return matches
 
 
-def _entry_activity_datetime(anime: Anime):
-    """Return the most relevant activity datetime for a flat anime row."""
-    return anime.end_date or anime.progressed_at or anime.created_at or timezone.now()
+def _completed_target(
+    user_id: int,
+    mapped_entries: list[tuple[Anime, dict]],
+    provider: str,
+    series_id: str,
+) -> Item | None:
+    marked = [
+        anime
+        for anime, _mapping in mapped_entries
+        if anime.migrated_to_item_id is not None or anime.migrated_at is not None
+    ]
+    if not marked:
+        return None
+    for anime in marked:
+        if (anime.migrated_to_item_id is None) != (anime.migrated_at is None):
+            raise _migration_error(
+                AnimeMigrationState.PROVABLY_PARTIAL,
+                PARTIAL_CODE,
+                "Migration markers do not reference a complete grouped target.",
+            )
+    if len(marked) != len(mapped_entries):
+        raise _migration_error(
+            AnimeMigrationState.AMBIGUOUS,
+            AMBIGUOUS_CODE,
+            "Migrated and unmigrated source rows coexist; no data was changed.",
+        )
+    target_ids = {anime.migrated_to_item_id for anime in marked}
+    if len(target_ids) != 1:
+        raise _migration_error(
+            AnimeMigrationState.PROVABLY_PARTIAL,
+            PARTIAL_CODE,
+            "Migration markers reference conflicting grouped targets.",
+        )
+    target = Item.objects.filter(pk=target_ids.pop()).first()
+    target_is_valid = target is not None and (
+        target.media_id == series_id
+        and target.source == provider
+        and target.media_type == MediaTypes.TV.value
+        and target.library_media_type == MediaTypes.ANIME.value
+    )
+    if not target_is_valid or not TV.objects.filter(
+        user_id=user_id,
+        item=target,
+    ).exists():
+        raise _migration_error(
+            AnimeMigrationState.PROVABLY_PARTIAL,
+            PARTIAL_CODE,
+            "Migration markers reference missing grouped tracking.",
+        )
+    return target
 
 
-def migrate_flat_anime_to_grouped(
-    user, anime_item: Item, provider: str
-) -> AnimeMigrationResult:
-    """Migrate all matching flat anime rows for a user into a grouped series."""
-    if anime_item.source != "mal" or anime_item.media_type != MediaTypes.ANIME.value:
+def _existing_grouped_tracking(user_id: int, provider: str, series_id: str) -> bool:
+    target_items = Item.objects.filter(
+        media_id=series_id,
+        source=provider,
+        media_type=MediaTypes.TV.value,
+        library_media_type=MediaTypes.ANIME.value,
+    )
+    return TV.objects.filter(user_id=user_id, item__in=target_items).exists() or (
+        MetadataProviderPreference.objects.filter(
+            user_id=user_id,
+            item__in=target_items,
+        ).exists()
+    )
+
+
+def _entry_payload(
+    anime: Anime,
+    *,
+    season_number: int,
+    episode_offset: int,
+    season_metadata: dict,
+) -> AnimeEntryPayload:
+    return AnimeEntryPayload(
+        anime_id=anime.id,
+        item_id=anime.item_id,
+        item_media_id=anime.item.media_id,
+        item_title=anime.item.title,
+        progress=int(anime.progress or 0),
+        status=anime.status,
+        score=anime.score,
+        notes=anime.notes,
+        start_date=anime.start_date,
+        end_date=anime.end_date,
+        progressed_at=anime.progressed_at,
+        created_at=anime.created_at,
+        migrated_to_item_id=anime.migrated_to_item_id,
+        migrated_at=anime.migrated_at,
+        season_number=season_number,
+        episode_offset=episode_offset,
+        season_metadata=_freeze(season_metadata),
+    )
+
+
+def preflight_flat_anime_to_grouped(
+    user,
+    anime_item: Item,
+    provider: str,
+) -> AnimeMigrationPreflight:
+    """Read and validate all provider data without mutating any ORM table."""
+    if anime_item.source != Sources.MAL.value or (
+        anime_item.media_type != MediaTypes.ANIME.value
+    ):
         msg = "Only flat MAL anime can be migrated in this phase."
         raise AnimeMigrationError(msg)
 
@@ -127,213 +319,521 @@ def migrate_flat_anime_to_grouped(
     )
     if not provider_series_id:
         msg = f"No {provider.upper()} mapping was found for this anime."
-        raise AnimeMigrationError(
-            msg,
-        )
+        raise AnimeMigrationError(msg)
+    provider_series_id = str(provider_series_id)
 
-    flat_anime_entries = list(
-        Anime.all_objects.filter(
-            user=user,
-            migrated_to_item__isnull=True,
-        ).select_related("item"),
+    anime_entries = list(
+        Anime.all_objects.filter(user=user).select_related("item").order_by("id")
     )
-    mapped_entries = _entries_for_provider_series(
-        flat_anime_entries,
+    mapped_entries = _mapped_entries(anime_entries, provider, provider_series_id)
+    if not mapped_entries:
+        msg = "No anime entries matched this grouped series."
+        raise AnimeMigrationError(msg)
+
+    completed_target = _completed_target(
+        user.id,
+        mapped_entries,
         provider,
         provider_series_id,
     )
-    if not mapped_entries:
-        msg = "No unmigrated anime entries matched this grouped series."
-        raise AnimeMigrationError(msg)
+    if completed_target is not None:
+        entries = tuple(
+            _entry_payload(
+                anime,
+                season_number=0,
+                episode_offset=0,
+                season_metadata={},
+            )
+            for anime, _mapping in mapped_entries
+        )
+        return AnimeMigrationPreflight(
+            state=AnimeMigrationState.COMPLETE,
+            user_id=user.id,
+            provider=provider,
+            provider_series_id=provider_series_id,
+            entries=entries,
+            series_metadata=_freeze({}),
+            completed_target_item_id=completed_target.id,
+        )
 
-    season_numbers = []
-    for _anime, mapping_entry in mapped_entries:
+    if _existing_grouped_tracking(user.id, provider, provider_series_id):
+        raise _migration_error(
+            AnimeMigrationState.AMBIGUOUS,
+            AMBIGUOUS_CODE,
+            "Grouped tracking already coexists with unmigrated source rows; no data was changed.",
+        )
+
+    season_numbers: list[int] = []
+    normalized_entries: list[tuple[Anime, int, int]] = []
+    for anime, mapping_entry in mapped_entries:
         season_number = _provider_season_number(mapping_entry, provider)
         if season_number is None:
             msg = "One or more mapped entries do not define a season."
             raise AnimeMigrationError(msg)
         season_numbers.append(season_number)
+        normalized_entries.append(
+            (anime, season_number, _provider_episode_offset(mapping_entry, provider))
+        )
 
-    hydration = ensure_item_metadata(
-        user,
+    series_metadata = services.get_media_metadata(
         MediaTypes.ANIME.value,
         provider_series_id,
         provider,
-        identity_media_type=MediaTypes.TV.value,
-        library_media_type=MediaTypes.ANIME.value,
     )
-    series_metadata = hydration.metadata
-    grouped_tv, _ = TV.objects.get_or_create(
-        item=hydration.item,
-        user=user,
-        defaults={
-            "status": Status.PLANNING.value,
-            "score": None,
-            "notes": "",
-        },
-    )
-    upsert_provider_links(
-        grouped_tv.item,
-        series_metadata,
-        provider=provider,
-        provider_media_type=MediaTypes.TV.value,
+    series_metadata = dict(series_metadata or {})
+    series_metadata.update(
+        {
+            "media_id": provider_series_id,
+            "source": provider,
+            "identity_media_type": MediaTypes.TV.value,
+            "library_media_type": MediaTypes.ANIME.value,
+        }
     )
     tv_with_seasons = services.get_media_metadata(
         "tv_with_seasons",
         provider_series_id,
         provider,
-        season_numbers,
+        sorted(set(season_numbers)),
     )
 
-    for anime, mapping_entry in mapped_entries:
-        season_number = _provider_season_number(mapping_entry, provider)
-        episode_offset = _provider_episode_offset(mapping_entry, provider)
-        season_key = f"season/{season_number}"
-        season_metadata = tv_with_seasons.get(season_key)
+    payload_entries = []
+    for anime, season_number, episode_offset in normalized_entries:
+        season_metadata = dict(tv_with_seasons.get(f"season/{season_number}") or {})
         if not season_metadata:
             msg = f"Season {season_number} could not be loaded from {provider.upper()}."
-            raise AnimeMigrationError(
-                msg,
+            raise AnimeMigrationError(msg)
+        episodes = season_metadata.get("episodes") or []
+        if anime.progress > max(len(episodes) - episode_offset, 0):
+            msg = (
+                f'"{anime.item.title}" has more watched episodes than the '
+                "mapped season can hold."
             )
-
-        available_episodes = len(season_metadata.get("episodes") or [])
-        if anime.progress > max(available_episodes - episode_offset, 0):
-            msg = f'"{anime.item.title}" has more watched episodes than the mapped season can hold.'
-            raise AnimeMigrationError(
-                msg,
+            raise AnimeMigrationError(msg)
+        if provider == Sources.TMDB.value:
+            season_metadata["_tvdb_episode_image_map"] = (
+                providers.tmdb.get_tvdb_episode_image_map(
+                    season_metadata.get("tvdb_id"),
+                    season_metadata.get("season_number") or season_number,
+                    tmdb_media_id=provider_series_id,
+                )
             )
-
-    latest_score_entry = None
-    latest_notes_entry = None
-    now = timezone.now()
-
-    for anime, mapping_entry in mapped_entries:
-        season_number = _provider_season_number(mapping_entry, provider)
-        episode_offset = _provider_episode_offset(mapping_entry, provider)
-        upsert_provider_links(
-            anime.item,
-            {
-                "media_id": provider_series_id,
-                "source": provider,
-                "identity_media_type": MediaTypes.TV.value,
-                "provider_external_ids": {
-                    f"{provider}_id": provider_series_id,
-                },
-            },
-            provider=provider,
-            provider_media_type=MediaTypes.TV.value,
-            season_number=season_number,
-            episode_offset=episode_offset,
-            extra_metadata={
-                "season_number": season_number,
-                "episode_offset": episode_offset,
-            },
-        )
-        season_key = f"season/{season_number}"
-        season_metadata = tv_with_seasons[season_key]
-        season_image = season_metadata.get("image") or grouped_tv.item.image
-
-        season_item, _ = Item.objects.get_or_create(
-            media_id=provider_series_id,
-            source=provider,
-            media_type=MediaTypes.SEASON.value,
-            season_number=season_number,
-            defaults={
-                **Item.title_fields_from_metadata(
-                    season_metadata,
-                    fallback_title=grouped_tv.item.title,
-                ),
-                "library_media_type": MediaTypes.ANIME.value,
-                "image": season_image,
-            },
-        )
-        season_item_updates = []
-        if season_item.library_media_type != MediaTypes.ANIME.value:
-            season_item.library_media_type = MediaTypes.ANIME.value
-            season_item_updates.append("library_media_type")
-        if season_item.image != season_image and season_image:
-            season_item.image = season_image
-            season_item_updates.append("image")
-        if season_item_updates:
-            season_item.save(update_fields=season_item_updates)
-
-        season_tracker, _ = Season.objects.get_or_create(
-            item=season_item,
-            user=user,
-            related_tv=grouped_tv,
-            defaults={
-                "status": Status.PLANNING.value,
-                "score": None,
-                "notes": "",
-            },
+        payload_entries.append(
+            _entry_payload(
+                anime,
+                season_number=season_number,
+                episode_offset=episode_offset,
+                season_metadata=season_metadata,
+            )
         )
 
-        watched_episode_numbers = [
-            episode_offset + episode_index
-            for episode_index in range(1, int(anime.progress or 0) + 1)
-        ]
-        watched_timestamps = _distribution_timestamps(
-            anime, len(watched_episode_numbers)
-        )
+    return AnimeMigrationPreflight(
+        state=AnimeMigrationState.READY,
+        user_id=user.id,
+        provider=provider,
+        provider_series_id=provider_series_id,
+        entries=tuple(payload_entries),
+        series_metadata=_freeze(series_metadata),
+    )
 
-        for episode_number, watched_at in zip(
-            watched_episode_numbers, watched_timestamps, strict=False
-        ):
-            episode_item = season_tracker.get_episode_item(
-                episode_number,
+
+def _source_matches_payload(anime: Anime, entry: AnimeEntryPayload) -> bool:
+    return (
+        anime.item_id == entry.item_id
+        and anime.item.media_id == entry.item_media_id
+        and int(anime.progress or 0) == entry.progress
+        and anime.status == entry.status
+        and anime.score == entry.score
+        and anime.notes == entry.notes
+        and anime.start_date == entry.start_date
+        and anime.end_date == entry.end_date
+        and anime.progressed_at == entry.progressed_at
+        and anime.created_at == entry.created_at
+        and anime.migrated_to_item_id == entry.migrated_to_item_id
+        and anime.migrated_at == entry.migrated_at
+    )
+
+
+def _completed_result(
+    preflight: AnimeMigrationPreflight,
+    anime_rows: list[Anime],
+) -> AnimeMigrationResult | None:
+    if not anime_rows or any(
+        anime.migrated_to_item_id is None or anime.migrated_at is None
+        for anime in anime_rows
+    ):
+        return None
+    target_ids = {anime.migrated_to_item_id for anime in anime_rows}
+    if len(target_ids) != 1:
+        raise _migration_error(
+            AnimeMigrationState.PROVABLY_PARTIAL,
+            PARTIAL_CODE,
+            "Migration markers reference conflicting grouped targets.",
+        )
+    grouped_tv = (
+        TV.objects.select_related("item")
+        .filter(user_id=preflight.user_id, item_id=target_ids.pop())
+        .first()
+    )
+    if grouped_tv is None or not (
+        grouped_tv.item.media_id == preflight.provider_series_id
+        and grouped_tv.item.source == preflight.provider
+        and grouped_tv.item.media_type == MediaTypes.TV.value
+        and grouped_tv.item.library_media_type == MediaTypes.ANIME.value
+    ):
+        raise _migration_error(
+            AnimeMigrationState.PROVABLY_PARTIAL,
+            PARTIAL_CODE,
+            "Migration markers reference missing grouped tracking.",
+        )
+    return AnimeMigrationResult(grouped_tv=grouped_tv, migrated_entries=anime_rows)
+
+
+def _upsert_provider_link(
+    item: Item,
+    *,
+    provider: str,
+    series_id: str,
+    season_number: int | None = None,
+    episode_offset: int | None = None,
+    metadata: dict | None = None,
+) -> None:
+    defaults = {
+        "provider_media_id": series_id,
+        "metadata": metadata or {},
+    }
+    if episode_offset is not None:
+        defaults["episode_offset"] = episode_offset
+    ItemProviderLink.objects.update_or_create(
+        item=item,
+        provider=provider,
+        provider_media_type=MediaTypes.TV.value,
+        season_number=season_number,
+        defaults=defaults,
+    )
+
+    external_ids = dict(item.provider_external_ids or {})
+    external_ids[f"{provider}_id"] = series_id
+    if item.provider_external_ids != external_ids:
+        item.provider_external_ids = external_ids
+        item.save(update_fields=["provider_external_ids"])
+
+
+def _grouped_item(preflight: AnimeMigrationPreflight) -> Item:
+    metadata = _thaw(preflight.series_metadata)
+    title_fields = Item.title_fields_from_metadata(
+        metadata,
+        fallback_title=preflight.entries[0].item_title,
+    )
+    item, created = Item.objects.get_or_create(
+        media_id=preflight.provider_series_id,
+        source=preflight.provider,
+        media_type=MediaTypes.TV.value,
+        library_media_type=MediaTypes.ANIME.value,
+        defaults={
+            **title_fields,
+            "image": metadata.get("image") or settings.IMG_NONE,
+            "metadata_fetched_at": timezone.now(),
+        },
+    )
+    if not created:
+        update_fields = []
+        for field_name, value in title_fields.items():
+            if value and getattr(item, field_name) != value:
+                setattr(item, field_name, value)
+                update_fields.append(field_name)
+        if item.image == settings.IMG_NONE and metadata.get("image"):
+            item.image = metadata["image"]
+            update_fields.append("image")
+        if update_fields:
+            item.save(update_fields=update_fields)
+    _upsert_provider_link(
+        item,
+        provider=preflight.provider,
+        series_id=preflight.provider_series_id,
+    )
+    return item
+
+
+def _season_tracker(
+    preflight: AnimeMigrationPreflight,
+    grouped_tv: TV,
+    entry: AnimeEntryPayload,
+) -> Season:
+    season_metadata = _thaw(entry.season_metadata)
+    season_image = season_metadata.get("image") or grouped_tv.item.image
+    season_item, _created = Item.objects.get_or_create(
+        media_id=preflight.provider_series_id,
+        source=preflight.provider,
+        media_type=MediaTypes.SEASON.value,
+        library_media_type=MediaTypes.ANIME.value,
+        season_number=entry.season_number,
+        defaults={
+            **Item.title_fields_from_metadata(
                 season_metadata,
-            )
-            if episode_item.library_media_type != MediaTypes.ANIME.value:
-                episode_item.library_media_type = MediaTypes.ANIME.value
-                episode_item.save(update_fields=["library_media_type"])
-
-            Episode.objects.create(
-                related_season=season_tracker,
-                item=episode_item,
-                end_date=watched_at,
-            )
-
-        if anime.score is not None and (
-            latest_score_entry is None
-            or _entry_activity_datetime(anime)
-            > _entry_activity_datetime(latest_score_entry)
-        ):
-            latest_score_entry = anime
-        if anime.notes and (
-            latest_notes_entry is None
-            or _entry_activity_datetime(anime)
-            > _entry_activity_datetime(latest_notes_entry)
-        ):
-            latest_notes_entry = anime
-
-    update_fields: list[str] = []
-    if latest_score_entry is not None and grouped_tv.score != latest_score_entry.score:
-        grouped_tv.score = latest_score_entry.score
-        update_fields.append("score")
-    if latest_notes_entry is not None and grouped_tv.notes != latest_notes_entry.notes:
-        grouped_tv.notes = latest_notes_entry.notes
-        update_fields.append("notes")
-    if grouped_tv.status == Status.PLANNING.value:
-        grouped_tv.status = Status.IN_PROGRESS.value
-        update_fields.append("status")
+                fallback_title=grouped_tv.item.title,
+            ),
+            "image": season_image,
+        },
+    )
+    update_fields = []
+    if season_item.library_media_type != MediaTypes.ANIME.value:
+        season_item.library_media_type = MediaTypes.ANIME.value
+        update_fields.append("library_media_type")
+    if season_item.image != season_image and season_image:
+        season_item.image = season_image
+        update_fields.append("image")
     if update_fields:
-        grouped_tv.save(update_fields=update_fields)
+        season_item.save(update_fields=update_fields)
+    return bulk_create_with_history(
+        [
+            Season(
+                item=season_item,
+                user_id=preflight.user_id,
+                related_tv=grouped_tv,
+                status=Status.PLANNING.value,
+                score=None,
+                notes="",
+            )
+        ],
+        Season,
+    )[0]
 
-    migrated_entries = [anime for anime, _mapping in mapped_entries]
-    for anime in migrated_entries:
-        anime.migrated_to_item = grouped_tv.item
-        anime.migrated_at = now
-    Anime.all_objects.bulk_update(
-        migrated_entries,
-        ["migrated_to_item", "migrated_at"],
-    )
-    MetadataProviderPreference.objects.update_or_create(
-        user=user,
-        item=grouped_tv.item,
-        defaults={"provider": provider},
-    )
 
-    return AnimeMigrationResult(
-        grouped_tv=grouped_tv,
-        migrated_entries=migrated_entries,
-    )
+def _create_migration_episodes(
+    season: Season,
+    entry: AnimeEntryPayload,
+) -> list[Episode]:
+    if entry.progress <= 0:
+        return []
+    season_metadata = _thaw(entry.season_metadata)
+    episode_numbers = [
+        entry.episode_offset + index for index in range(1, entry.progress + 1)
+    ]
+    episode_items = [
+        season.get_episode_item(episode_number, season_metadata)
+        for episode_number in episode_numbers
+    ]
+    episodes = [
+        Episode(related_season=season, item=item, end_date=watched_at)
+        for item, watched_at in zip(
+            episode_items,
+            _distribution_timestamps(entry),
+            strict=False,
+        )
+    ]
+    return bulk_create_with_history(episodes, Episode)
+
+
+def _persist_preflight_once(
+    preflight: AnimeMigrationPreflight,
+) -> AnimeMigrationResult:
+    with transaction.atomic(), suppress_media_change_side_effects():
+        locked_rows = list(
+            Anime.all_objects.select_for_update()
+            .filter(id__in=[entry.anime_id for entry in preflight.entries])
+            .select_related("item")
+            .order_by("id")
+        )
+        by_id = {anime.id: anime for anime in locked_rows}
+        if len(by_id) != len(preflight.entries):
+            raise _migration_error(
+                AnimeMigrationState.STALE,
+                STALE_CODE,
+                "Source rows changed after preflight; retry from a fresh preflight.",
+            )
+
+        completed = _completed_result(preflight, locked_rows)
+        if completed is not None:
+            return completed
+        if preflight.state == AnimeMigrationState.COMPLETE:
+            raise _migration_error(
+                AnimeMigrationState.STALE,
+                STALE_CODE,
+                "Completed migration state changed after preflight.",
+            )
+
+        inconsistent = [
+            anime
+            for anime in locked_rows
+            if (anime.migrated_to_item_id is None) != (anime.migrated_at is None)
+        ]
+        if inconsistent:
+            raise _migration_error(
+                AnimeMigrationState.PROVABLY_PARTIAL,
+                PARTIAL_CODE,
+                "Migration markers do not reference a complete grouped target.",
+            )
+        marked_count = sum(
+            anime.migrated_to_item_id is not None for anime in locked_rows
+        )
+        if marked_count:
+            raise _migration_error(
+                AnimeMigrationState.AMBIGUOUS,
+                AMBIGUOUS_CODE,
+                "Migrated and unmigrated source rows coexist; no data was changed.",
+            )
+        for entry in preflight.entries:
+            if not _source_matches_payload(by_id[entry.anime_id], entry):
+                raise _migration_error(
+                    AnimeMigrationState.STALE,
+                    STALE_CODE,
+                    "Source rows changed after preflight; retry from a fresh preflight.",
+                )
+
+        if _existing_grouped_tracking(
+            preflight.user_id,
+            preflight.provider,
+            preflight.provider_series_id,
+        ):
+            raise _migration_error(
+                AnimeMigrationState.AMBIGUOUS,
+                AMBIGUOUS_CODE,
+                "Grouped tracking appeared after preflight; no data was changed.",
+            )
+
+        grouped_item = _grouped_item(preflight)
+        grouped_tv = bulk_create_with_history(
+            [
+                TV(
+                    item=grouped_item,
+                    user_id=preflight.user_id,
+                    status=Status.PLANNING.value,
+                    score=None,
+                    notes="",
+                )
+            ],
+            TV,
+        )[0]
+
+        latest_score_entry = None
+        latest_notes_entry = None
+        created_seasons: dict[int, Season] = {}
+        history_days = set()
+        for entry in preflight.entries:
+            source_item = by_id[entry.anime_id].item
+            _upsert_provider_link(
+                source_item,
+                provider=preflight.provider,
+                series_id=preflight.provider_series_id,
+                season_number=entry.season_number,
+                episode_offset=entry.episode_offset,
+                metadata={
+                    "season_number": entry.season_number,
+                    "episode_offset": entry.episode_offset,
+                },
+            )
+            season = created_seasons.get(entry.season_number)
+            if season is None:
+                season = _season_tracker(preflight, grouped_tv, entry)
+                created_seasons[entry.season_number] = season
+            created_episodes = _create_migration_episodes(season, entry)
+            history_days.update(
+                day_key
+                for episode in created_episodes
+                if (day_key := history_cache.history_day_key(episode.end_date))
+            )
+
+            if entry.score is not None and (
+                latest_score_entry is None
+                or _entry_activity_datetime(entry)
+                > _entry_activity_datetime(latest_score_entry)
+            ):
+                latest_score_entry = entry
+            if entry.notes and (
+                latest_notes_entry is None
+                or _entry_activity_datetime(entry)
+                > _entry_activity_datetime(latest_notes_entry)
+            ):
+                latest_notes_entry = entry
+
+        for season_number, season in created_seasons.items():
+            season_entries = [
+                entry
+                for entry in preflight.entries
+                if entry.season_number == season_number
+            ]
+            season_metadata = _thaw(season_entries[0].season_metadata)
+            desired_status = season.derived_status_from_episode_progress(
+                max_progress=len(season_metadata.get("episodes") or []),
+            )
+            if not all(
+                entry.status == Status.COMPLETED.value for entry in season_entries
+            ):
+                desired_status = (
+                    Status.IN_PROGRESS.value
+                    if any(entry.progress for entry in season_entries)
+                    else Status.PLANNING.value
+                )
+            if season.status != desired_status:
+                season.status = desired_status
+                bulk_update_with_history([season], Season, fields=["status"])
+
+        grouped_tv_updates = []
+        if latest_score_entry is not None:
+            grouped_tv.score = latest_score_entry.score
+            grouped_tv_updates.append("score")
+        if latest_notes_entry is not None:
+            grouped_tv.notes = latest_notes_entry.notes
+            grouped_tv_updates.append("notes")
+        desired_tv_status = (
+            Status.COMPLETED.value
+            if created_seasons
+            and all(
+                season.status == Status.COMPLETED.value
+                for season in created_seasons.values()
+            )
+            else Status.IN_PROGRESS.value
+        )
+        if grouped_tv.status != desired_tv_status:
+            grouped_tv.status = desired_tv_status
+            grouped_tv_updates.append("status")
+        if grouped_tv_updates:
+            bulk_update_with_history(
+                [grouped_tv],
+                TV,
+                fields=list(dict.fromkeys(grouped_tv_updates)),
+            )
+
+        now = timezone.now()
+        for anime in locked_rows:
+            anime.migrated_to_item = grouped_item
+            anime.migrated_at = now
+        Anime.all_objects.bulk_update(
+            locked_rows,
+            ["migrated_to_item", "migrated_at"],
+        )
+        MetadataProviderPreference.objects.update_or_create(
+            user_id=preflight.user_id,
+            item=grouped_item,
+            defaults={"provider": preflight.provider},
+        )
+        committed_changes = {preflight.user_id: sorted(history_days)}
+        transaction.on_commit(
+            lambda changes=committed_changes: signals._invalidate_episode_history_changes(
+                changes
+            )
+        )
+        return AnimeMigrationResult(
+            grouped_tv=grouped_tv,
+            migrated_entries=locked_rows,
+        )
+
+
+def persist_flat_anime_migration(
+    preflight: AnimeMigrationPreflight,
+) -> AnimeMigrationResult:
+    """Persist a preflight in a fresh transaction on every lock retry."""
+    return run_retryable_db_operation(
+        lambda: _persist_preflight_once(preflight),
+        operation_name="flat anime grouped migration",
+    ).value
+
+
+def migrate_flat_anime_to_grouped(
+    user,
+    anime_item: Item,
+    provider: str,
+) -> AnimeMigrationResult:
+    """Migrate all matching flat anime rows using preflight then one transaction."""
+    preflight = preflight_flat_anime_to_grouped(user, anime_item, provider)
+    return persist_flat_anime_migration(preflight)

--- a/src/app/services/tracking_hydration.py
+++ b/src/app/services/tracking_hydration.py
@@ -273,16 +273,26 @@ def ensure_item_metadata(
     fallback_image: str | None = None,
     fallback_release_date: str | None = None,
     edition_id: str | None = None,
+    prefetched_metadata: dict | None = None,
+    provider_link_retry_max_retries: int | None = None,
 ) -> HydratedItemResult:
-    """Get or create an Item with the same metadata quality used for tracked saves."""
+    """Get or create an Item with the same metadata quality used for tracked saves.
+
+    ``prefetched_metadata`` lets validate-first flows persist an already fetched
+    provider response without making network calls inside their transaction.
+    """
     season_numbers = [season_number]
-    metadata = services.get_media_metadata(
-        media_type,
-        media_id,
-        source,
-        season_numbers,
-        episode_number,
-        edition_id=edition_id,
+    metadata = (
+        services.get_media_metadata(
+            media_type,
+            media_id,
+            source,
+            season_numbers,
+            episode_number,
+            edition_id=edition_id,
+        )
+        if prefetched_metadata is None
+        else dict(prefetched_metadata)
     )
     podcast_show = None
     if media_type == MediaTypes.PODCAST.value and source in {
@@ -497,6 +507,7 @@ def ensure_item_metadata(
         provider=source,
         provider_media_type=tracking_media_type,
         season_number=season_number,
+        retry_max_retries=provider_link_retry_max_retries,
     )
 
     if source == Sources.TMDB.value and tracking_media_type in (

--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -337,13 +337,14 @@ def _invalidate_history_for_media_change(
     if not normalized_day_keys:
         return
 
+    invalidate_kwargs = {"force": True} if force else {}
     history_cache.invalidate_history_days(
         user_id,
         day_keys=normalized_day_keys,
         logging_styles=logging_styles,
         reason=reason,
-        force=force,
         refresh_index=not prioritized,
+        **invalidate_kwargs,
     )
     if not prioritized:
         return
@@ -374,24 +375,7 @@ def _schedule_statistics_refresh_for_media_change(
     statistics_cache.schedule_all_ranges_refresh(user_id)
 
 
-def _handle_media_cache_change(
-    user_id: int | None,
-    changed_media_type: str,
-    *,
-    reason: str,
-    history_specs=None,
-    statistics_day_values=None,
-    schedule_statistics: bool = True,
-    force_history_days: bool = False,
-) -> None:
-    if not user_id:
-        return
-    if (
-        media_cache_change_signals_suppressed()
-        or media_change_side_effects_suppressed()
-    ):
-        return
-
+def _clear_media_runtime_caches(user_id: int, changed_media_type: str) -> None:
     from app.cache_utils import (
         clear_home_row_cache_for_user,
         clear_media_list_cache_for_user,
@@ -405,9 +389,30 @@ def _handle_media_cache_change(
         MediaTypes.SEASON.value,
         MediaTypes.TV.value,
     ):
-        # The time_left sort order depends on watched episodes; keep its
-        # cache in sync with TV-family changes made outside the save views.
         clear_time_left_cache_for_user(user_id)
+
+
+def _handle_media_cache_change(
+    user_id: int | None,
+    changed_media_type: str,
+    *,
+    reason: str,
+    history_specs=None,
+    statistics_day_values=None,
+    schedule_statistics: bool = True,
+    force_history_days: bool = False,
+    clear_runtime_caches: bool = True,
+) -> None:
+    if not user_id:
+        return
+    if (
+        media_cache_change_signals_suppressed()
+        or media_change_side_effects_suppressed()
+    ):
+        return
+
+    if clear_runtime_caches:
+        _clear_media_runtime_caches(user_id, changed_media_type)
 
     active_context = discover_tab_cache.get_active_context(user_id)
     targets = discover_tab_cache.invalidate_for_media_change(
@@ -661,6 +666,7 @@ def _invalidate_episode_history_changes(changes):
             history_specs=[(day_keys, ("sessions", "repeats"))],
             statistics_day_values=day_keys,
             force_history_days=True,
+            clear_runtime_caches=False,
         )
 
 
@@ -698,6 +704,8 @@ def refresh_history_cache_on_episode_save(sender, instance, **kwargs):
     if hasattr(instance, "_previous_history_identity"):
         delattr(instance, "_previous_history_identity")
     user_id = getattr(getattr(instance, "related_season", None), "user_id", None)
+    if user_id:
+        _clear_media_runtime_caches(user_id, MediaTypes.EPISODE.value)
     day_key = history_cache.history_day_key(getattr(instance, "end_date", None))
     changes = {}
     for changed_user_id, changed_day_key in (
@@ -727,6 +735,8 @@ def refresh_history_cache_on_episode_delete(sender, instance, **kwargs):
     ):
         return
     user_id = getattr(getattr(instance, "related_season", None), "user_id", None)
+    if user_id:
+        _clear_media_runtime_caches(user_id, MediaTypes.EPISODE.value)
     day_key = history_cache.history_day_key(getattr(instance, "end_date", None))
     changes = {user_id: [day_key]} if user_id and day_key else {}
     transaction.on_commit(

--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -656,8 +656,11 @@ def refresh_discover_cache_on_item_person_credit_change(sender, instance, **kwar
         discover_tab_cache.invalidate_for_media_change(user_id, media_type)
 
 
-def _invalidate_episode_history_changes(changes):
-    """Invalidate committed Episode activity days grouped by owner."""
+def _invalidate_episode_history_changes(changes, runtime_user_ids=()):
+    """Invalidate committed Episode history and runtime caches by owner."""
+    for user_id in runtime_user_ids:
+        _clear_media_runtime_caches(user_id, MediaTypes.EPISODE.value)
+
     for user_id, day_keys in changes.items():
         _handle_media_cache_change(
             user_id,
@@ -704,8 +707,6 @@ def refresh_history_cache_on_episode_save(sender, instance, **kwargs):
     if hasattr(instance, "_previous_history_identity"):
         delattr(instance, "_previous_history_identity")
     user_id = getattr(getattr(instance, "related_season", None), "user_id", None)
-    if user_id:
-        _clear_media_runtime_caches(user_id, MediaTypes.EPISODE.value)
     day_key = history_cache.history_day_key(getattr(instance, "end_date", None))
     changes = {}
     for changed_user_id, changed_day_key in (
@@ -718,8 +719,18 @@ def refresh_history_cache_on_episode_save(sender, instance, **kwargs):
         if changed_user_id and changed_day_key:
             changes.setdefault(changed_user_id, set()).add(changed_day_key)
     committed_changes = {user: sorted(days) for user, days in changes.items()}
+    runtime_user_ids = sorted(
+        {
+            changed_user_id
+            for changed_user_id in (previous[0] if previous else None, user_id)
+            if changed_user_id
+        },
+    )
     transaction.on_commit(
-        lambda: _invalidate_episode_history_changes(committed_changes),
+        lambda: _invalidate_episode_history_changes(
+            committed_changes,
+            runtime_user_ids,
+        ),
         using=kwargs.get("using"),
     )
 
@@ -735,12 +746,14 @@ def refresh_history_cache_on_episode_delete(sender, instance, **kwargs):
     ):
         return
     user_id = getattr(getattr(instance, "related_season", None), "user_id", None)
-    if user_id:
-        _clear_media_runtime_caches(user_id, MediaTypes.EPISODE.value)
     day_key = history_cache.history_day_key(getattr(instance, "end_date", None))
     changes = {user_id: [day_key]} if user_id and day_key else {}
+    runtime_user_ids = [user_id] if user_id else []
     transaction.on_commit(
-        lambda changes=changes: _invalidate_episode_history_changes(changes),
+        lambda changes=changes: _invalidate_episode_history_changes(
+            changes,
+            runtime_user_ids,
+        ),
         using=kwargs.get("using"),
     )
 
@@ -1140,7 +1153,7 @@ def schedule_runtime_backfill_on_item_save(
 
     Also invalidates time_left cache when episode runtime changes.
     """
-    if kwargs.get("raw"):
+    if kwargs.get("raw") or media_change_side_effects_suppressed():
         return
 
     # Check if runtime_minutes was actually updated (not just saving the same value)

--- a/src/app/tests/models/test_anime_completion_migrates.py
+++ b/src/app/tests/models/test_anime_completion_migrates.py
@@ -99,7 +99,6 @@ class AnimeCompletionAutoMigrateTests(TestCase):
         # Drive the real migration (only the provider/network calls are stubbed)
         # to prove completion produces actual Episode watch records.
         from app.models import Episode
-        from app.services.tracking_hydration import HydratedItemResult
 
         anime = self._make()
 
@@ -107,6 +106,7 @@ class AnimeCompletionAutoMigrateTests(TestCase):
             media_id="275798",
             source=Sources.TVDB.value,
             media_type=MediaTypes.TV.value,
+            library_media_type=MediaTypes.ANIME.value,
             title="Fate/Zero",
         )
         season_meta = {
@@ -154,18 +154,6 @@ class AnimeCompletionAutoMigrateTests(TestCase):
                     ],
                 ),
             )
-            stack.enter_context(
-                patch(
-                    "app.services.anime_migration.ensure_item_metadata",
-                    return_value=HydratedItemResult(
-                        item=tv_item, metadata={"title": "Fate/Zero"}, created=False
-                    ),
-                ),
-            )
-            stack.enter_context(
-                patch("app.services.anime_migration.upsert_provider_links"),
-            )
-
             anime.status = Status.COMPLETED.value
             anime.save()
 

--- a/src/app/tests/test_anime_migration.py
+++ b/src/app/tests/test_anime_migration.py
@@ -22,7 +22,6 @@ from app.models import (
     Status,
 )
 from app.services import anime_migration
-from app.services.tracking_hydration import HydratedItemResult
 
 
 class AnimeMigrationTests(TestCase):
@@ -71,10 +70,8 @@ class AnimeMigrationTests(TestCase):
     @patch("app.services.anime_migration.anime_mapping.find_entries_for_mal_id")
     @patch("app.services.anime_migration.anime_mapping.resolve_provider_series_id")
     @patch("app.services.anime_migration.services.get_media_metadata")
-    @patch("app.services.anime_migration.ensure_item_metadata")
     def test_migrate_flat_anime_to_grouped_series(
         self,
-        mock_ensure_item_metadata,
         mock_get_media_metadata,
         mock_resolve_provider_series_id,
         mock_find_entries_for_mal_id,
@@ -89,20 +86,6 @@ class AnimeMigrationTests(TestCase):
                 "tvdb_epoffset": 0,
             },
         ]
-        mock_ensure_item_metadata.return_value = HydratedItemResult(
-            item=self.grouped_item,
-            metadata={
-                "media_id": "9350138",
-                "source": Sources.TVDB.value,
-                "media_type": MediaTypes.ANIME.value,
-                "identity_media_type": MediaTypes.TV.value,
-                "library_media_type": MediaTypes.ANIME.value,
-                "title": "Frieren: Beyond Journey's End",
-                "image": "https://example.com/grouped.jpg",
-                "related": {"seasons": [{"season_number": 1}]},
-            },
-            created=False,
-        )
         mock_get_media_metadata.return_value = {
             "related": {"seasons": [{"season_number": 1}]},
             "season/1": {
@@ -175,10 +158,8 @@ class AnimeMigrationTests(TestCase):
     @patch("app.services.anime_migration.anime_mapping.find_entries_for_mal_id")
     @patch("app.services.anime_migration.anime_mapping.resolve_provider_series_id")
     @patch("app.services.anime_migration.services.get_media_metadata")
-    @patch("app.services.anime_migration.ensure_item_metadata")
     def test_grouped_anime_progress_appears_in_warm_history_immediately(
         self,
-        mock_ensure_item_metadata,
         mock_get_media_metadata,
         mock_resolve_provider_series_id,
         mock_find_entries_for_mal_id,
@@ -229,21 +210,6 @@ class AnimeMigrationTests(TestCase):
                 "tvdb_epoffset": 0,
             },
         ]
-        mock_ensure_item_metadata.return_value = HydratedItemResult(
-            item=self.grouped_item,
-            metadata={
-                "media_id": "9350138",
-                "source": Sources.TVDB.value,
-                "media_type": MediaTypes.ANIME.value,
-                "identity_media_type": MediaTypes.TV.value,
-                "library_media_type": MediaTypes.ANIME.value,
-                "title": "Frieren: Beyond Journey's End",
-                "image": "https://example.com/grouped.jpg",
-                "related": {"seasons": [{"season_number": 1}]},
-            },
-            created=False,
-        )
-
         def media_metadata(media_type, *_args, **_kwargs):
             if media_type == MediaTypes.SEASON.value:
                 return {
@@ -251,7 +217,7 @@ class AnimeMigrationTests(TestCase):
                     "episodes": episodes,
                     "max_progress": 3,
                 }
-            if media_type == MediaTypes.TV.value:
+            if media_type in {MediaTypes.ANIME.value, MediaTypes.TV.value}:
                 return {
                     "max_progress": 3,
                     "related": {"seasons": [{"season_number": 1}]},
@@ -414,10 +380,8 @@ class AnimeMigrationTests(TestCase):
     @patch("app.services.anime_migration.anime_mapping.find_entries_for_mal_id")
     @patch("app.services.anime_migration.anime_mapping.resolve_provider_series_id")
     @patch("app.services.anime_migration.services.get_media_metadata")
-    @patch("app.services.anime_migration.ensure_item_metadata")
     def test_migration_blocks_when_progress_exceeds_mapped_season(
         self,
-        mock_ensure_item_metadata,
         mock_get_media_metadata,
         mock_resolve_provider_series_id,
         mock_find_entries_for_mal_id,
@@ -434,20 +398,6 @@ class AnimeMigrationTests(TestCase):
                 "tvdb_epoffset": 0,
             },
         ]
-        mock_ensure_item_metadata.return_value = HydratedItemResult(
-            item=self.grouped_item,
-            metadata={
-                "media_id": "9350138",
-                "source": Sources.TVDB.value,
-                "media_type": MediaTypes.ANIME.value,
-                "identity_media_type": MediaTypes.TV.value,
-                "library_media_type": MediaTypes.ANIME.value,
-                "title": "Frieren: Beyond Journey's End",
-                "image": "https://example.com/grouped.jpg",
-                "related": {"seasons": [{"season_number": 1}]},
-            },
-            created=False,
-        )
         mock_get_media_metadata.return_value = {
             "related": {"seasons": [{"season_number": 1}]},
             "season/1": {

--- a/src/app/tests/test_anime_migration_atomicity.py
+++ b/src/app/tests/test_anime_migration_atomicity.py
@@ -4,17 +4,21 @@ from unittest import skipUnless
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.db import close_old_connections, connection
 from django.db.utils import OperationalError
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
 
+from app import cache_utils
 from app.models import (
     TV,
     Anime,
     Episode,
     Item,
+    ItemPersonCredit,
     ItemProviderLink,
+    ItemStudioCredit,
     MediaTypes,
     MetadataProviderPreference,
     Season,
@@ -22,12 +26,15 @@ from app.models import (
     Status,
 )
 from app.services import anime_migration
+from lists.models import CustomList
 
 
 class AnimeMigrationAtomicityTests(TransactionTestCase):
     reset_sequences = True
 
     def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
         self.user = get_user_model().objects.create_user(username="atomic-migrate")
         self.flat_item = Item.objects.create(
             media_id="52991",
@@ -77,6 +84,19 @@ class AnimeMigrationAtomicityTests(TransactionTestCase):
         for provider_patch in self.provider_patches:
             provider_patch.start()
             self.addCleanup(provider_patch.stop)
+        for task_patch in (
+            patch(
+                "app.signals.discover_tab_cache.schedule_tab_refresh",
+                return_value=True,
+            ),
+            patch(
+                "app.history_cache_lifecycle.schedule_history_refresh",
+                return_value=True,
+            ),
+            patch("app.signals.statistics_cache.schedule_all_ranges_refresh"),
+        ):
+            task_patch.start()
+            self.addCleanup(task_patch.stop)
 
     def _metadata(self, media_type, *_args, **_kwargs):
         episodes = [
@@ -178,6 +198,118 @@ class AnimeMigrationAtomicityTests(TransactionTestCase):
         invalidate.assert_called_once()
         self.assertEqual(set(invalidate.call_args.args[0]), {self.user.id})
 
+    @override_settings(TESTING=False)
+    def test_item_backfills_are_not_enqueued_inside_transaction(self):
+        self.grouped_item.delete()
+        preflight = self._preflight()
+
+        with (
+            patch("app.tasks.enqueue_runtime_backfill_items") as runtime_backfill,
+            patch("app.tasks.enqueue_episode_runtime_backfill") as episode_backfill,
+            patch("app.tasks.enqueue_genre_backfill_items") as genre_backfill,
+            patch("app.tasks.enqueue_credits_backfill_items") as credits_backfill,
+        ):
+            anime_migration.persist_flat_anime_migration(preflight)
+
+        runtime_backfill.assert_not_called()
+        episode_backfill.assert_not_called()
+        genre_backfill.assert_not_called()
+        credits_backfill.assert_not_called()
+
+    def test_absent_target_preserves_metadata_external_ids_and_credits(self):
+        self.grouped_item.delete()
+        mapping = {
+            **self.mapping,
+            "tmdb_show_id": "209867",
+            "tmdb_season": 1,
+            "tmdb_epoffset": 0,
+        }
+        rich_metadata = {
+            "title": "Frieren: Beyond Journey's End",
+            "image": "https://example.com/grouped.jpg",
+            "genres": ["Animation", "Drama"],
+            "details": {
+                "runtime": "24 min",
+                "country": "JP",
+                "languages": ["ja"],
+                "studios": ["Madhouse"],
+            },
+            "provider_external_ids": {
+                "tmdb_id": "209867",
+                "tvdb_id": "9350138",
+            },
+            "cast": [
+                {
+                    "id": "1",
+                    "name": "Voice Actor",
+                    "character": "Frieren",
+                }
+            ],
+            "crew": [],
+            "studios_full": [{"id": "2", "name": "Madhouse"}],
+        }
+
+        def metadata(media_type, *_args, **_kwargs):
+            if media_type == MediaTypes.ANIME.value:
+                return rich_metadata
+            return self._metadata(media_type)
+
+        with (
+            patch(
+                "app.services.anime_migration.anime_mapping.resolve_provider_series_id",
+                return_value="209867",
+            ),
+            patch(
+                "app.services.anime_migration.anime_mapping.find_entries_for_mal_id",
+                return_value=[mapping],
+            ),
+            patch(
+                "app.services.anime_migration.services.get_media_metadata",
+                side_effect=metadata,
+            ),
+            patch(
+                "app.services.anime_migration.providers.tmdb.get_tvdb_episode_image_map",
+                return_value={},
+            ),
+        ):
+            preflight = anime_migration.preflight_flat_anime_to_grouped(
+                self.user,
+                self.flat_item,
+                Sources.TMDB.value,
+            )
+
+        with (
+            patch(
+                "app.services.anime_migration.services.get_media_metadata",
+                side_effect=AssertionError("provider call inside persistence"),
+            ),
+            patch(
+                "app.services.anime_migration.providers.tmdb.get_tvdb_episode_image_map",
+                side_effect=AssertionError("provider call inside persistence"),
+            ),
+        ):
+            result = anime_migration.persist_flat_anime_migration(preflight)
+
+        grouped_item = result.grouped_tv.item
+        self.assertEqual(grouped_item.runtime_minutes, 24)
+        self.assertEqual(grouped_item.genres, ["Animation", "Drama"])
+        self.assertEqual(grouped_item.country, "JP")
+        self.assertEqual(grouped_item.languages, ["ja"])
+        self.assertEqual(grouped_item.studios, ["Madhouse"])
+        self.assertEqual(
+            grouped_item.provider_external_ids,
+            {"tmdb_id": "209867", "tvdb_id": "9350138"},
+        )
+        self.assertTrue(
+            ItemProviderLink.objects.filter(
+                item=grouped_item,
+                provider=Sources.TVDB.value,
+                provider_media_id="9350138",
+            ).exists()
+        )
+        self.assertEqual(ItemPersonCredit.objects.filter(item=grouped_item).count(), 1)
+        self.assertEqual(ItemStudioCredit.objects.filter(item=grouped_item).count(), 1)
+
     def test_late_failure_rolls_back_every_migration_write(self):
         preflight = self._preflight()
         before = self._table_snapshot()
@@ -188,11 +320,16 @@ class AnimeMigrationAtomicityTests(TransactionTestCase):
                 "update_or_create",
                 side_effect=RuntimeError("late failure"),
             ),
+            patch.object(
+                anime_migration,
+                "_reconcile_committed_migration",
+            ) as reconcile,
             self.assertRaisesRegex(RuntimeError, "late failure"),
         ):
             anime_migration.persist_flat_anime_migration(preflight)
 
         self.assertEqual(self._table_snapshot(), before)
+        reconcile.assert_not_called()
 
     def test_retry_after_lock_uses_fresh_transaction(self):
         preflight = self._preflight()
@@ -243,6 +380,88 @@ class AnimeMigrationAtomicityTests(TransactionTestCase):
             ).state,
             anime_migration.AnimeMigrationState.COMPLETE,
         )
+
+    def test_cross_provider_retry_returns_existing_completed_target(self):
+        mapping = {
+            **self.mapping,
+            "tmdb_show_id": "209867",
+            "tmdb_season": 1,
+            "tmdb_epoffset": 0,
+        }
+
+        def resolve(_mal_id, provider):
+            return "9350138" if provider == Sources.TVDB.value else "209867"
+
+        with (
+            patch(
+                "app.services.anime_migration.anime_mapping.resolve_provider_series_id",
+                side_effect=resolve,
+            ),
+            patch(
+                "app.services.anime_migration.anime_mapping.find_entries_for_mal_id",
+                return_value=[mapping],
+            ),
+            patch(
+                "app.services.anime_migration.providers.tmdb.get_tvdb_episode_image_map",
+                return_value={},
+            ),
+        ):
+            tvdb_preflight = anime_migration.preflight_flat_anime_to_grouped(
+                self.user,
+                self.flat_item,
+                Sources.TVDB.value,
+            )
+            tmdb_preflight = anime_migration.preflight_flat_anime_to_grouped(
+                self.user,
+                self.flat_item,
+                Sources.TMDB.value,
+            )
+            tvdb_result = anime_migration.persist_flat_anime_migration(
+                tvdb_preflight
+            )
+            tmdb_result = anime_migration.persist_flat_anime_migration(
+                tmdb_preflight
+            )
+            completed = anime_migration.preflight_flat_anime_to_grouped(
+                self.user,
+                self.flat_item,
+                Sources.TMDB.value,
+            )
+
+        self.assertEqual(tmdb_result.grouped_tv.id, tvdb_result.grouped_tv.id)
+        self.assertEqual(completed.state, anime_migration.AnimeMigrationState.COMPLETE)
+        self.assertEqual(completed.completed_target_item_id, self.grouped_item.id)
+        self.assertEqual(TV.objects.count(), 1)
+        self.assertEqual(Episode.objects.count(), 2)
+
+    def test_commit_reconciles_warm_caches_and_smart_lists_once(self):
+        warm_keys = {
+            "media": "anime-migration-media-cache",
+            "home": "anime-migration-home-cache",
+            "time": "anime-migration-time-cache",
+        }
+        for key in warm_keys.values():
+            cache.set(key, {"stale": True})
+        cache_utils.register_media_list_cache_key(self.user.id, warm_keys["media"])
+        cache_utils.register_home_row_cache_key(self.user.id, warm_keys["home"])
+        cache_utils.register_time_left_cache_key(self.user.id, warm_keys["time"])
+        smart_list = CustomList.objects.create(
+            owner=self.user,
+            name="All tracked media",
+            is_smart=True,
+        )
+
+        with patch.object(
+            anime_migration,
+            "_reconcile_committed_migration",
+            wraps=anime_migration._reconcile_committed_migration,
+        ) as reconcile:
+            result = anime_migration.persist_flat_anime_migration(self._preflight())
+
+        reconcile.assert_called_once()
+        for key in warm_keys.values():
+            self.assertIsNone(cache.get(key))
+        self.assertTrue(smart_list.items.filter(pk=result.grouped_tv.item_id).exists())
 
     def test_stale_preflight_aborts_without_mutation(self):
         preflight = self._preflight()

--- a/src/app/tests/test_anime_migration_atomicity.py
+++ b/src/app/tests/test_anime_migration_atomicity.py
@@ -1,0 +1,367 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from unittest import skipUnless
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.db import close_old_connections, connection
+from django.db.utils import OperationalError
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from app.models import (
+    TV,
+    Anime,
+    Episode,
+    Item,
+    ItemProviderLink,
+    MediaTypes,
+    MetadataProviderPreference,
+    Season,
+    Sources,
+    Status,
+)
+from app.services import anime_migration
+
+
+class AnimeMigrationAtomicityTests(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="atomic-migrate")
+        self.flat_item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+            image="https://example.com/frieren.jpg",
+        )
+        self.flat_entry = Anime.objects.create(
+            item=self.flat_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=2,
+            score=9,
+            notes="Great adaptation",
+            start_date=timezone.now(),
+            end_date=timezone.now(),
+        )
+        self.grouped_item = Item.objects.create(
+            media_id="9350138",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            library_media_type=MediaTypes.ANIME.value,
+            title="Frieren: Beyond Journey's End",
+            image="https://example.com/grouped.jpg",
+        )
+        self.mapping = {
+            "mal_id": "52991",
+            "tvdb_id": "9350138",
+            "tvdb_season": 1,
+            "tvdb_epoffset": 0,
+        }
+        self.provider_patches = (
+            patch(
+                "app.services.anime_migration.anime_mapping.resolve_provider_series_id",
+                return_value="9350138",
+            ),
+            patch(
+                "app.services.anime_migration.anime_mapping.find_entries_for_mal_id",
+                return_value=[self.mapping],
+            ),
+            patch(
+                "app.services.anime_migration.services.get_media_metadata",
+                side_effect=self._metadata,
+            ),
+        )
+        for provider_patch in self.provider_patches:
+            provider_patch.start()
+            self.addCleanup(provider_patch.stop)
+
+    def _metadata(self, media_type, *_args, **_kwargs):
+        episodes = [
+            {"episode_number": 1, "air_date": "2023-09-29", "runtime": 24},
+            {"episode_number": 2, "air_date": "2023-10-06", "runtime": 24},
+            {"episode_number": 3, "air_date": "2023-10-13", "runtime": 24},
+        ]
+        if media_type == MediaTypes.ANIME.value:
+            return {
+                "title": "Frieren: Beyond Journey's End",
+                "image": "https://example.com/grouped.jpg",
+                "related": {"seasons": [{"season_number": 1}]},
+            }
+        if media_type == "tv_with_seasons":
+            return {
+                "related": {"seasons": [{"season_number": 1}]},
+                "season/1": {
+                    "title": "Frieren: Beyond Journey's End",
+                    "image": "https://example.com/season1.jpg",
+                    "season_number": 1,
+                    "episodes": episodes,
+                },
+            }
+        raise AssertionError(f"Unexpected provider request: {media_type}")
+
+    def _preflight(self):
+        return anime_migration.preflight_flat_anime_to_grouped(
+            self.user,
+            self.flat_item,
+            Sources.TVDB.value,
+        )
+
+    def _table_snapshot(self):
+        return {
+            "items": list(Item.objects.order_by("id").values()),
+            "tv": list(TV.objects.order_by("id").values()),
+            "seasons": list(Season.objects.order_by("id").values()),
+            "episodes": list(Episode.objects.order_by("id").values()),
+            "links": list(ItemProviderLink.objects.order_by("id").values()),
+            "preferences": list(
+                MetadataProviderPreference.objects.order_by("id").values()
+            ),
+            "anime": list(Anime.all_objects.order_by("id").values()),
+            "historical_tv": list(TV.history.order_by("history_id").values()),
+            "historical_seasons": list(
+                Season.history.order_by("history_id").values()
+            ),
+            "historical_episodes": list(
+                Episode.history.order_by("history_id").values()
+            ),
+        }
+
+    def test_preflight_is_immutable_and_does_not_write_tables(self):
+        before = self._table_snapshot()
+
+        preflight = self._preflight()
+
+        self.assertEqual(preflight.state, anime_migration.AnimeMigrationState.READY)
+        self.assertEqual(self._table_snapshot(), before)
+        with self.assertRaises(TypeError):
+            preflight.series_metadata["title"] = "Changed"
+        with self.assertRaises(TypeError):
+            preflight.entries[0].season_metadata["episodes"] = []
+
+    def test_persistence_makes_no_provider_or_episode_save_call(self):
+        preflight = self._preflight()
+
+        with (
+            patch(
+                "app.services.anime_migration.services.get_media_metadata",
+                side_effect=AssertionError("provider call inside persistence"),
+            ),
+            patch(
+                "app.services.anime_migration.providers.tmdb.get_tvdb_episode_image_map",
+                side_effect=AssertionError("provider call inside persistence"),
+            ),
+            patch(
+                "app.services.anime_migration.anime_mapping.resolve_provider_series_id",
+                side_effect=AssertionError("mapping call inside persistence"),
+            ),
+            patch(
+                "app.services.anime_migration.anime_mapping.find_entries_for_mal_id",
+                side_effect=AssertionError("mapping call inside persistence"),
+            ),
+            patch.object(
+                Episode,
+                "save",
+                side_effect=AssertionError("Episode.save inside persistence"),
+            ),
+            patch.object(
+                anime_migration.signals,
+                "_invalidate_episode_history_changes",
+            ) as invalidate,
+        ):
+            result = anime_migration.persist_flat_anime_migration(preflight)
+
+        self.assertEqual(result.grouped_tv.item_id, self.grouped_item.id)
+        self.assertEqual(Episode.objects.count(), 2)
+        invalidate.assert_called_once()
+        self.assertEqual(set(invalidate.call_args.args[0]), {self.user.id})
+
+    def test_late_failure_rolls_back_every_migration_write(self):
+        preflight = self._preflight()
+        before = self._table_snapshot()
+
+        with (
+            patch.object(
+                MetadataProviderPreference.objects,
+                "update_or_create",
+                side_effect=RuntimeError("late failure"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "late failure"),
+        ):
+            anime_migration.persist_flat_anime_migration(preflight)
+
+        self.assertEqual(self._table_snapshot(), before)
+
+    def test_retry_after_lock_uses_fresh_transaction(self):
+        preflight = self._preflight()
+        persist_once = anime_migration._persist_preflight_once
+        attempts = 0
+
+        def locked_once(payload):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OperationalError("database is locked")
+            return persist_once(payload)
+
+        with patch.object(
+            anime_migration,
+            "_persist_preflight_once",
+            side_effect=locked_once,
+        ):
+            result = anime_migration.persist_flat_anime_migration(preflight)
+
+        self.assertEqual(attempts, 2)
+        self.assertEqual(result.grouped_tv.item_id, self.grouped_item.id)
+        self.assertEqual(Episode.objects.count(), 2)
+
+    def test_completed_retry_is_a_noop(self):
+        first = anime_migration.migrate_flat_anime_to_grouped(
+            self.user,
+            self.flat_item,
+            Sources.TVDB.value,
+        )
+        first_episode_ids = list(Episode.objects.values_list("id", flat=True))
+
+        second = anime_migration.migrate_flat_anime_to_grouped(
+            self.user,
+            self.flat_item,
+            Sources.TVDB.value,
+        )
+
+        self.assertEqual(second.grouped_tv.id, first.grouped_tv.id)
+        self.assertEqual(
+            list(Episode.objects.values_list("id", flat=True)), first_episode_ids
+        )
+        self.assertEqual(
+            anime_migration.preflight_flat_anime_to_grouped(
+                self.user,
+                self.flat_item,
+                Sources.TVDB.value,
+            ).state,
+            anime_migration.AnimeMigrationState.COMPLETE,
+        )
+
+    def test_stale_preflight_aborts_without_mutation(self):
+        preflight = self._preflight()
+        Anime.all_objects.filter(pk=self.flat_entry.pk).update(progress=1)
+
+        with self.assertRaises(anime_migration.AnimeMigrationError) as raised:
+            anime_migration.persist_flat_anime_migration(preflight)
+
+        self.assertEqual(raised.exception.state, anime_migration.AnimeMigrationState.STALE)
+        self.assertEqual(raised.exception.code, anime_migration.STALE_CODE)
+        self.assertFalse(TV.objects.exists())
+        self.assertFalse(Episode.objects.exists())
+
+    def test_inconsistent_marker_is_provably_partial_and_not_repaired(self):
+        Anime.all_objects.filter(pk=self.flat_entry.pk).update(
+            migrated_to_item=self.grouped_item,
+            migrated_at=None,
+        )
+        before = self._table_snapshot()
+
+        with self.assertRaises(anime_migration.AnimeMigrationError) as raised:
+            self._preflight()
+
+        self.assertEqual(
+            raised.exception.state,
+            anime_migration.AnimeMigrationState.PROVABLY_PARTIAL,
+        )
+        self.assertEqual(raised.exception.code, anime_migration.PARTIAL_CODE)
+        self.assertEqual(self._table_snapshot(), before)
+
+    def test_grouped_rewatches_are_ambiguous_and_preserved(self):
+        grouped_tv = TV.objects.create(
+            item=self.grouped_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="9350138",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            library_media_type=MediaTypes.ANIME.value,
+            season_number=1,
+            title="Frieren",
+            image="https://example.com/season.jpg",
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=grouped_tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.create(
+            media_id="9350138",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.ANIME.value,
+            season_number=1,
+            episode_number=1,
+            title="Episode 1",
+            image="https://example.com/episode.jpg",
+        )
+        Episode.objects.bulk_create(
+            [
+                Episode(item=episode_item, related_season=season, end_date=timezone.now()),
+                Episode(item=episode_item, related_season=season, end_date=timezone.now()),
+            ]
+        )
+        before = self._table_snapshot()
+
+        with self.assertRaises(anime_migration.AnimeMigrationError) as raised:
+            self._preflight()
+
+        self.assertEqual(
+            raised.exception.state,
+            anime_migration.AnimeMigrationState.AMBIGUOUS,
+        )
+        self.assertEqual(raised.exception.code, anime_migration.AMBIGUOUS_CODE)
+        self.assertEqual(self._table_snapshot(), before)
+
+    def _concurrent_submit(self, preflight):
+        barrier = Barrier(2)
+
+        def migrate():
+            close_old_connections()
+            try:
+                barrier.wait(timeout=5)
+                return anime_migration.persist_flat_anime_migration(preflight)
+            finally:
+                close_old_connections()
+
+        with (
+            patch.object(
+                signals := anime_migration.signals,
+                "_invalidate_episode_history_changes",
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            results = list(executor.map(lambda _index: migrate(), range(2)))
+        self.assertIsNotNone(signals)
+        return results
+
+    @skipUnless(connection.vendor == "sqlite", "SQLite concurrency coverage")
+    def test_sqlite_double_submit_returns_one_completed_migration(self):
+        results = self._concurrent_submit(self._preflight())
+
+        self.assertEqual(
+            {result.grouped_tv.id for result in results},
+            {results[0].grouped_tv.id},
+        )
+        self.assertEqual(TV.objects.count(), 1)
+        self.assertEqual(Episode.objects.count(), 2)
+
+    @skipUnless(connection.vendor == "postgresql", "PostgreSQL locking coverage")
+    def test_postgresql_double_submit_waits_on_source_row_lock(self):
+        results = self._concurrent_submit(self._preflight())
+
+        self.assertEqual(
+            {result.grouped_tv.id for result in results},
+            {results[0].grouped_tv.id},
+        )
+        self.assertEqual(TV.objects.count(), 1)
+        self.assertEqual(Episode.objects.count(), 2)

--- a/src/app/tests/test_episode_history_invalidation.py
+++ b/src/app/tests/test_episode_history_invalidation.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.test import TransactionTestCase
 from django.utils import timezone
 
-from app import history_cache, signals
+from app import cache_utils, history_cache, signals
 from app.models import TV, Episode, Item, MediaTypes, Season, Sources, Status
 
 
@@ -91,6 +91,29 @@ class EpisodeHistoryInvalidationTests(TransactionTestCase):
         cache.clear()
         self.logging_style = "repeats"
 
+    def _warm_runtime_caches(self, user, payload=None):
+        payload = payload or {"owner": user.id}
+        keys = {
+            "media": f"episode-runtime-media-{user.id}",
+            "home": f"episode-runtime-home-{user.id}",
+            "time": f"episode-runtime-time-{user.id}",
+        }
+        for key in keys.values():
+            cache.set(key, payload)
+        cache_utils.register_media_list_cache_key(user.id, keys["media"])
+        cache_utils.register_home_row_cache_key(user.id, keys["home"])
+        cache_utils.register_time_left_cache_key(user.id, keys["time"])
+        return keys, payload
+
+    def _assert_runtime_cache_values(self, keys, expected):
+        for key in keys.values():
+            self.assertEqual(cache.get(key), expected)
+
+    def _assert_runtime_caches_cleared(self, *key_groups):
+        for keys in key_groups:
+            for key in keys.values():
+                self.assertIsNone(cache.get(key))
+
     def _warm_old_and_new_days(self):
         history_cache.refresh_history_cache(
             self.user.id,
@@ -163,6 +186,54 @@ class EpisodeHistoryInvalidationTests(TransactionTestCase):
         self.assertIsNone(cache.get(old_key))
         self.assertIsNone(cache.get(new_key))
         self._assert_current_history()
+
+    def test_moving_episode_clears_runtime_caches_for_old_and_new_owners(self):
+        other_user = get_user_model().objects.create_user(username="history-move-to")
+        current_season = self.episode.related_season
+        other_tv = TV.objects.create(
+            item=current_season.related_tv.item,
+            user=other_user,
+            status=Status.IN_PROGRESS.value,
+        )
+        other_season = Season.objects.create(
+            item=current_season.item,
+            user=other_user,
+            related_tv=other_tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        old_owner_keys, _payload = self._warm_runtime_caches(self.user)
+        new_owner_keys, _payload = self._warm_runtime_caches(other_user)
+
+        self.episode.related_season = other_season
+        self.episode.save(update_fields=["related_season"])
+
+        self._assert_runtime_caches_cleared(old_owner_keys, new_owner_keys)
+
+    def test_outer_transaction_commit_clears_repopulated_runtime_caches(self):
+        keys, _payload = self._warm_runtime_caches(self.user)
+        repopulated = {"uncommitted": True}
+
+        with transaction.atomic():
+            self.episode.end_date = self.new_date
+            self.episode.save(update_fields=["end_date"])
+            for key in keys.values():
+                cache.set(key, repopulated)
+            self._assert_runtime_cache_values(keys, repopulated)
+
+        self._assert_runtime_caches_cleared(keys)
+
+    def test_outer_transaction_rollback_keeps_committed_runtime_cache_visible(self):
+        keys, committed_payload = self._warm_runtime_caches(self.user)
+
+        with self.assertRaises(RuntimeError), transaction.atomic():
+            self.episode.end_date = self.new_date
+            self.episode.save(update_fields=["end_date"])
+            self._assert_runtime_cache_values(keys, committed_payload)
+            raise RuntimeError("roll back episode change")
+
+        self.episode.refresh_from_db()
+        self.assertEqual(self.episode.end_date, self.old_date)
+        self._assert_runtime_cache_values(keys, committed_payload)
 
     @patch("app.signals._invalidate_episode_history_changes")
     def test_bulk_suppression_prevents_deferred_episode_invalidation(

--- a/src/app/tests/test_statistics.py
+++ b/src/app/tests/test_statistics.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase, tag
 from django.urls import reverse
 from django.utils import timezone
@@ -1339,6 +1340,7 @@ class ConsumptionStatisticsTests(TestCase):
             status=Status.COMPLETED.value,
             end_date=now - datetime.timedelta(hours=6),
         )
+        cache.clear()
 
     @tag("network")
     def test_consumption_stats_aggregation(self):

--- a/src/app/tests/views/test_crud.py
+++ b/src/app/tests/views/test_crud.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from types import SimpleNamespace
 from unittest.mock import patch
+from uuid import UUID, uuid4
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -693,6 +694,7 @@ class CreateMedia(TestCase):
         )
         self.assertEqual(create_response.status_code, 302)
 
+        watch_operation_id = uuid4()
         response = self.client.post(
             f"{reverse('episode_save')}?next=/details/tmdb/tv/1668/friends/season/1",
             {
@@ -701,6 +703,7 @@ class CreateMedia(TestCase):
                 "episode_number": 1,
                 "source": Sources.TMDB.value,
                 "end_date": "2023-06-02",
+                "watch_operation_id": watch_operation_id,
             },
             HTTP_HX_REQUEST="true",
         )
@@ -713,7 +716,9 @@ class CreateMedia(TestCase):
         self.assertContains(response, "season-progress-mobile-", html=False)
         self.assertContains(response, "season-progress-desktop-", html=False)
         trigger = json.loads(response["HX-Trigger"])
-        self.assertEqual(trigger["closeModal"], {})
+        returned_token = trigger["closeModal"]["watchOperationId"]
+        self.assertEqual(str(UUID(returned_token)), returned_token)
+        self.assertNotEqual(returned_token, str(watch_operation_id))
         self.assertEqual(trigger["showToast"]["type"], "success")
         self.assertIn("Added watch", trigger["showToast"]["message"])
         self.assertEqual(
@@ -1554,6 +1559,7 @@ class DeleteMedia(TestCase):
             related_season=self.season,
             end_date=datetime.datetime(2023, 6, 1, 0, 0, tzinfo=datetime.UTC),
         )
+        cache.clear()
 
     def test_delete_tv(self):
         """Test the deletion of a tv through views."""

--- a/src/app/tests/views/test_history.py
+++ b/src/app/tests/views/test_history.py
@@ -405,6 +405,7 @@ class HistoryMonthViewTests(TestCase):
             related_season=season,
             end_date=now,
         )
+        cache.clear()
 
     def test_default_month_view_does_not_bootstrap_cache_status_poll(self):
         response = self.client.get(reverse("history"))

--- a/src/app/tests/views/test_home.py
+++ b/src/app/tests/views/test_home.py
@@ -940,11 +940,12 @@ class HomeRowCacheTests(TestCase):
                 "image": "http://example.com/image.jpg",
             },
         )
-        Episode.objects.create(
-            item=episode_item,
-            related_season=season,
-            end_date=timezone.now(),
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            Episode.objects.create(
+                item=episode_item,
+                related_season=season,
+                end_date=timezone.now(),
+            )
 
         with patch(
             "users.home_screen._library_query_entries",

--- a/src/app/tests/views/test_person_detail.py
+++ b/src/app/tests/views/test_person_detail.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -596,6 +597,7 @@ class PersonDetailViewTests(TestCase):
             },
             base_time=base_time,
         )
+        cache.clear()
 
         mock_person.return_value = {
             "person_id": "7790",

--- a/src/app/tests/views/test_statistics.py
+++ b/src/app/tests/views/test_statistics.py
@@ -2913,6 +2913,7 @@ class StatisticsViewTests(TestCase):
             base_time=base_time,
         )
 
+        cache.clear()
         statistics_cache.invalidate_statistics_cache(self.user.id)
         response = self.client.get(
             reverse("statistics_talent_fragment") + "?start-date=all&end-date=all"

--- a/src/app/tests/views/test_time_left_sort.py
+++ b/src/app/tests/views/test_time_left_sort.py
@@ -325,11 +325,12 @@ class TVTimeLeftCachedOrderTests(TestCase):
             media_type=MediaTypes.EPISODE.value,
             media_id=season.item.media_id,
         ).first()
-        Episode.objects.create(
-            item=episode_item,
-            related_season=season,
-            end_date=timezone.now(),
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            Episode.objects.create(
+                item=episode_item,
+                related_season=season,
+                end_date=timezone.now(),
+            )
 
         with patch(
             "app.media_list_views._sort_tv_media_by_time_left",

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -741,11 +741,12 @@ def progress_edit(request, media_type, instance_id):
 
     if operation == "increase":
         try:
-            media.increase_progress(
-                watch_operation_id=request.POST.get("watch_operation_id")
-                if media_type in {MediaTypes.TV.value, MediaTypes.SEASON.value}
-                else None,
-            )
+            increase_kwargs = {}
+            if media_type in {MediaTypes.TV.value, MediaTypes.SEASON.value}:
+                increase_kwargs["watch_operation_id"] = request.POST.get(
+                    "watch_operation_id"
+                )
+            media.increase_progress(**increase_kwargs)
         except ValidationError:
             return HttpResponseBadRequest("Invalid watch operation")
         except fork_services_episode.EpisodeWatchConflictError as error:

--- a/src/static/js/mediaStatusDateHandler.js
+++ b/src/static/js/mediaStatusDateHandler.js
@@ -301,6 +301,14 @@ window.showTrackToast = function showTrackToast(detail) {
 };
 
 function trackModalHandleClose(event) {
+  const requestElement = event.detail?.elt;
+  const operationField = requestElement?.querySelector?.(
+    '[name="watch_operation_id"]',
+  );
+  if (operationField && event.detail?.watchOperationId) {
+    operationField.value = event.detail.watchOperationId;
+  }
+
   const formId = event.detail?.formId;
   if (formId) {
     const form = document.getElementById(formId);


### PR DESCRIPTION
## Summary

- Make flat-anime to grouped-series migration one atomic, retry-safe operation.
- Split provider/network preflight from database persistence so no provider request runs while migration rows are locked.
- Return completed retries as safe no-ops; reject stale, provably partial, and ambiguous states without repairing or rewriting existing data.
- Preserve normalized metadata, credits, and all external provider IDs, including the grouped-anime IDs introduced by PR #688.
- Reconcile History, library, home, time-left, statistics, and smart-list caches once after commit.
- Repair the T2 regressions found by PR #740's full CI: generic progress arguments, commit-safe Episode cache invalidation, and browser retry-token rotation.

### Bottom line up front

A grouped-anime migration now either commits completely or leaves the database unchanged. Concurrent retries converge on one result, existing legitimate grouped history is never deduplicated or repaired, and browser retries cannot reuse an old watch identity for a new intentional watch.

### Why this is important

The previous migration wrote grouped Items, links, seasons, and Episodes before it marked the source anime as migrated. A late error or concurrent retry could leave both tracking shapes active and make the user's History harder to trust. This change moves every write into one short database-only transaction and gives uncertain legacy shapes a safe diagnostic instead of guessing.

### Post-mortem

- Provider hydration and database mutation were interleaved in one function.
- Late validation happened after some grouped rows already existed.
- Retries reread only unmigrated rows, so a completed concurrent request looked like a new error.
- Bulk persistence initially bypassed cache/list side effects, and Item signals could enqueue work inside the transaction; independent review caught both before this PR.
- PR #740's post-merge full suite also exposed T2 assumptions that focused tests missed. These are repaired here with exact regression coverage.

Refs #110
Refs #159
Complements #688

## AI Assistance

- GPT-5 Codex substantially shaped the implementation, tests, independent reviews, and PR preparation.

## Validation

- T3 migration/completion/hydration: 25/25 passed on SQLite.
- Atomicity/state/concurrency: 14/14 passed on SQLite; the PostgreSQL-only case is skipped there by design.
- Real PostgreSQL 16 row-lock concurrency test: 1/1 passed.
- T3 plus a disposable merge of PR #688: 71 passed, 1 PostgreSQL-only skip in the SQLite run; no merge conflicts.
- T2 signal/cache and grouped-History regressions: 25/25 passed.
- Exact non-browser failures from PR #740 CI: 12/12 passed.
- Exact Playwright season-progress retry flow: 1/1 passed.
- `ruff check src` and `git diff --check`: passed.
- Full fast suite: 3,577 tests passed, 1 expected skip.

## Human Review

- [x] Completed — two independent review cycles; final verdict: Ready, no severity findings.

## Gstack QA

- [x] Behavior QA completed through focused Django and exact Playwright regressions. No visible layout change is included.

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)

- Not applicable: this is not an `upstream` -> `latest` sync and adds no schema migration.

## Notes

- PR #688 remains independent and untouched. It merges cleanly with this branch and its grouped-anime import/webhook tests pass in the combined scope.
- No provider settings, credential, integration, account, import, or webhook data is migrated or rewritten.
- Screenshots are not applicable: the only frontend behavior change rotates a hidden operation token inside the submitting form; the exact browser flow is covered by Playwright.
