### PR TITLE
Show a recovery page while SQLite startup is paused

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,11 @@ if [ -z "$DB_HOST" ]; then
             esac
             parking_pid=
             trap 'kill "$parking_pid" 2>/dev/null || :; wait "$parking_pid" 2>/dev/null || :; exit 0' TERM INT
+            # Show the recovery page. It writes a copy beside the database, then
+            # serves it. If it stops, the container must stay alive and idle.
+            python -m config.sqlite_recovery_server "$DB_FILE" &
+            parking_pid=$!
+            wait "$parking_pid" || :
             while :; do
                 sleep 86400 &
                 parking_pid=$!

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -555,12 +555,16 @@ def _describe_affected(conn: sqlite3.Connection) -> dict:
     """
     described: Counter = Counter()
     unidentified = 0
+    # The scan below reads every foreign key, so test the one thing that makes
+    # it worth doing before paying for it.
+    has_item_table = conn.execute(
+        "SELECT 1 FROM main.sqlite_schema "
+        "WHERE type = 'table' AND name = 'app_item' COLLATE NOCASE",
+    ).fetchone()
+    if not has_item_table:
+        return {}
     try:
         unidentified += _snapshot_conflicts(conn, require_row_ids=False)
-        has_item_table = conn.execute(
-            "SELECT 1 FROM main.sqlite_schema "
-            "WHERE type = 'table' AND name = 'app_item' COLLATE NOCASE",
-        ).fetchone()
         tables = [
             row[0]
             for row in conn.execute(
@@ -580,7 +584,7 @@ def _describe_affected(conn: sqlite3.Connection) -> dict:
                     [table],
                 )
             }
-            if not has_item_table or "item_id" not in columns:
+            if "item_id" not in columns:
                 unidentified += total
                 continue
             named = 0
@@ -728,7 +732,12 @@ def _check_foreign_keys(conn: sqlite3.Connection, db_path: str) -> None:
                 )
         return
 
-    incident.update(_describe_affected(conn))
+    # Naming the affected titles is a convenience. The report is the only way
+    # out of the incident, so a failure here must never stop it being written.
+    try:
+        incident.update(_describe_affected(conn))
+    except Exception as error:
+        _log(f"[entrypoint] Could not name the affected entries: {error}")
     _print_incident(db_path, incident)
     if (
         prior_report

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -29,7 +29,10 @@ _BUSY_HINT = (
 _ALBUM_ARTIST_TABLE = "app_albumartist"
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
 _MAX_CONFLICT_SAMPLES = 20
+_MAX_AFFECTED_TITLES = 5
 _REPORT_SUFFIX = ".integrity.json"
+_DECISION_SUFFIX = ".integrity.decision"
+_RECOVERY_PAGE_NAME = "floppy-recovery.html"
 
 
 def _log(message: str) -> None:
@@ -186,7 +189,12 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
-def _publish_report(report_path: Path, contents: str) -> None:
+def _publish_report(report_path: Path, contents: str, *, mode: int = 0o600) -> None:
+    """Publish text atomically, so a reader never sees a half-written file.
+
+    The report holds an approval token and stays owner-only. The recovery page
+    holds nothing secret and must stay readable by the person who opens it.
+    """
     descriptor, temporary_name = tempfile.mkstemp(
         dir=report_path.parent,
         prefix=f".{report_path.name}.",
@@ -194,7 +202,7 @@ def _publish_report(report_path: Path, contents: str) -> None:
     )
     temporary_path = Path(temporary_name)
     try:
-        os.fchmod(descriptor, 0o600)
+        os.fchmod(descriptor, mode)
         with os.fdopen(descriptor, "w") as report_file:
             descriptor = -1
             report_file.write(contents)
@@ -227,6 +235,10 @@ def _write_incident_report(
             actions["quarantine"] = f"quarantine:{incident_token}"
     payload = {
         "actions": actions,
+        "affected": incident.get("affected", []),
+        "affected_other_titles": incident.get("other_titles", 0),
+        "affected_other_titles_count": incident.get("other_titles_count", 0),
+        "affected_unidentified": incident.get("unidentified", 0),
         "backup_path": str(backup_path) if backup_path else None,
         "can_quarantine": incident["can_quarantine"],
         "database": str(Path(db_path).resolve()),
@@ -308,6 +320,53 @@ def _print_resolution_options(incident: dict, incident_token: str) -> None:
     else:
         for reason in incident.get("unsafe_reasons", []):
             _log(f"[entrypoint] - Manual repair required: {reason}")
+
+
+def _decision_path(db_path: str) -> Path:
+    database_path = Path(db_path).resolve()
+    return database_path.with_name(f"{database_path.name}{_DECISION_SUFFIX}")
+
+
+def _read_decision(db_path: str, incident: dict, incident_token: str) -> str | None:
+    """Read a choice made on the recovery page, then remove the file.
+
+    The choice carries the identity of the incident it was made for. A choice
+    made for an earlier incident must never apply to a later one, so the file
+    is held to the same test as the environment variable.
+    """
+    decision_path = _decision_path(db_path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(decision_path, flags)
+    except OSError:
+        return None
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            return None
+        with os.fdopen(descriptor) as decision_file:
+            descriptor = -1
+            decision = json.load(decision_file)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        decision = None
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+    # Remove the file whether or not it was valid. A choice is used once.
+    with suppress(OSError):
+        decision_path.unlink()
+    if not isinstance(decision, dict):
+        return None
+    if decision.get("fingerprint") != incident["fingerprint"]:
+        _log(
+            "[entrypoint] The choice on file was made for a different problem; "
+            "using halt",
+        )
+        return None
+    if decision.get("token") != incident_token:
+        _log("[entrypoint] The choice on file has an old code; using halt")
+        return None
+    action = decision.get("action")
+    return action if action in {"accept", "quarantine"} else None
 
 
 def _selected_action(incident: dict, incident_token: str) -> str:
@@ -445,8 +504,12 @@ def _quote_identifier(identifier: str) -> str:
     return f'"{escaped}"'
 
 
-def _delete_orphaned_rows(conn: sqlite3.Connection) -> int:
-    """Delete every child row named by the stable foreign-key snapshot."""
+def _snapshot_conflicts(conn: sqlite3.Connection, *, require_row_ids: bool) -> None:
+    """Record every conflicting row id in a temporary table.
+
+    The delete path must refuse a row it cannot address, so it sets
+    ``require_row_ids``. The description path only reads, so it skips such rows.
+    """
     conn.execute(
         "CREATE TEMP TABLE floppy_fk_conflicts ("
         "table_name TEXT NOT NULL, row_id INTEGER NOT NULL, "
@@ -454,7 +517,9 @@ def _delete_orphaned_rows(conn: sqlite3.Connection) -> int:
     )
     cursor = conn.execute("PRAGMA foreign_key_check")
     while rows := cursor.fetchmany(500):
-        if any(row_id is None for _table, row_id, _parent, _key in rows):
+        if require_row_ids and any(
+            row_id is None for _table, row_id, _parent, _key in rows
+        ):
             message = (
                 "one or more conflicts cannot be quarantined automatically "
                 "because the child table has no rowid"
@@ -462,8 +527,83 @@ def _delete_orphaned_rows(conn: sqlite3.Connection) -> int:
             raise ValueError(message)
         conn.executemany(
             "INSERT OR IGNORE INTO floppy_fk_conflicts VALUES (?, ?)",
-            ((table, row_id) for table, row_id, _parent, _key in rows),
+            (
+                (table, row_id)
+                for table, row_id, _parent, _key in rows
+                if row_id is not None
+            ),
         )
+
+
+def _describe_affected(conn: sqlite3.Connection) -> dict:
+    """Name the affected content, grouped and bounded.
+
+    The reference that broke is not the one that carries the title. An affected
+    row usually still points at a valid ``app_item``, so the title survives even
+    though the parent row is gone. This only reads columns that already exist.
+    """
+    described: Counter = Counter()
+    unidentified = 0
+    _snapshot_conflicts(conn, require_row_ids=False)
+    try:
+        has_item_table = conn.execute(
+            "SELECT 1 FROM main.sqlite_schema "
+            "WHERE type = 'table' AND name = 'app_item' COLLATE NOCASE",
+        ).fetchone()
+        tables = [
+            row[0]
+            for row in conn.execute(
+                "SELECT DISTINCT table_name FROM floppy_fk_conflicts "
+                "ORDER BY table_name",
+            )
+        ]
+        for table in tables:
+            total = conn.execute(
+                "SELECT COUNT(*) FROM floppy_fk_conflicts WHERE table_name = ?",
+                [table],
+            ).fetchone()[0]
+            columns = {
+                name.casefold()
+                for name, in conn.execute(
+                    "SELECT name FROM pragma_table_xinfo(?, 'main')",
+                    [table],
+                )
+            }
+            if not has_item_table or "item_id" not in columns:
+                unidentified += total
+                continue
+            named = 0
+            for title, season, count in conn.execute(
+                f"SELECT i.title, i.season_number, COUNT(*) "  # noqa: S608
+                f"FROM main.{_quote_identifier(table)} AS child "
+                "JOIN main.app_item AS i ON i.id = child.item_id "
+                "WHERE child.rowid IN ("
+                "SELECT row_id FROM floppy_fk_conflicts WHERE table_name = ?) "
+                "GROUP BY i.title, i.season_number",
+                [table],
+            ):
+                described[(title, season)] += count
+                named += count
+            unidentified += total - named
+    finally:
+        conn.execute("DROP TABLE floppy_fk_conflicts")
+
+    affected = [
+        {"count": count, "season": season, "title": title}
+        for (title, season), count in described.most_common(_MAX_AFFECTED_TITLES)
+    ]
+    remaining = sum(described.values()) - sum(item["count"] for item in affected)
+    return {
+        "affected": affected,
+        "other_titles": len(described) - len(affected),
+        "other_titles_count": remaining,
+        "unidentified": unidentified,
+    }
+
+
+def _delete_orphaned_rows(conn: sqlite3.Connection) -> int:
+    """Delete every child row named by the stable foreign-key snapshot."""
+    _snapshot_conflicts(conn, require_row_ids=True)
 
     tables = [
         row[0]
@@ -572,6 +712,7 @@ def _check_foreign_keys(conn: sqlite3.Connection, db_path: str) -> None:
                 )
         return
 
+    incident.update(_describe_affected(conn))
     _print_incident(db_path, incident)
     if (
         prior_report
@@ -588,7 +729,10 @@ def _check_foreign_keys(conn: sqlite3.Connection, db_path: str) -> None:
     incident_token = _valid_blocked_token(prior_report, incident)
     if incident_token is None:
         incident_token = secrets.token_hex(16)
-    action = _selected_action(incident, incident_token)
+    action = _read_decision(db_path, incident, incident_token) or _selected_action(
+        incident,
+        incident_token,
+    )
     try:
         report_path = _write_incident_report(
             db_path,

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -504,7 +504,13 @@ def _quote_identifier(identifier: str) -> str:
     return f'"{escaped}"'
 
 
-def _snapshot_conflicts(conn: sqlite3.Connection, *, require_row_ids: bool) -> None:
+def _drop_conflict_snapshot(conn: sqlite3.Connection) -> None:
+    """Remove the snapshot. The table may not exist if the build failed."""
+    with suppress(sqlite3.DatabaseError):
+        conn.execute("DROP TABLE floppy_fk_conflicts")
+
+
+def _snapshot_conflicts(conn: sqlite3.Connection, *, require_row_ids: bool) -> int:
     """Record every conflicting row id in a temporary table.
 
     The delete path must refuse a row it cannot address, so it sets
@@ -515,6 +521,7 @@ def _snapshot_conflicts(conn: sqlite3.Connection, *, require_row_ids: bool) -> N
         "table_name TEXT NOT NULL, row_id INTEGER NOT NULL, "
         "PRIMARY KEY (table_name, row_id))"
     )
+    skipped = 0
     cursor = conn.execute("PRAGMA foreign_key_check")
     while rows := cursor.fetchmany(500):
         if require_row_ids and any(
@@ -525,6 +532,7 @@ def _snapshot_conflicts(conn: sqlite3.Connection, *, require_row_ids: bool) -> N
                 "because the child table has no rowid"
             )
             raise ValueError(message)
+        skipped += sum(1 for _t, row_id, _p, _k in rows if row_id is None)
         conn.executemany(
             "INSERT OR IGNORE INTO floppy_fk_conflicts VALUES (?, ?)",
             (
@@ -533,6 +541,9 @@ def _snapshot_conflicts(conn: sqlite3.Connection, *, require_row_ids: bool) -> N
                 if row_id is not None
             ),
         )
+    # A row we cannot address is still an affected row. Report it rather than
+    # let the breakdown quietly add up to less than the total.
+    return skipped
 
 
 def _describe_affected(conn: sqlite3.Connection) -> dict:
@@ -544,8 +555,8 @@ def _describe_affected(conn: sqlite3.Connection) -> dict:
     """
     described: Counter = Counter()
     unidentified = 0
-    _snapshot_conflicts(conn, require_row_ids=False)
     try:
+        unidentified += _snapshot_conflicts(conn, require_row_ids=False)
         has_item_table = conn.execute(
             "SELECT 1 FROM main.sqlite_schema "
             "WHERE type = 'table' AND name = 'app_item' COLLATE NOCASE",
@@ -586,7 +597,7 @@ def _describe_affected(conn: sqlite3.Connection) -> dict:
                 named += count
             unidentified += total - named
     finally:
-        conn.execute("DROP TABLE floppy_fk_conflicts")
+        _drop_conflict_snapshot(conn)
 
     affected = [
         {"count": count, "season": season, "title": title}
@@ -603,8 +614,14 @@ def _describe_affected(conn: sqlite3.Connection) -> dict:
 
 def _delete_orphaned_rows(conn: sqlite3.Connection) -> int:
     """Delete every child row named by the stable foreign-key snapshot."""
-    _snapshot_conflicts(conn, require_row_ids=True)
+    try:
+        return _delete_snapshotted_rows(conn)
+    finally:
+        _drop_conflict_snapshot(conn)
 
+
+def _delete_snapshotted_rows(conn: sqlite3.Connection) -> int:
+    _snapshot_conflicts(conn, require_row_ids=True)
     tables = [
         row[0]
         for row in conn.execute(
@@ -620,7 +637,6 @@ def _delete_orphaned_rows(conn: sqlite3.Connection) -> int:
             [table],
         )
         deleted += result.rowcount
-    conn.execute("DROP TABLE floppy_fk_conflicts")
     return deleted
 
 

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import html
 import json
+import secrets
+import socket
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -27,6 +29,34 @@ from config.sqlite_integrity import (
 
 _PORT = 8000
 _HEALTH_PATHS = frozenset({"/health", "/health/"})
+_MAX_BODY_BYTES = 4096
+_SOCKET_TIMEOUT_SECONDS = 15
+# The approval code proves that the person has read the report file. The page
+# must never show it, or the code proves only that they opened the page.
+_SECRET_REPORT_KEYS = frozenset({"actions", "incident_token"})
+
+_HELP_LINKS = (
+    ("Report a problem", "https://github.com/dannyvfilms/Floppy/issues"),
+    ("Read the wiki", "https://github.com/dannyvfilms/Floppy/wiki"),
+    ("Ask on Discord", "https://discord.gg/QfNA6zJ5Ws"),
+)
+
+# navigator.clipboard exists only in a secure context. Floppy is usually opened
+# over plain HTTP on a local address, where it is undefined. The button falls
+# back to the older command, and the text stays on the page to select by hand.
+_COPY_SCRIPT = """
+document.addEventListener('click',function(e){
+ var b=e.target.closest('[data-copy]');if(!b)return;
+ var t=document.getElementById(b.getAttribute('data-copy'));if(!t)return;
+ var s=t.innerText,done=function(){b.textContent='Copied';
+  setTimeout(function(){b.textContent='Copy details'},2000)};
+ if(navigator.clipboard&&window.isSecureContext){
+  navigator.clipboard.writeText(s).then(done,function(){b.textContent='Press Ctrl+C'})}
+ else{var r=document.createRange();r.selectNodeContents(t);
+  var sel=window.getSelection();sel.removeAllRanges();sel.addRange(r);
+  try{document.execCommand('copy');done()}catch(err){b.textContent='Press Ctrl+C'}}
+});
+"""
 
 # Copied from src/static/css/input.css. The page must not request an external
 # stylesheet, because it also opens as a file from the database folder.
@@ -59,6 +89,7 @@ details{margin-top:1.5rem;color:var(--muted)}
 pre{overflow-x:auto;background:var(--panel);border:1px solid var(--border);
 border-radius:8px;padding:1rem;font-size:.85rem}
 .note{font-size:.9rem}
+a{color:var(--accent)}
 """
 
 
@@ -96,6 +127,7 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
             "<h1>Your data is safe. Nothing was deleted.</h1>"
             "<p>Floppy paused before it started. It cannot read the report that "
             "explains why. Look at the container log for the reason.</p>"
+            + _help_card()
         )
         return _document(body)
 
@@ -147,12 +179,34 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
         "<p>Stop Floppy. Replace <code>db.sqlite3</code> with your backup. "
         "Start Floppy again.</p></div>",
     )
+    parts.append(_help_card())
+    public = {
+        key: value
+        for key, value in report.items()
+        if key not in _SECRET_REPORT_KEYS
+    }
     parts.append(
-        "<details><summary>Technical details for a bug report</summary><pre>"
-        + html.escape(json.dumps(report, indent=2, sort_keys=True))
+        "<details><summary>Technical details for a bug report</summary>"
+        "<p><button data-copy='details'>Copy details</button></p>"
+        "<pre id='details'>"
+        + html.escape(json.dumps(public, indent=2, sort_keys=True))
         + "</pre></details>",
     )
     return _document("".join(parts))
+
+
+def _help_card() -> str:
+    """Offer the places where a person can get help."""
+    links = " · ".join(
+        f"<a href='{url}' target='_blank' rel='noopener noreferrer'>"
+        f"{html.escape(label)}</a>"
+        for label, url in _HELP_LINKS
+    )
+    return (
+        "<div class='card'><h2>Get help</h2>"
+        "<p>Copy the details below and send them with your question.</p>"
+        f"<p>{links}</p></div>"
+    )
 
 
 def _document(body: str) -> str:
@@ -160,7 +214,8 @@ def _document(body: str) -> str:
         "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
         "<meta name='viewport' content='width=device-width,initial-scale=1'>"
         "<title>Floppy needs a decision</title>"
-        f"<style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+        f"<style>{_STYLE}</style></head><body><main>{body}</main>"
+        f"<script>{_COPY_SCRIPT}</script></body></html>"
     )
 
 
@@ -189,6 +244,7 @@ def _write_decision(db_path: str, report: dict, action: str) -> None:
 
 class _Handler(BaseHTTPRequestHandler):
     db_path = ""
+    timeout = _SOCKET_TIMEOUT_SECONDS
 
     def log_message(self, *_args) -> None:
         """Keep the container log free of one line per request."""
@@ -214,18 +270,49 @@ class _Handler(BaseHTTPRequestHandler):
             "text/html; charset=utf-8",
         )
 
+    def _read_body(self) -> dict | None:
+        """Read a small form body. Refuse a large or malformed one."""
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            return None
+        if length < 0 or length > _MAX_BODY_BYTES:
+            return None
+        return parse_qs(self.rfile.read(length).decode(errors="replace"))
+
+    def _is_same_origin(self) -> bool:
+        """Refuse a form sent from another site.
+
+        A page on another site must not be able to make this choice for the
+        person who runs Floppy.
+        """
+        site = self.headers.get("Sec-Fetch-Site")
+        if site is not None:
+            return site in {"same-origin", "none"}
+        origin = self.headers.get("Origin")
+        if not origin:
+            return True
+        return origin.rstrip("/").endswith(self.headers.get("Host", "\0"))
+
     def do_POST(self) -> None:
         action = {"/accept": "accept", "/quarantine": "quarantine"}.get(self.path)
         report = _read_incident_report(self.db_path)
         if action is None or not report:
             self._send(404, "not found", "text/plain; charset=utf-8")
             return
+        if not self._is_same_origin():
+            self._send(403, "cross-site request", "text/plain; charset=utf-8")
+            return
         if action == "quarantine":
-            length = int(self.headers.get("Content-Length") or 0)
-            fields = parse_qs(self.rfile.read(length).decode(errors="replace"))
+            fields = self._read_body()
+            if fields is None:
+                self._send(400, "bad request", "text/plain; charset=utf-8")
+                return
             supplied = (fields.get("token") or [""])[0].strip()
-            if not report.get("can_quarantine") or supplied != report.get(
-                "incident_token",
+            expected = report.get("incident_token") or ""
+            if not report.get("can_quarantine") or not secrets.compare_digest(
+                supplied,
+                expected,
             ):
                 self._send(
                     403,
@@ -258,6 +345,7 @@ def serve(db_path: str) -> None:
         _log(f"[entrypoint] Could not write the recovery page: {error}")
 
     _Handler.db_path = db_path
+    socket.setdefaulttimeout(_SOCKET_TIMEOUT_SECONDS)
     try:
         server = ThreadingHTTPServer(("", _PORT), _Handler)
     except OSError as error:

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -1,0 +1,280 @@
+"""Show the SQLite recovery page while startup is paused.
+
+Django cannot serve this page. The database is the thing that is paused, and
+migrations have not run, so this uses only the standard library.
+
+The same page is written to disk beside the database. If the port is in use, or
+the container is stopped, the person who runs Floppy can still open the file and
+read what happened.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from config.sqlite_integrity import (
+    _RECOVERY_PAGE_NAME,
+    _decision_path,
+    _log,
+    _publish_report,
+    _read_incident_report,
+)
+
+_PORT = 8000
+_HEALTH_PATHS = frozenset({"/health", "/health/"})
+
+# Copied from src/static/css/input.css. The page must not request an external
+# stylesheet, because it also opens as a file from the database folder.
+_STYLE = """
+:root{--page:#212529;--panel:#272c31;--text:#f3f4f6;--muted:#9ca3af;
+--accent:#4a9eff;--border:#2c3136}
+@media (prefers-color-scheme: light){:root{--page:#f8f9fa;--panel:#fff;
+--text:#1f2937;--muted:#4b5563;--accent:#2f80ed;--border:#dee2e6}}
+*{box-sizing:border-box}
+body{margin:0;padding:2.5rem 1.25rem;background:var(--page);color:var(--text);
+font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+main{max-width:44rem;margin:0 auto}
+h1{font-size:1.5rem;margin:0 0 .5rem}
+p{margin:0 0 1rem;color:var(--muted)}
+.card{background:var(--panel);border:1px solid var(--border);border-radius:10px;
+padding:1.25rem;margin:1rem 0}
+.card h2{font-size:1.05rem;margin:0 0 .35rem;color:var(--text)}
+ul{list-style:none;padding:0;margin:.5rem 0}
+li{display:flex;justify-content:space-between;gap:1rem;padding:.3rem 0;
+border-bottom:1px solid var(--border);color:var(--text)}
+li:last-child{border-bottom:0}
+li span:last-child{color:var(--muted);white-space:nowrap}
+button{background:var(--accent);color:#fff;border:0;border-radius:7px;
+padding:.6rem 1.1rem;font-size:1rem;cursor:pointer}
+input{background:var(--page);color:var(--text);border:1px solid var(--border);
+border-radius:7px;padding:.55rem .7rem;font-size:1rem;margin-right:.5rem}
+code{background:var(--page);padding:.1rem .35rem;border-radius:4px;
+border:1px solid var(--border);font-size:.9em}
+details{margin-top:1.5rem;color:var(--muted)}
+pre{overflow-x:auto;background:var(--panel);border:1px solid var(--border);
+border-radius:8px;padding:1rem;font-size:.85rem}
+.note{font-size:.9rem}
+"""
+
+
+def _affected_list(report: dict) -> str:
+    rows = []
+    for entry in report.get("affected", []):
+        title = html.escape(str(entry.get("title") or "Unknown"))
+        season = entry.get("season")
+        label = f"{title}, Season {int(season)}" if season is not None else title
+        rows.append(
+            f"<li><span>{label}</span><span>{int(entry['count'])} entries</span></li>",
+        )
+    other = int(report.get("affected_other_titles", 0) or 0)
+    if other:
+        count = int(report.get("affected_other_titles_count", 0) or 0)
+        rows.append(
+            f"<li><span>and {other} other titles</span>"
+            f"<span>{count} entries</span></li>",
+        )
+    unknown = int(report.get("affected_unidentified", 0) or 0)
+    if unknown:
+        rows.append(
+            f"<li><span>Entries we cannot identify</span>"
+            f"<span>{unknown} entries</span></li>",
+        )
+    if not rows:
+        return ""
+    return "<div class='card'><h2>What is affected</h2><ul>" + "".join(rows) + "</ul></div>"
+
+
+def render_page(report: dict | None, *, interactive: bool) -> str:
+    """Build the page. The written file is the same page without the buttons."""
+    if not report:
+        body = (
+            "<h1>Your data is safe. Nothing was deleted.</h1>"
+            "<p>Floppy paused before it started. It cannot read the report that "
+            "explains why. Look at the container log for the reason.</p>"
+        )
+        return _document(body)
+
+    total = int(report.get("total_conflicts", 0) or 0)
+    can_quarantine = bool(report.get("can_quarantine"))
+    parts = [
+        "<h1>Your data is safe. Nothing was deleted.</h1>",
+        f"<p>Floppy found {total} entries that point to a record that is no "
+        "longer in the database. Floppy paused so that you can choose what to "
+        "do. No entry was changed.</p>",
+        _affected_list(report),
+    ]
+
+    if interactive:
+        parts.append(
+            "<div class='card'><h2>Start anyway, keep everything</h2>"
+            "<p>Floppy starts and changes no data. The affected entries stay "
+            "hidden until you repair them.</p>"
+            "<form method='POST' action='/accept'><button>Start Floppy</button>"
+            "</form></div>",
+        )
+        if can_quarantine:
+            parts.append(
+                "<div class='card'><h2>Remove the affected entries</h2>"
+                "<p>Floppy saves a full backup first. Then it removes the "
+                f"{total} entries above and starts.</p>"
+                "<p class='note'>To confirm, copy the code from "
+                "<code>db.sqlite3.integrity.json</code> in the same folder as "
+                "your database.</p>"
+                "<form method='POST' action='/quarantine'>"
+                "<input name='token' placeholder='Paste the code' size='34'>"
+                "<button>Remove entries</button></form></div>",
+            )
+        else:
+            parts.append(
+                "<div class='card'><h2>Repair these entries yourself</h2>"
+                "<p>Floppy cannot remove these entries safely. The container "
+                "log gives the reason.</p></div>",
+            )
+    else:
+        parts.append(
+            "<div class='card'><h2>How to choose</h2>"
+            "<p>This is a copy on disk. To choose an action, open Floppy at "
+            "port 8000 while the container runs.</p></div>",
+        )
+
+    parts.append(
+        "<div class='card'><h2>Use a backup instead</h2>"
+        "<p>Stop Floppy. Replace <code>db.sqlite3</code> with your backup. "
+        "Start Floppy again.</p></div>",
+    )
+    parts.append(
+        "<details><summary>Technical details for a bug report</summary><pre>"
+        + html.escape(json.dumps(report, indent=2, sort_keys=True))
+        + "</pre></details>",
+    )
+    return _document("".join(parts))
+
+
+def _document(body: str) -> str:
+    return (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        "<title>Floppy needs a decision</title>"
+        f"<style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+    )
+
+
+def write_page(db_path: str, report: dict | None) -> Path:
+    """Write the page beside the database so it is always available."""
+    page_path = Path(db_path).resolve().with_name(_RECOVERY_PAGE_NAME)
+    _publish_report(page_path, render_page(report, interactive=False), mode=0o644)
+    return page_path
+
+
+def _write_decision(db_path: str, report: dict, action: str) -> None:
+    _publish_report(
+        _decision_path(db_path),
+        json.dumps(
+            {
+                "action": action,
+                "fingerprint": report.get("fingerprint"),
+                "token": report.get("incident_token"),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+
+
+class _Handler(BaseHTTPRequestHandler):
+    db_path = ""
+
+    def log_message(self, *_args) -> None:
+        """Keep the container log free of one line per request."""
+
+    def _send(self, status: int, body: str, content_type: str) -> None:
+        payload = body.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        # Floppy is not able to serve requests, so the health check must fail.
+        # A success here would report the container as healthy while it is not.
+        if self.path.split("?")[0] in _HEALTH_PATHS:
+            self._send(503, "paused", "text/plain; charset=utf-8")
+            return
+        report = _read_incident_report(self.db_path)
+        self._send(
+            200,
+            render_page(report, interactive=True),
+            "text/html; charset=utf-8",
+        )
+
+    def do_POST(self) -> None:
+        action = {"/accept": "accept", "/quarantine": "quarantine"}.get(self.path)
+        report = _read_incident_report(self.db_path)
+        if action is None or not report:
+            self._send(404, "not found", "text/plain; charset=utf-8")
+            return
+        if action == "quarantine":
+            length = int(self.headers.get("Content-Length") or 0)
+            fields = parse_qs(self.rfile.read(length).decode(errors="replace"))
+            supplied = (fields.get("token") or [""])[0].strip()
+            if not report.get("can_quarantine") or supplied != report.get(
+                "incident_token",
+            ):
+                self._send(
+                    403,
+                    _document(
+                        "<h1>That code is not correct.</h1><p>Copy the code from "
+                        "<code>db.sqlite3.integrity.json</code>. No entry was "
+                        "changed.</p>",
+                    ),
+                    "text/html; charset=utf-8",
+                )
+                return
+        _write_decision(self.db_path, report, action)
+        self._send(
+            200,
+            _document(
+                "<h1>Thank you. Restart Floppy now.</h1>"
+                "<p>Floppy applies your choice when it starts again.</p>",
+            ),
+            "text/html; charset=utf-8",
+        )
+
+
+def serve(db_path: str) -> None:
+    """Write the page, then serve it until the container stops."""
+    report = _read_incident_report(db_path)
+    try:
+        page_path = write_page(db_path, report)
+        _log(f"[entrypoint] Recovery page written to {page_path}")
+    except OSError as error:
+        _log(f"[entrypoint] Could not write the recovery page: {error}")
+
+    _Handler.db_path = db_path
+    try:
+        server = ThreadingHTTPServer(("", _PORT), _Handler)
+    except OSError as error:
+        _log(
+            f"[entrypoint] Could not use port {_PORT} for the recovery page: "
+            f"{error}. Open the file above instead.",
+        )
+        return
+    _log(
+        f"[entrypoint] Open http://localhost:{_PORT}/ to choose what Floppy does "
+        "next.",
+    )
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    serve(sys.argv[1])

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -17,7 +17,7 @@ import socket
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlsplit
 
 from config.sqlite_integrity import (
     _RECOVERY_PAGE_NAME,
@@ -93,23 +93,38 @@ a{color:var(--accent)}
 """
 
 
+def _count(value: object) -> int:
+    """Read a number from a damaged database without failing.
+
+    The page exists because the database is damaged, so a value in it can be
+    the wrong type. A wrong number must never stop the page from opening.
+    """
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
 def _affected_list(report: dict) -> str:
     rows = []
     for entry in report.get("affected", []):
         title = html.escape(str(entry.get("title") or "Unknown"))
         season = entry.get("season")
-        label = f"{title}, Season {int(season)}" if season is not None else title
+        label = title
+        if season is not None:
+            label = f"{title}, Season {html.escape(str(season))}"
         rows.append(
-            f"<li><span>{label}</span><span>{int(entry['count'])} entries</span></li>",
+            f"<li><span>{label}</span>"
+            f"<span>{_count(entry.get('count'))} entries</span></li>",
         )
-    other = int(report.get("affected_other_titles", 0) or 0)
+    other = _count(report.get("affected_other_titles"))
     if other:
-        count = int(report.get("affected_other_titles_count", 0) or 0)
+        count = _count(report.get("affected_other_titles_count"))
         rows.append(
             f"<li><span>and {other} other titles</span>"
             f"<span>{count} entries</span></li>",
         )
-    unknown = int(report.get("affected_unidentified", 0) or 0)
+    unknown = _count(report.get("affected_unidentified"))
     if unknown:
         rows.append(
             f"<li><span>Entries we cannot identify</span>"
@@ -131,7 +146,7 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
         )
         return _document(body)
 
-    total = int(report.get("total_conflicts", 0) or 0)
+    total = _count(report.get("total_conflicts"))
     can_quarantine = bool(report.get("can_quarantine"))
     parts = [
         "<h1>Your data is safe. Nothing was deleted.</h1>",
@@ -292,7 +307,10 @@ class _Handler(BaseHTTPRequestHandler):
         origin = self.headers.get("Origin")
         if not origin:
             return True
-        return origin.rstrip("/").endswith(self.headers.get("Host", "\0"))
+        host = self.headers.get("Host", "")
+        # Compare the whole name. A name that merely ends with the host, such
+        # as "notfloppy.local" against "floppy.local", is another site.
+        return bool(host) and urlsplit(origin).netloc == host
 
     def do_POST(self) -> None:
         action = {"/accept": "accept", "/quarantine": "quarantine"}.get(self.path)

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -1268,3 +1268,33 @@ class SqliteIntegrityTests(SimpleTestCase):
         self.assertIn("parking_pid=$!", script)
         self.assertIn('wait "$parking_pid" || :', script)
         self.assertNotIn("tail -f /dev/null", script)
+
+    def test_the_report_survives_a_failure_to_name_the_titles(self):
+        """The report is the only way out. Nothing may suppress it."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_orphan_database(tmp_dir, rows=3)
+
+            def raise_damaged(_conn):
+                message = "database disk image is malformed"
+                raise sqlite3.DatabaseError(message)
+
+            with (
+                mock.patch.object(
+                    sqlite_integrity,
+                    "_describe_affected",
+                    raise_damaged,
+                ),
+                self.assertRaises(SystemExit) as ctx,
+                mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+            ):
+                check_database_integrity(db_path)
+
+            self.assertEqual(ctx.exception.code, 1)
+            output = stderr.getvalue()
+            self.assertIn("Could not name the affected entries", output)
+            # The operator still gets the report and the way out of the incident.
+            report = self.read_incident_report(db_path)
+            self.assertEqual(report["status"], "blocked")
+            self.assertIn(f"accept:{report['incident_token']}", output)
+            self.assertEqual(report["affected"], [])
+

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -372,3 +372,36 @@ class RecoveryPageTests(SimpleTestCase):
             page_path = Path(tmp_dir) / "floppy-recovery.html"
             self.assertTrue(page_path.is_file())
             self.assertIn("Your data is safe", page_path.read_text())
+
+    def test_a_damaged_value_does_not_stop_the_page(self):
+        # The page exists because the database is damaged. SQLite gives an
+        # INTEGER column integer affinity only for values that look numeric,
+        # so a damaged season number can be text.
+        report = {
+            "total_conflicts": "many",
+            "can_quarantine": True,
+            "affected": [{"title": "Breaking Bad", "season": "S1", "count": "x"}],
+            "affected_other_titles": None,
+            "affected_unidentified": "?",
+        }
+        page = recovery.render_page(report, interactive=True)
+        self.assertIn("Breaking Bad, Season S1", page)
+        self.assertIn("0 entries", page)
+
+    def test_a_lookalike_host_cannot_make_the_choice(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+            host = base.split("//", 1)[1]
+
+            request = urllib.request.Request(  # noqa: S310
+                f"{base}/accept",
+                data=b"",
+                headers={"Origin": f"http://not{host}"},
+            )
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(request)  # noqa: S310
+            self.assertEqual(ctx.exception.code, 403)
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
+

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -1,0 +1,317 @@
+"""Tests for the SQLite recovery page (issue #731 follow-up)."""
+
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from config import sqlite_recovery_server as recovery
+from config.sqlite_integrity import check_database_integrity
+
+
+class RecoveryPageTests(SimpleTestCase):
+    def create_incident(self, tmp_dir, *, rows=3, with_titles=True):
+        """Create a database whose episodes point at a season that is gone."""
+        db_path = str(Path(tmp_dir) / "db.sqlite3")
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE app_item (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                season_number INTEGER
+            );
+            CREATE TABLE app_season (id INTEGER PRIMARY KEY);
+            CREATE TABLE app_episode (
+                id INTEGER PRIMARY KEY,
+                related_season_id INTEGER NOT NULL REFERENCES app_season(id),
+                item_id INTEGER REFERENCES app_item(id)
+            );
+            INSERT INTO app_season VALUES (500);
+            """
+        )
+        for index in range(1, rows + 1):
+            title = "Breaking Bad" if index % 2 else "The Wire"
+            conn.execute(
+                "INSERT INTO app_item VALUES (?, ?, ?)",
+                (index, title, 1),
+            )
+            conn.execute(
+                "INSERT INTO app_episode VALUES (?, 500, ?)",
+                (index, index if with_titles else None),
+            )
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("DELETE FROM app_season WHERE id = 500")
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def block_startup(self, db_path):
+        """Run the checker so that it writes a blocked report."""
+        with self.assertRaises(SystemExit), mock.patch("sys.stderr"):
+            check_database_integrity(db_path)
+        return json.loads(Path(f"{db_path}.integrity.json").read_text())
+
+    def serve(self, db_path):
+        """Start the handler on a free port and return its base URL."""
+        recovery._Handler.db_path = db_path
+        server = ThreadingHTTPServer(("127.0.0.1", 0), recovery._Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        return f"http://127.0.0.1:{server.server_address[1]}"
+
+    def post(self, url, fields=None):
+        """Send a form post to the recovery page."""
+        data = urllib.parse.urlencode(fields or {}).encode()
+        request = urllib.request.Request(url, data=data)  # noqa: S310
+        return urllib.request.urlopen(request)  # noqa: S310
+
+    def test_health_always_fails_so_the_container_stays_unhealthy(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            for path in ("/health/", "/health"):
+                with self.assertRaises(urllib.error.HTTPError) as ctx:
+                    urllib.request.urlopen(f"{base}{path}")  # noqa: S310
+                # A success here would report the container as healthy while
+                # Floppy cannot serve a single request.
+                self.assertEqual(ctx.exception.code, 503)
+
+    def test_page_names_the_affected_titles(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir, rows=6)
+            report = self.block_startup(db_path)
+
+            titles = {entry["title"] for entry in report["affected"]}
+            self.assertEqual(titles, {"Breaking Bad", "The Wire"})
+            self.assertEqual(
+                sum(entry["count"] for entry in report["affected"]),
+                6,
+            )
+            self.assertEqual(report["affected_unidentified"], 0)
+
+            base = self.serve(db_path)
+            with urllib.request.urlopen(f"{base}/") as response:  # noqa: S310
+                page = response.read().decode()
+            self.assertIn("Your data is safe", page)
+            self.assertIn("Breaking Bad, Season 1", page)
+            self.assertIn("The Wire, Season 1", page)
+
+    def test_rows_without_a_usable_title_are_reported_honestly(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir, rows=4, with_titles=False)
+            report = self.block_startup(db_path)
+
+            # Never invent a title for a row we cannot identify.
+            self.assertEqual(report["affected"], [])
+            self.assertEqual(report["affected_unidentified"], 4)
+            base = self.serve(db_path)
+            with urllib.request.urlopen(f"{base}/") as response:  # noqa: S310
+                page = response.read().decode()
+            self.assertIn("cannot identify", page)
+
+    def test_accept_writes_a_choice_carrying_the_incident_identity(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            self.post(f"{base}/accept").read()
+
+            decision = json.loads(
+                Path(f"{db_path}.integrity.decision").read_text(),
+            )
+            self.assertEqual(decision["action"], "accept")
+            self.assertEqual(decision["fingerprint"], report["fingerprint"])
+            self.assertEqual(decision["token"], report["incident_token"])
+
+    def test_quarantine_without_the_code_changes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                self.post(f"{base}/quarantine", {"token": "wrong"})
+            self.assertEqual(ctx.exception.code, 403)
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_episode").fetchone()[0],
+                3,
+            )
+            conn.close()
+
+    def test_quarantine_with_the_code_records_the_choice(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            self.post(
+                f"{base}/quarantine",
+                {"token": report["incident_token"]},
+            ).read()
+
+            decision = json.loads(
+                Path(f"{db_path}.integrity.decision").read_text(),
+            )
+            self.assertEqual(decision["action"], "quarantine")
+
+    def test_the_page_is_written_beside_the_database_and_is_readable(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+
+            with mock.patch("sys.stderr"):
+                page_path = recovery.write_page(
+                    db_path,
+                    json.loads(Path(f"{db_path}.integrity.json").read_text()),
+                )
+
+            self.assertTrue(page_path.is_file())
+            # The person who runs Floppy must be able to open this file.
+            self.assertEqual(page_path.stat().st_mode & 0o777, 0o644)
+            page = page_path.read_text()
+            self.assertIn("Your data is safe", page)
+            # The written copy cannot act, so it must not offer buttons.
+            self.assertNotIn("<form", page)
+
+    def test_a_choice_for_a_different_incident_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+
+            Path(f"{db_path}.integrity.decision").write_text(
+                json.dumps(
+                    {
+                        "action": "quarantine",
+                        "fingerprint": "0" * 64,
+                        "token": report["incident_token"],
+                    },
+                ),
+            )
+            with self.assertRaises(SystemExit), mock.patch("sys.stderr"):
+                check_database_integrity(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_episode").fetchone()[0],
+                3,
+            )
+            conn.close()
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
+
+    def test_a_choice_with_an_old_code_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+
+            Path(f"{db_path}.integrity.decision").write_text(
+                json.dumps(
+                    {
+                        "action": "quarantine",
+                        "fingerprint": report["fingerprint"],
+                        "token": "0" * 32,
+                    },
+                ),
+            )
+            with self.assertRaises(SystemExit), mock.patch("sys.stderr"):
+                check_database_integrity(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_episode").fetchone()[0],
+                3,
+            )
+            conn.close()
+
+    def test_a_malformed_choice_changes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            Path(f"{db_path}.integrity.decision").write_text("not json")
+
+            with self.assertRaises(SystemExit), mock.patch("sys.stderr"):
+                check_database_integrity(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_episode").fetchone()[0],
+                3,
+            )
+            conn.close()
+
+    def test_a_valid_choice_starts_floppy_without_changing_rows(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+
+            Path(f"{db_path}.integrity.decision").write_text(
+                json.dumps(
+                    {
+                        "action": "accept",
+                        "fingerprint": report["fingerprint"],
+                        "token": report["incident_token"],
+                    },
+                ),
+            )
+            with mock.patch("sys.stderr"):
+                check_database_integrity(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_episode").fetchone()[0],
+                3,
+            )
+            conn.close()
+            # The choice is used once and then removed.
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
+
+    def test_a_missing_report_still_produces_a_readable_page(self):
+        page = recovery.render_page(None, interactive=True)
+        self.assertIn("Your data is safe", page)
+        self.assertNotIn("<form", page)
+
+    def test_the_page_does_not_request_anything_external(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+            page = recovery.render_page(report, interactive=True)
+            # The file opens from disk, where no external request can resolve.
+            for marker in ("http://", "https://", "<script", "<link"):
+                self.assertNotIn(marker, page.replace("http://127.0.0.1", ""))
+
+    def test_a_busy_port_does_not_stop_the_page_from_being_written(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+
+            with (
+                mock.patch.object(
+                    recovery,
+                    "ThreadingHTTPServer",
+                    side_effect=OSError("address already in use"),
+                ),
+                mock.patch("sys.stderr"),
+            ):
+                recovery.serve(db_path)
+
+            page_path = Path(tmp_dir) / "floppy-recovery.html"
+            self.assertTrue(page_path.is_file())
+            self.assertIn("Your data is safe", page_path.read_text())

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -288,14 +288,71 @@ class RecoveryPageTests(SimpleTestCase):
         self.assertIn("Your data is safe", page)
         self.assertNotIn("<form", page)
 
-    def test_the_page_does_not_request_anything_external(self):
+    def test_the_page_loads_no_external_resource(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_incident(tmp_dir)
             report = self.block_startup(db_path)
             page = recovery.render_page(report, interactive=True)
-            # The file opens from disk, where no external request can resolve.
-            for marker in ("http://", "https://", "<script", "<link"):
-                self.assertNotIn(marker, page.replace("http://127.0.0.1", ""))
+            # The page also opens from disk, where a subresource request cannot
+            # resolve. Styles and scripts stay inline. A link is different: the
+            # person clicks it, so the page requests nothing.
+            for marker in ("src=", "<link ", "@import"):
+                self.assertNotIn(marker, page)
+
+    def test_the_page_never_shows_the_approval_code(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+            token = report["incident_token"]
+            self.assertTrue(token)
+            for interactive in (True, False):
+                page = recovery.render_page(report, interactive=interactive)
+                # The code proves that the person read the report file. If the
+                # page shows it, the code proves only that they opened a page
+                # that anyone on the network can open.
+                self.assertNotIn(token, page)
+                self.assertNotIn(f"quarantine:{token}", page)
+
+    def test_the_page_offers_places_to_get_help(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+            for candidate in (report, None):
+                page = recovery.render_page(candidate, interactive=True)
+                self.assertIn("github.com/dannyvfilms/Floppy/issues", page)
+                self.assertIn("github.com/dannyvfilms/Floppy/wiki", page)
+                self.assertIn("discord.gg/QfNA6zJ5Ws", page)
+
+    def test_a_cross_site_form_cannot_make_the_choice(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            request = urllib.request.Request(  # noqa: S310
+                f"{base}/accept",
+                data=b"",
+                headers={"Sec-Fetch-Site": "cross-site"},
+            )
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(request)  # noqa: S310
+            self.assertEqual(ctx.exception.code, 403)
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
+
+    def test_an_oversized_body_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            request = urllib.request.Request(  # noqa: S310
+                f"{base}/quarantine",
+                data=b"token=" + b"a" * 9000,
+            )
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(request)  # noqa: S310
+            self.assertEqual(ctx.exception.code, 400)
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
 
     def test_a_busy_port_does_not_stop_the_page_from_being_written(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## The problem

When the foreign key check fails, Floppy pauses before migrations and stays
idle. This is correct: an orphaned row is not safe to read. Django builds an
INNER JOIN for `select_related` on a NOT NULL foreign key, so an orphaned row
does not come back in the queryset. It disappears from the page without an
error. Starting anyway would show a library that quietly misses entries.

But the person who runs Floppy saw only this:

- The web address did not answer.
- The container reported "unhealthy".
- The reason was in the container log, which many people never open.

The usual conclusion was "Floppy lost my data". The data was never touched.

This branch keeps the pause and adds a page that says so.

## What a person sees now

Floppy serves a recovery page on the usual port while it is paused. The page
names what is affected, offers the two choices, and points to help.

<!-- screenshots: console-dark.png, console-light.png -->

The page also writes itself to `floppy-recovery.html`, beside the database. If
the port is in use, or the container is stopped, the file still opens.

### It names what is affected

Earlier the report gave a number only. A number does not tell a person whether
the problem is one show or the whole library. The page now groups the affected
entries by title and season:

```
What is affected
  Breaking Bad, Season 1        40 entries
  Breaking Bad, Season 2        13 entries
  The Wire, Season 1             9 entries
  Severance, Season 2            6 entries
  Andor, Season 1                4 entries
  and 2 other titles             3 entries
```

The list is bounded at five titles. The remainder is summed into one row, so
an incident with 4000 titles cannot fill the page.

**This adds no column and no migration.** The reference that breaks is not the
one that carries the title. An affected `app_episode` row usually still points
at a valid `app_item`, so the title and the season number survive the incident.
The lookup reads only `item_id`, which already exists. A table without
`item_id`, and a row whose `item_id` no longer resolves, are counted as
"Entries we cannot identify", so the numbers always add up to the total.

### It offers the two choices

**Start anyway, keep everything.** Floppy starts and changes no data. The
affected entries stay hidden until they are repaired.

**Remove the affected entries.** Floppy saves a verified backup first, then
removes the affected rows, then starts.

The second choice deletes data, so it asks for the approval code from
`db.sqlite3.integrity.json`. That file sits beside the database. Only a person
who can read the database folder can read it. A wrong code changes nothing:

<!-- screenshot: console-wrong-code.png -->

A choice made on the page is written to `db.sqlite3.integrity.decision`. The
integrity check reads that file on the next start, applies it once, and removes
it. The file carries the fingerprint and the code of the incident it was made
for, so a choice made for an earlier problem can never apply to a later one.
This is the same test the `FLOPPY_SQLITE_CONFLICT_ACTION` variable already had,
and that variable still works exactly as before.

### It offers help

The page links to the issue tracker, the wiki, and Discord, and a button copies
the technical details for a bug report. `navigator.clipboard` exists only in a
secure context, and Floppy is usually opened over plain HTTP on a local
address, so the button falls back to the older copy command. The text stays on
the page, so a person can always select it by hand.

## What did not change

- Floppy still pauses. It does not start with orphaned rows unless a person
  asks for it.
- The health check still fails while paused. A success there would report the
  container as healthy while it serves nothing.
- `FLOPPY_SQLITE_CONFLICT_ACTION` works as before.
- No migration, no new column, no new dependency. The page uses the standard
  library only, because Django cannot serve it: the database is the thing that
  is paused, and migrations have not run.

## How it was tested

`58` unit tests, and every path reproduced in a real image built from this
branch. The test database holds 75 orphaned episodes across 7 title and season
groups, made by deleting `app_season` rows with foreign keys off.

| Path | Result |
| --- | --- |
| Pause | Page served, `floppy-recovery.html` written, `/health` answers 503 |
| Report | 75 conflicts, 20 samples logged (bounded), report at mode 0600 |
| Naming | 40 + 13 + 9 + 6 + 4 + 3 = 75. The numbers add up |
| Start anyway | Choice used once, then removed. 75 entries kept. No backup made |
| Remove entries | Backup made **first**, holds all 75. Live database: 0 orphans, `quick_check` ok |
| Bystanders | `app_item` 14, `app_tv` 7, `users_user` 2. Untouched |
| Wrong code | 403, no decision file, no change |
| Cross-site POST | 403, no decision file |
| Lookalike Origin | 403, no decision file |
| Oversized body | 400, no decision file |
| TERM while paused | Exit 0 in under one second, data untouched |
| No report file | Page still opens and still links to help. POST answers 404 |

## Post-mortem

Four defects were found and fixed inside this branch before it was opened. All
four are recorded here because the pattern behind them is worth keeping.

**1. The page showed the approval code (critical).** The "Technical details"
block wrote the whole report to the page, and the report holds
`incident_token`, and holds it twice more inside `actions`. The code is meant
to prove that a person read a file in the database folder. It proved only that
they opened a page. Anyone who could reach the port could copy the code and
send it to `/quarantine`, which deletes rows on the next start. Confirmed
before the fix: the code appeared in the page. The page now hides
`incident_token` and `actions`, and a test asserts the code never appears in
either the served page or the file on disk.

**2. Naming the titles could suppress the whole report (high).** The lookup ran
before the report was written, and nothing caught its errors. On a damaged
database the join can raise "database disk image is malformed". The run then
ended with no report file, no approval code, and no
`FLOPPY_SQLITE_CONFLICT_ACTION` line in the log. There was no way out of the
incident at all. This was worse than the behaviour before the branch, where the
report was always written. The lookup is now wrapped: a failure logs one line
and continues.

**3. A damaged value stopped the page (medium).** The page called `int()` on
values it read from the report. SQLite gives an INTEGER column integer affinity
only for values that look numeric, so a damaged season number can hold text
such as `S1`. `int("S1")` raised, and the page answered 500 at the moment a
person most needed it. A damaged value now shows on the page instead of hiding
it.

**4. A lookalike host passed the cross-site check (low).** The check compared
Origin with `endswith` against Host, so `notfloppy.local:8000` passed for
`floppy.local:8000`. The whole name is now compared.

**The common cause.** Every one of these is the same mistake: code added to
*explain* an incident could itself fail on the damaged database that *caused*
the incident, and it sat in front of the code that gets a person out. The rule
this branch now follows is that the report and the way out come first, and
every convenience added around them is allowed to fail quietly.

**What caught them.** Defect 1 came from an independent adversarial review, not
from the tests. The tests passed. A test that asserted the code never reaches
the page did not exist, because the leak came in through a debugging block
added after the security tests were written. Defects 2, 3 and 4 came from a
line-by-line review of this branch's own diff, and each was reproduced before
it was fixed. Every one now has a test.

### One cost worth naming

Naming the titles reads every foreign key, so the pause path now runs that scan
twice instead of once, and the remove path three times instead of twice. The
whole check keeps its 600 second bound. The scan is skipped completely on a
database with no `app_item` table, which is the only thing that makes it
useful. On a Floppy database the cost stays. It is accepted here because the
container is already stopped and a person is already waiting, and because
knowing which shows are affected is the point of the change.

### Known limit

The recovery page runs before Floppy drops to the `abc` user, so it serves as
root. It reads two files and writes one, runs no command, caps a request body
at 4096 bytes, and times out a socket at 15 seconds. Dropping privileges first
would risk leaving it unable to write the decision file into a folder whose
ownership has not been fixed yet, which would break the only way out of an
incident. The safer trade was taken deliberately and is recorded here.

Refs #731
