### PR TITLE
fix(sqlite): keep the verified backup and single-source the timeout bound

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,15 +34,18 @@ if [ -z "$DB_HOST" ]; then
         echo "[entrypoint] Checking SQLite storage and relationships for ${DB_FILE}" >&2
         integrity_status=0
         integrity_pid=
+        # One bound, used by the command and its operator message, so the two
+        # can never drift apart.
+        integrity_timeout=600
         trap 'kill "$integrity_pid" 2>/dev/null || :; wait "$integrity_pid" 2>/dev/null || :; exit 0' TERM INT
-        timeout 600 python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+        timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
         integrity_pid=$!
         wait "$integrity_pid" || integrity_status=$?
         trap - TERM INT
         if [ "$integrity_status" -ne 0 ]; then
             case "$integrity_status" in
                 124|143)
-                    echo "[entrypoint] SQLite integrity check exceeded its 600s timeout; startup is paused before migrations and services. The container will remain unhealthy and idle." >&2
+                    echo "[entrypoint] SQLite integrity check exceeded its ${integrity_timeout}s timeout; startup is paused before migrations and services. The container will remain unhealthy and idle." >&2
                     ;;
                 *)
                     echo "[entrypoint] SQLite startup is paused because the integrity check failed; migrations and services were not started. The container will remain unhealthy and idle." >&2

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -155,7 +155,7 @@ def _read_incident_report(db_path: str) -> dict | None:
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(report_path, flags)
-    except (FileNotFoundError, OSError):
+    except OSError:
         return None
     try:
         if not stat.S_ISREG(os.fstat(descriptor).st_mode):
@@ -382,6 +382,7 @@ def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
         source = None
         destination = None
         published = False
+        succeeded = False
         try:
             source = sqlite3.connect(f"{database_path.as_uri()}?mode=ro", uri=True)
             destination = sqlite3.connect(staging_path)
@@ -425,6 +426,7 @@ def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
             published = True
             os.unlink(staging_name, dir_fd=recovery_descriptor)
             os.fsync(recovery_descriptor)
+            succeeded = True
             return recovery_dir / final_name
         finally:
             if destination is not None:
@@ -433,7 +435,10 @@ def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
                 source.close()
             with suppress(FileNotFoundError):
                 os.unlink(staging_name, dir_fd=recovery_descriptor)
-            if published and sys.exc_info()[0] is not None:
+            # Key the rollback off this call's own outcome. sys.exc_info() also
+            # reports an exception the caller is already handling, which would
+            # delete a good backup and leave the delete path without one.
+            if published and not succeeded:
                 with suppress(FileNotFoundError):
                     os.unlink(final_name, dir_fd=recovery_descriptor)
     finally:

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -632,6 +632,25 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(conn.execute("SELECT COUNT(*) FROM child").fetchone()[0], 1)
             conn.close()
 
+    def test_verified_backup_survives_call_during_exception_handling(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_orphan_database(tmp_dir)
+            # Cleanup must key off this call's own outcome. A caller that is
+            # already handling an unrelated exception must still get a backup,
+            # otherwise rows are deleted against a file that was just removed.
+            try:
+                json.loads("{")
+            except ValueError:
+                backup_path = sqlite_integrity._create_verified_backup(
+                    db_path,
+                    "0" * 64,
+                )
+
+            self.assertTrue(backup_path.is_file())
+            backup = sqlite3.connect(f"file:{backup_path}?mode=ro", uri=True)
+            self.assertEqual(backup.execute("PRAGMA quick_check").fetchone(), ("ok",))
+            backup.close()
+
     def test_prepared_report_survives_resolved_report_failure_and_reconciles(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_orphan_database(tmp_dir)
@@ -1210,12 +1229,15 @@ class SqliteIntegrityTests(SimpleTestCase):
     def test_entrypoint_bounds_integrity_check_without_background_polling(self):
         script = ENTRYPOINT.read_text()
         check = (
-            "timeout 600 python -c 'from config.sqlite_integrity import "
+            'timeout "$integrity_timeout" python -c '
+            "'from config.sqlite_integrity import "
             "check_database_integrity; import sys; "
-            "check_database_integrity(sys.argv[1])' \"$DB_FILE\""
+            'check_database_integrity(sys.argv[1])\' "$DB_FILE"'
         )
 
         self.assertIn(check, script)
+        # The bound and the message it reports must come from one definition.
+        self.assertIn("integrity_timeout=600", script)
         self.assertIn('"$DB_FILE" &', script)
         self.assertNotIn("kill -0", script)
         self.assertNotIn("/proc/", script)
@@ -1233,7 +1255,8 @@ class SqliteIntegrityTests(SimpleTestCase):
         timeout_case = script.index("124|143)")
         failure_case = script.index("*)", timeout_case)
         self.assertIn(
-            "exceeded its 600s timeout", script[timeout_case:failure_case]
+            "exceeded its ${integrity_timeout}s timeout",
+            script[timeout_case:failure_case],
         )
         self.assertIn("integrity check failed", script[failure_case:])
         self.assertIn(


### PR DESCRIPTION
Follow-ups to #741, found while QA'ing the merged SQLite recovery path. One is a
latent data-safety bug; the other two remove a drift hazard and dead code.

## 1. A published backup could be deleted before rows are removed

`_create_verified_backup` decided whether to roll back its just-published backup with
`sys.exc_info()[0] is not None`. That reports **any** exception currently being handled,
including one the *caller* is handling. Called from inside an `except` block it would
publish the backup, see a non-empty `exc_info`, and unlink it — then quarantine deletes
rows against a `backup_path` that no longer exists.

Not reachable from today's only call site, but this is the one code path where losing the
backup means losing data, and it is one refactor away from being reachable. The rollback
now keys off this call's own outcome.

Regression test fails on the old code (`AssertionError: False is not true`) and passes now.

## 2. The integrity timeout bound was written twice

`timeout 600 python ...` and `"exceeded its 600s timeout"` were independent literals, so a
change to one would silently make the operator message report a bound that is not the real
one. Both now read `integrity_timeout`.

This was observable, not theoretical: with the duplicated literals, a run bounded at 3s
still printed *"exceeded its 600s timeout"*. With the fix, a container bounded at 1s
correctly reports *"exceeded its 1s timeout"*.

## 3. Redundant exception class

`except (FileNotFoundError, OSError)` — `FileNotFoundError` is an `OSError` subclass.

## Validation

- `scripts/test.sh config.tests.test_sqlite_integrity` — **37/37** (36 + the new regression test)
- `scripts/test.sh` (fast suite) — **3577 tests, OK**
- `ruff check`, `/bin/sh -n entrypoint.sh`, `git diff --check` — clean

Container smoke on an image built from this branch (Alpine/BusyBox, rootless podman), since
`entrypoint.sh` changed:

| Path | Result |
|---|---|
| Blocked (1200 conflicts) | exactly 20 samples, no `Still checking` loop, no migrations, running, `RestartCount=0`, 135 ms stop |
| Timeout branch (bound reduced to 1s, 300k-conflict database taking ~2.1 s) | fires, reports **"exceeded its 1s timeout"**, parks before migrations, `RestartCount=0`, 81 ms stop |

## Deliberately not changed

- **`sqlite-recovery/` retention.** Automatic pruning would delete operator backups, which is
  the outcome this whole feature exists to prevent. Documented for the operator instead.
- **The second `_inspect_foreign_keys` call after quarantine.** It looks like a duplicate full
  scan, but when the recheck finds zero conflicts `affected_tables` is empty, so no schema or
  trigger queries run. The only repeated work is the `PRAGMA foreign_key_check` that *is* the
  safety assertion.

Refs #731
