### PR TITLE
🔒 fix(lists): harden separate entry display and add regression suite

### DIFF
--- a/src/app/media_list_entry_grouping.py
+++ b/src/app/media_list_entry_grouping.py
@@ -1,0 +1,211 @@
+"""Request-scoped policy for grouping matching media-list entries."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+
+from django.apps import apps
+from django.db import models
+
+from app import cache_utils
+from app.models.choices import MediaTypes
+from app.models.manager import MediaManager
+from users.models import MediaStatusChoices
+
+ENTRY_GROUPING_PREFERENCE_FIELDS = {
+    MediaTypes.MOVIE.value: "movie_show_each_play",
+    MediaTypes.ANIME.value: "anime_show_each_play",
+    MediaTypes.MANGA.value: "manga_show_each_play",
+    MediaTypes.GAME.value: "game_show_each_play",
+    MediaTypes.BOOK.value: "book_show_each_play",
+}
+
+_ENTRY_GROUPING_MODE: ContextVar[bool | None] = ContextVar(
+    "media_list_entry_grouping_mode",
+    default=None,
+)
+_POST_SORT_KEYS = frozenset({"progress", "plays", "next_episode_air_date"})
+_DEFERRED_ITEM_FIELDS = (
+    "item__isbn",
+    "item__creators",
+    "item__provider_keywords",
+    "item__provider_external_ids",
+    "item__provider_certification",
+    "item__provider_collection_id",
+    "item__provider_collection_name",
+    "item__provider_game_lengths_match",
+    "item__provider_game_lengths_fetched_at",
+    "item__trakt_popularity_fetched_at",
+    "item__metadata_fetched_at",
+    "item__themes",
+    "item__provider_popularity",
+    "item__provider_rating_count",
+    "item__trakt_rating",
+    "item__trakt_rating_count",
+    "item__trakt_popularity_score",
+    "item__publishers",
+    "item__source_material",
+    "item__series_name",
+)
+
+
+def preference_field(media_type: str) -> str | None:
+    """Return the saved preference field for a supported media type."""
+    return ENTRY_GROUPING_PREFERENCE_FIELDS.get(media_type)
+
+
+def show_separate_entries(user, media_type: str) -> bool:
+    """Return whether the user wants matching entries as separate rows."""
+    field_name = preference_field(media_type)
+    return bool(field_name and getattr(user, field_name, False))
+
+
+@contextmanager
+def entry_grouping_mode(enabled: bool | None):
+    """Set the list-entry grouping mode for one request context."""
+    token = _ENTRY_GROUPING_MODE.set(enabled)
+    try:
+        yield
+    finally:
+        _ENTRY_GROUPING_MODE.reset(token)
+
+
+def _normalized_status_filters(status_filter) -> list[str]:
+    if isinstance(status_filter, (list, tuple, set, frozenset)):
+        return [
+            value
+            for value in status_filter
+            if value and value != MediaStatusChoices.ALL
+        ]
+    if status_filter and status_filter != MediaStatusChoices.ALL:
+        return [status_filter]
+    return []
+
+
+def _get_separate_media_list(
+    manager,
+    user,
+    media_type,
+    status_filter,
+    sort_filter,
+    search,
+    direction,
+    list_sql_filters,
+):
+    """Return raw tracking rows without duplicate reduction or aggregation."""
+    model = apps.get_model(app_label="app", model_name=media_type)
+    direction = manager.resolve_direction(sort_filter, direction)
+    queryset = model.objects.filter(user=user.id)
+
+    status_filters = _normalized_status_filters(status_filter)
+    if status_filters:
+        queryset = queryset.filter(status__in=status_filters)
+    else:
+        queryset = queryset.exclude(status__isnull=True)
+
+    if search:
+        queryset = queryset.filter(
+            models.Q(item__title__icontains=search)
+            | models.Q(item__media_id__icontains=search),
+        )
+
+    queryset = manager._apply_list_sql_filters(
+        queryset,
+        user,
+        media_type,
+        list_sql_filters or {},
+    )
+    queryset = queryset.select_related("item").defer(*_DEFERRED_ITEM_FIELDS)
+    queryset = manager._apply_prefetch_related(
+        queryset,
+        media_type,
+        list_mode=True,
+    )
+
+    if not sort_filter:
+        return list(queryset)
+
+    if (
+        sort_filter in _POST_SORT_KEYS
+        and media_type not in {MediaTypes.TV.value, MediaTypes.SEASON.value}
+    ):
+        queryset = list(queryset)
+
+    return list(
+        manager._sort_media_list(
+            queryset,
+            sort_filter,
+            media_type,
+            direction,
+        )
+    )
+
+
+def _install_media_list_policy() -> None:
+    current_method = MediaManager.get_media_list
+    if hasattr(current_method, "_supports_entry_grouping_context"):
+        return
+
+    @wraps(current_method)
+    def get_media_list(
+        manager,
+        user,
+        media_type,
+        status_filter,
+        sort_filter,
+        search=None,
+        direction=None,
+        *,
+        list_sql_filters=None,
+    ):
+        """Return media rows under the active entry-grouping policy."""
+        if _ENTRY_GROUPING_MODE.get() is not True:
+            return current_method(
+                manager,
+                user,
+                media_type,
+                status_filter,
+                sort_filter,
+                search,
+                direction,
+                list_sql_filters=list_sql_filters,
+            )
+
+        return _get_separate_media_list(
+            manager,
+            user,
+            media_type,
+            status_filter,
+            sort_filter,
+            search,
+            direction,
+            list_sql_filters,
+        )
+
+    get_media_list._supports_entry_grouping_context = True
+    MediaManager.get_media_list = get_media_list
+
+
+def _install_cache_key_policy() -> None:
+    current_builder = cache_utils.build_media_list_cache_key
+    if hasattr(current_builder, "_supports_entry_grouping_context"):
+        return
+
+    @wraps(current_builder)
+    def build_media_list_cache_key(*args, **kwargs):
+        """Build a cache key with the active entry-grouping mode."""
+        cache_key = current_builder(*args, **kwargs)
+        mode = _ENTRY_GROUPING_MODE.get()
+        if mode is None:
+            return cache_key
+        mode_key = "separate" if mode else "grouped"
+        return f"{cache_key}_entry_grouping_{mode_key}"
+
+    build_media_list_cache_key._supports_entry_grouping_context = True
+    cache_utils.build_media_list_cache_key = build_media_list_cache_key
+
+
+_install_media_list_policy()
+_install_cache_key_policy()

--- a/src/app/media_list_entry_grouping_views.py
+++ b/src/app/media_list_entry_grouping_views.py
@@ -1,0 +1,83 @@
+"""Media-list routes for explicit entry-grouping preferences."""
+
+from __future__ import annotations
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import Http404, HttpResponseBadRequest
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.http import require_GET, require_POST
+
+from app import cache_utils
+from app.media_list_entry_grouping import (
+    entry_grouping_mode,
+    preference_field,
+    show_separate_entries,
+)
+from app.media_list_views import media_list as base_media_list
+from app.models.choices import MediaTypes
+
+_BOOLEAN_VALUES = {"false": False, "true": True}
+
+
+def _safe_return_url(request, media_type: str) -> str:
+    target = (request.POST.get("next") or "").strip()
+    if target.startswith("/") and url_has_allowed_host_and_scheme(
+        target,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return target
+    return reverse("medialist", args=[media_type])
+
+
+@login_required
+@require_GET
+def media_list(request, media_type: str):
+    """Render a media list with one request-scoped grouping policy."""
+    if media_type not in MediaTypes.values:
+        raise Http404
+
+    field_name = preference_field(media_type)
+    mode = show_separate_entries(request.user, media_type) if field_name else None
+
+    original_query = request.GET
+    if "separate_plays" in original_query:
+        request.GET = original_query.copy()
+        request.GET.pop("separate_plays", None)
+
+    try:
+        with entry_grouping_mode(mode):
+            return base_media_list(request, media_type)
+    finally:
+        request.GET = original_query
+
+
+@login_required
+@require_POST
+def update_entry_grouping(request, media_type: str):
+    """Save whether a supported media list groups matching entries."""
+    field_name = preference_field(media_type)
+    if field_name is None:
+        return HttpResponseBadRequest(
+            "This media type does not support separate entries."
+        )
+
+    raw_value = request.POST.get("show_separate_entries")
+    if raw_value not in _BOOLEAN_VALUES:
+        return HttpResponseBadRequest("Select a valid entry display setting.")
+
+    enabled = _BOOLEAN_VALUES[raw_value]
+    if getattr(request.user, field_name) != enabled:
+        request.user.update_preference(field_name, enabled)
+        cache_utils.clear_media_list_cache_for_user(request.user.id)
+
+    message = (
+        "Matching entries are now shown separately."
+        if enabled
+        else "Matching entries are now grouped."
+    )
+    messages.success(request, message)
+    return redirect(_safe_return_url(request, media_type))

--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -473,8 +473,6 @@ def build_filter_data_from_items(
 def media_list(request, media_type):
     """Return the media list page."""
     route_media_type = media_type
-    context_show_each_play = False
-    aggregate_duplicates = True
     comic_subview = None
     if route_media_type == MediaTypes.COMIC.value:
         comic_subview = request.GET.get("subview", "comics")
@@ -604,17 +602,6 @@ def media_list(request, media_type):
             )
         request.user.update_preference(direction_field, direction)
     media_type = effective_media_type
-    
-    # Which media types should show the "Show all plays" menu item.
-    # Change this set to include any other types you want (e.g. MediaTypes.TV.value).
-    _show_separate_plays_allowed = {
-        MediaTypes.MOVIE.value,
-        MediaTypes.ANIME.value,
-        MediaTypes.MANGA.value,
-        MediaTypes.GAME.value,
-        MediaTypes.BOOK.value,
-    }
-    show_separate_plays = media_type in _show_separate_plays_allowed
 
     # Pre-filter sort choices to only include those valid for the current media type.
     # critic_rating and author remain template-gated via supports_critic_rating_sort /
@@ -1543,35 +1530,6 @@ def media_list(request, media_type):
             # Sentinel: skips the list build below; the page is hydrated
             # from _time_left_cached_order in the time_left branch.
             _media_list_cached = []
-            
-    # Read in context_show_each_play
-    # Read and persist the preference (toggle via ?separate_plays=1/0)
-    separate_param = request.GET.get("separate_plays")  # will be '0' or '1' if you use the hidden input
-
-    if request.user.is_authenticated:
-        # If user provided the param, persist it
-        if separate_param is not None:
-            new_val = str(separate_param).lower() in ("1", "true", "yes")
-            try:
-                request.user.update_preference(f"{route_media_type}_show_each_play", new_val)
-                try:
-                    _media_list_cached = None
-                except NameError:
-                    # If that variable doesn't exist yet, ignore
-                    pass
-            except Exception:
-                logger.exception("Failed to persist %s_show_each_play", route_media_type)
-
-        # Always read persisted preference for authenticated users
-        context_show_each_play = bool(getattr(request.user, f"{route_media_type}_show_each_play", False))
-    else:
-        # Anonymous: use the param for the current request only (no DB write)
-        if separate_param is not None:
-            context_show_each_play = str(separate_param).lower() in ("1", "true", "yes")
-        else:
-            context_show_each_play = False
-
-    aggregate_duplicates = not context_show_each_play
 
     if _media_list_cached is None:
         media_queryset = BasicMedia.objects.get_media_list(
@@ -1581,8 +1539,7 @@ def media_list(request, media_type):
             sort_filter=query_sort_filter,
             search=search_query,
             direction=direction,
-            list_sql_filters=list_sql_filters,            
-            aggregate_duplicates=aggregate_duplicates,
+            list_sql_filters=list_sql_filters,
         )
 
         # Convert to list for filtering (rating and collection filters work on lists)
@@ -2144,8 +2101,6 @@ def media_list(request, media_type):
         "is_artist_list": False,
         "is_album_list": False,
         "supports_critic_rating_sort": media_type in critic_rating_media_types,
-        "show_each_play": context_show_each_play,
-        "show_separate_plays": show_separate_plays,
     }
     if comic_subview:
         context["current_subview"] = comic_subview

--- a/src/app/models/manager.py
+++ b/src/app/models/manager.py
@@ -253,7 +253,6 @@ class MediaManager(models.Manager):
         direction=None,
         *,
         list_sql_filters=None,
-        aggregate_duplicates=True,
     ):
         """Get a media list by type with filtering and sorting."""
         model = apps.get_model(app_label="app", model_name=media_type)
@@ -294,39 +293,37 @@ class MediaManager(models.Manager):
         )
 
         # Handle duplicate entries by selecting the most recent record for each item
-        # Only process if aggregate_duplicates is True
-        if aggregate_duplicates:
-            has_progress_field = any(
-                getattr(field, "attname", "") == "progress"
-                for field in model._meta.get_fields()
-                if getattr(field, "concrete", False)
-            )
-            if sort_filter == "progress" and has_progress_field:
-                # For progress sorting, select the record with highest individual progress
-                queryset = queryset.annotate(
-                    repeats=Window(
-                        expression=Count("id"),
-                        partition_by=[F("item")],
-                    ),
-                    row_number=Window(
-                        expression=RowNumber(),
-                        partition_by=[F("item")],
-                        order_by=F("progress").desc(),
-                    ),
-                ).filter(row_number=1)
-            else:
-                # For non-progress sorting, select the most recent record
-                queryset = queryset.annotate(
-                    repeats=Window(
-                        expression=Count("id"),
-                        partition_by=[F("item")],
-                    ),
-                    row_number=Window(
-                        expression=RowNumber(),
-                        partition_by=[F("item")],
-                        order_by=F("created_at").desc(),
-                    ),
-                ).filter(row_number=1)
+        has_progress_field = any(
+            getattr(field, "attname", "") == "progress"
+            for field in model._meta.get_fields()
+            if getattr(field, "concrete", False)
+        )
+        if sort_filter == "progress" and has_progress_field:
+            # For progress sorting, select the record with highest individual progress
+            queryset = queryset.annotate(
+                repeats=Window(
+                    expression=Count("id"),
+                    partition_by=[F("item")],
+                ),
+                row_number=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("item")],
+                    order_by=F("progress").desc(),
+                ),
+            ).filter(row_number=1)
+        else:
+            # For non-progress sorting, select the most recent record
+            queryset = queryset.annotate(
+                repeats=Window(
+                    expression=Count("id"),
+                    partition_by=[F("item")],
+                ),
+                row_number=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("item")],
+                    order_by=F("created_at").desc(),
+                ),
+            ).filter(row_number=1)
 
         queryset = queryset.select_related("item").defer(
             "item__isbn",
@@ -373,12 +370,7 @@ class MediaManager(models.Manager):
 
         # Re-apply duplicate aggregation because SQL queryset operations in sorting
         # can materialize fresh model instances and drop dynamic aggregated attrs.
-        if not aggregate_duplicates: 
-            # materialize and return rows as-is (no aggregated_* attributes)
-            return list(queryset)
-        else:
-            # re-apply aggregate duplicate data
-            return self._aggregate_duplicate_data(queryset, user, media_type, dup_state)
+        return self._aggregate_duplicate_data(queryset, user, media_type, dup_state)
 
     def _aggregate_duplicate_data(self, queryset, user, media_type, dup_state=None):
         """Aggregate data from duplicate entries for each item."""

--- a/src/app/templatetags/media_list_entry_grouping.py
+++ b/src/app/templatetags/media_list_entry_grouping.py
@@ -1,0 +1,29 @@
+"""Template state for the media-list entry-grouping control."""
+
+from django import template
+
+from app.media_list_entry_grouping import (
+    preference_field,
+    show_separate_entries,
+)
+
+register = template.Library()
+
+
+@register.simple_tag
+def media_list_entry_grouping_control(request):
+    """Return the supported state for the current media-list route."""
+    resolver_match = request.resolver_match
+    media_type = (
+        resolver_match.kwargs.get("media_type")
+        if resolver_match is not None
+        else None
+    )
+    supported = preference_field(media_type) is not None
+    enabled = supported and show_separate_entries(request.user, media_type)
+    return {
+        "enabled": enabled,
+        "next_value": "false" if enabled else "true",
+        "state_label": "On" if enabled else "Off",
+        "supported": supported,
+    }

--- a/src/app/tests/views/test_media_list_entry_grouping.py
+++ b/src/app/tests/views/test_media_list_entry_grouping.py
@@ -1,0 +1,247 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from app import cache_utils, media_list_entry_grouping
+from app.media_list_entry_grouping import entry_grouping_mode
+from app.models import (
+    TV,
+    BasicMedia,
+    Item,
+    MediaTypes,
+    Movie,
+    Sources,
+    Status,
+)
+from users.models import MediaStatusChoices
+
+
+class MediaListEntryGroupingTests(TestCase):
+    def setUp(self):
+        self.credentials = {"username": "entry-grouping", "password": "12345"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+        self.client.login(**self.credentials)
+        self.movie_url = reverse("medialist", args=[MediaTypes.MOVIE.value])
+        self.movie_item = Item.objects.create(
+            media_id="entry-grouping-movie",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Entry Grouping Movie",
+            image="http://example.com/entry-grouping.jpg",
+        )
+        Movie.objects.bulk_create(
+            [
+                Movie(
+                    item=self.movie_item,
+                    user=self.user,
+                    status=Status.COMPLETED.value,
+                    progress=1,
+                    end_date=timezone.now() - timedelta(days=2),
+                ),
+                Movie(
+                    item=self.movie_item,
+                    user=self.user,
+                    status=Status.COMPLETED.value,
+                    progress=2,
+                    end_date=timezone.now() - timedelta(days=1),
+                ),
+            ],
+        )
+        cache.clear()
+
+    def _manager_list(self, *, sort_filter="title", direction="asc"):
+        return BasicMedia.objects.get_media_list(
+            user=self.user,
+            media_type=MediaTypes.MOVIE.value,
+            status_filter=MediaStatusChoices.ALL,
+            sort_filter=sort_filter,
+            direction=direction,
+        )
+
+    def test_default_mode_groups_matching_entries(self):
+        media_list = self._manager_list()
+
+        self.assertEqual(len(media_list), 1)
+        self.assertEqual(media_list[0].repeats, 2)
+
+    def test_separate_mode_returns_raw_progress_rows_without_aggregate_values(self):
+        with entry_grouping_mode(True):
+            media_list = self._manager_list(sort_filter="progress", direction="asc")
+
+        self.assertEqual([entry.progress for entry in media_list], [1, 2])
+        self.assertFalse(
+            any(hasattr(entry, "aggregated_progress") for entry in media_list)
+        )
+
+    def test_entry_modes_have_distinct_processed_list_cache_keys(self):
+        key_args = {
+            "user_id": self.user.id,
+            "media_type": MediaTypes.MOVIE.value,
+            "sort_filter": "title",
+            "direction": "asc",
+            "status_filter": "",
+            "search_query": "",
+            "rating_filter": "all",
+        }
+
+        with entry_grouping_mode(False):
+            grouped_key = cache_utils.build_media_list_cache_key(**key_args)
+        with entry_grouping_mode(True):
+            separate_key = cache_utils.build_media_list_cache_key(**key_args)
+
+        self.assertNotEqual(grouped_key, separate_key)
+        self.assertTrue(grouped_key.endswith("_entry_grouping_grouped"))
+        self.assertTrue(separate_key.endswith("_entry_grouping_separate"))
+
+    def test_get_query_cannot_change_the_saved_preference(self):
+        response = self.client.get(f"{self.movie_url}?separate_plays=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.movie_show_each_play)
+
+    def test_post_updates_each_supported_preference_and_preserves_the_full_view(self):
+        preference_fields = {
+            MediaTypes.MOVIE.value: "movie_show_each_play",
+            MediaTypes.ANIME.value: "anime_show_each_play",
+            MediaTypes.MANGA.value: "manga_show_each_play",
+            MediaTypes.GAME.value: "game_show_each_play",
+            MediaTypes.BOOK.value: "book_show_each_play",
+        }
+
+        for media_type, field_name in preference_fields.items():
+            with self.subTest(media_type=media_type):
+                endpoint = reverse("medialist_entry_grouping", args=[media_type])
+                target = (
+                    reverse("medialist", args=[media_type])
+                    + "?status=Completed&layout=table&tag=Favorite&tag_mode=not"
+                )
+                response = self.client.post(
+                    endpoint,
+                    {"show_separate_entries": "true", "next": target},
+                )
+
+                self.assertRedirects(response, target, fetch_redirect_response=False)
+                self.user.refresh_from_db()
+                self.assertTrue(getattr(self.user, field_name))
+
+    def test_post_rejects_invalid_values_and_unsupported_media_types(self):
+        movie_endpoint = reverse(
+            "medialist_entry_grouping",
+            args=[MediaTypes.MOVIE.value],
+        )
+        tv_endpoint = reverse(
+            "medialist_entry_grouping",
+            args=[MediaTypes.TV.value],
+        )
+
+        invalid_value = self.client.post(
+            movie_endpoint,
+            {"show_separate_entries": "yes"},
+        )
+        unsupported_type = self.client.post(
+            tv_endpoint,
+            {"show_separate_entries": "true"},
+        )
+
+        self.assertEqual(invalid_value.status_code, 400)
+        self.assertEqual(unsupported_type.status_code, 400)
+
+    def test_post_rejects_an_external_return_url(self):
+        endpoint = reverse(
+            "medialist_entry_grouping",
+            args=[MediaTypes.MOVIE.value],
+        )
+
+        response = self.client.post(
+            endpoint,
+            {
+                "show_separate_entries": "true",
+                "next": "//example.invalid/account",
+            },
+        )
+
+        self.assertRedirects(
+            response,
+            self.movie_url,
+            fetch_redirect_response=False,
+        )
+
+    def test_separate_mode_does_not_reuse_a_grouped_cache_entry(self):
+        list_url = f"{self.movie_url}?search=Entry+Grouping+Movie&sort=title"
+        grouped_response = self.client.get(list_url)
+        self.assertEqual(grouped_response.context["media_list"].paginator.count, 1)
+
+        with mock.patch(
+            "app.media_list_entry_grouping_views."
+            "cache_utils.clear_media_list_cache_for_user"
+        ):
+            self.client.post(
+                reverse(
+                    "medialist_entry_grouping",
+                    args=[MediaTypes.MOVIE.value],
+                ),
+                {"show_separate_entries": "true", "next": list_url},
+            )
+
+        separate_response = self.client.get(list_url)
+        self.assertEqual(separate_response.context["media_list"].paginator.count, 2)
+
+    def test_tv_backed_anime_uses_the_same_separate_entry_mode(self):
+        anime_item = Item.objects.create(
+            media_id="grouped-entry-anime",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            library_media_type=MediaTypes.ANIME.value,
+            title="Grouped Entry Anime",
+            image="http://example.com/grouped-entry-anime.jpg",
+        )
+        TV.objects.bulk_create(
+            [
+                TV(
+                    item=anime_item,
+                    user=self.user,
+                    status=Status.COMPLETED.value,
+                ),
+            ],
+        )
+        self.user.anime_library_mode = MediaTypes.ANIME.value
+        self.user.anime_show_each_play = True
+        self.user.save(
+            update_fields=["anime_library_mode", "anime_show_each_play"]
+        )
+        cache.clear()
+
+        with mock.patch.object(
+            media_list_entry_grouping,
+            "_get_separate_media_list",
+            wraps=media_list_entry_grouping._get_separate_media_list,
+        ) as separate_media_list:
+            response = self.client.get(
+                reverse("medialist", args=[MediaTypes.ANIME.value])
+                + "?search=Grouped+Entry+Anime&sort=title",
+            )
+
+        called_media_types = {
+            call.args[2] for call in separate_media_list.call_args_list
+        }
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["media_list"].paginator.count, 1)
+        self.assertIn(MediaTypes.ANIME.value, called_media_types)
+        self.assertIn(MediaTypes.TV.value, called_media_types)
+
+    def test_control_exposes_clear_state_and_keyboard_support(self):
+        response = self.client.get(self.movie_url)
+
+        self.assertContains(response, 'aria-label="View settings"')
+        self.assertContains(response, ':aria-expanded="open.toString()"')
+        self.assertContains(response, 'aria-pressed="false"')
+        self.assertContains(response, "Show matching entries separately")
+        self.assertContains(response, "Off")
+        self.assertContains(response, "@keydown.escape.window")

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -20,6 +20,12 @@ from drf_spectacular.views import SpectacularAPIView
 from health_check.views import MainView
 
 from api.contract_views import api_docs, openapi_contract
+from app.media_list_entry_grouping_views import (
+    media_list as media_list_with_entry_grouping,
+)
+from app.media_list_entry_grouping_views import (
+    update_entry_grouping,
+)
 from users.views import CustomSignupView, CustomSocialSignupView
 
 handler400 = "app.error_views.bad_request"
@@ -34,6 +40,14 @@ urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/openapi.yaml", openapi_contract, name="openapi-contract"),
     path("api/docs/", api_docs, name="swagger-ui"),
+    path(
+        "medialist/<str:media_type>/entry-grouping/",
+        update_entry_grouping,
+        name="medialist_entry_grouping",
+    ),
+    # Keep the established named route in app.urls. This earlier route handles
+    # requests for the same URL and applies the request-scoped display policy.
+    path("medialist/<str:media_type>", media_list_with_entry_grouping),
     path("", include("app.urls")),
     path("", include("integrations.urls")),
     path("", include("users.urls")),

--- a/src/templates/app/components/media_settings_menu.html
+++ b/src/templates/app/components/media_settings_menu.html
@@ -1,12 +1,20 @@
+{% load media_list_entry_grouping %}
+{% media_list_entry_grouping_control request as entry_grouping %}
 <div class="relative filter-control {{ menu_class|default:'' }}"
      x-data="{ open: false, sharing: false }"
-     @click.outside="open = false">
+     @click.outside="open = false"
+     @keydown.escape.window="if (open) { open = false; $refs.trigger.focus(); }">
   <button class="p-2 rounded-md border border-gray-700 bg-[var(--color-surface-strong)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-secondary)] transition-colors cursor-pointer"
           title="View settings"
+          aria-label="View settings"
+          :aria-expanded="open.toString()"
+          x-ref="trigger"
           @click="open = !open"
           type="button">{% include "app/icons/settings.svg" with classes="w-5 h-5" %}</button>
 
-  <div class="absolute right-0 z-40 mt-2 w-56 bg-[var(--color-surface-strong)] rounded-md shadow-lg overflow-hidden border border-gray-700"
+  <div class="absolute right-0 z-40 mt-2 w-64 bg-[var(--color-surface-strong)] rounded-md shadow-lg overflow-hidden border border-gray-700"
+       aria-label="View settings"
+       role="group"
        x-cloak
        x-show="open"
        x-transition:enter="transition ease-out duration-100"
@@ -24,6 +32,30 @@
       <span x-text="layout === 'grid' ? 'Table View' : 'Grid View'"></span>
     </a>
 
+    {% if entry_grouping.supported %}
+      <form method="post"
+            action="{% url 'medialist_entry_grouping' media_type %}"
+            class="w-full m-0">
+        {% csrf_token %}
+        <input type="hidden"
+               name="show_separate_entries"
+               value="{{ entry_grouping.next_value }}">
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button class="flex items-center gap-2 w-full px-3 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] transition-colors cursor-pointer"
+                type="submit"
+                aria-pressed="{% if entry_grouping.enabled %}true{% else %}false{% endif %}"
+                @click="open = false">
+          {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
+          <span>Show matching entries separately</span>
+          <span class="ml-auto text-xs text-[var(--color-text-muted)]">
+            {{ entry_grouping.state_label }}
+          </span>
+        </button>
+      </form>
+    {% endif %}
+
+    <div class="border-t border-gray-700 my-1" role="separator"></div>
+
     <button class="flex items-center gap-2 w-full px-3 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait"
             type="button"
             :disabled="sharing"
@@ -38,40 +70,5 @@
       {% include "app/icons/tag.svg" with classes="w-4 h-4" %}
       <span x-text="selectMode ? 'Cancel Select' : 'Select Items'"></span>
     </button>
-
-	{% if show_separate_plays %}
-		{# New menu button: Show all plays / Aggregate plays #}
-		<form method="get" id="separate-plays-form" class="w-full m-0">
-		  <!-- preserve current filters so toggling keeps state -->
-		  <input type="hidden" name="search" value="{{ request.GET.search|default:'' }}">
-		  <input type="hidden" name="sort" value="{{ request.GET.sort|default:current_sort|default:'' }}">
-		  <input type="hidden" name="direction" value="{{ request.GET.direction|default:current_direction|default:'' }}">
-		  {% for s in current_status %}
-			<input type="hidden" name="status" value="{{ s }}">
-		  {% endfor %}
-
-		  <!-- submit the opposite of current state so button toggles preference -->
-		  <input type="hidden" name="separate_plays" value="{% if show_each_play %}0{% else %}1{% endif %}" />
-
-		  <button
-			type="submit"
-			@click="open = false"
-			class="flex items-center gap-2 w-full px-3 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] transition-colors cursor-pointer"
-		  >
-			<span class="w-4 h-4 flex-shrink-0">
-			  {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
-			</span>
-
-			<span>
-			  {% if show_each_play %}
-				Group Multiple Plays
-			  {% else %}
-				Show All Plays
-			  {% endif %}
-			</span>
-		  </button>
-		</form>
-	{% endif %}
-
   </div>
 </div>

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -522,8 +522,8 @@ class User(AbstractUser):
         choices=MediaStatusChoices,
     )
     anime_show_each_play = models.BooleanField(
-    default=False,
-    help_text="Show each play/entry as its own row instead of aggregating duplicates",
+        default=False,
+        help_text="Show each play/entry as its own row instead of aggregating duplicates",
     )
 
     # Media type preferences: Manga
@@ -549,8 +549,8 @@ class User(AbstractUser):
         choices=MediaStatusChoices,
     )
     manga_show_each_play = models.BooleanField(
-    default=False,
-    help_text="Show each play/entry as its own row instead of aggregating duplicates",
+        default=False,
+        help_text="Show each play/entry as its own row instead of aggregating duplicates",
     )
 
     # Media type preferences: Games
@@ -576,8 +576,8 @@ class User(AbstractUser):
         choices=MediaStatusChoices,
     )
     game_show_each_play = models.BooleanField(
-    default=False,
-    help_text="Show each play/entry as its own row instead of aggregating duplicates",
+        default=False,
+        help_text="Show each play/entry as its own row instead of aggregating duplicates",
     )
 
     # Media type preferences: Board Games
@@ -626,8 +626,8 @@ class User(AbstractUser):
         choices=MediaStatusChoices,
     )
     book_show_each_play = models.BooleanField(
-    default=False,
-    help_text="Show each play/entry as its own row instead of aggregating duplicates",
+        default=False,
+        help_text="Show each play/entry as its own row instead of aggregating duplicates",
     )
 
     # Media type preferences: Comics


### PR DESCRIPTION
## Summary

Addresses review findings from #753 that were omitted in the initial merge:

1. **Request Safety & CSRF:** Replaced the unvalidated GET mutation (`?separate_plays=1`) with a CSRF-protected POST route (`medialist_entry_grouping`), strict boolean validation, safe local redirect validation, and rejection of unsupported media types.
2. **Cache Isolation:** Added entry-grouping mode to the media list cache key builder (`_entry_grouping_grouped` vs `_entry_grouping_separate`) and user cache eviction on preference change to prevent cross-contamination.
3. **Query & Display Consistency:**
   - Unified native and TV-backed Anime queries under the same `entry_grouping_mode` context manager so mixed lists display consistently.
   - Bypassed pre-sort aggregation when separate mode is active so raw rows remain raw without inheriting combined values.
4. **Filter Preservation:** Fixed the settings menu form to retain the full URL path (`request.get_full_path`) so active filters (genres, tags, ratings, providers) are preserved when toggling display mode.
5. **Accessibility & Terminology:** Standardized neutral terminology ("Show matching entries separately") and added ARIA attributes (`aria-pressed`, `aria-expanded`) with keyboard escape support.
6. **Model Hygiene:** Corrected field indentation in `users/models.py`.
7. **Automated Regression Suite:** Added 10 automated test cases covering default behavior, multi-type separate display, cache segregation, POST validation, redirect security, TV-backed Anime parity, and UI state.

## Related

- Fixes #753
- Refs #275
- Original request: #320

## Validation

- `SECRET=test-only uv run --no-sync python src/manage.py test app.tests.views.test_media_list_entry_grouping --parallel 1` -> 10 passed (OK)
- `SECRET=test-only uv run --no-sync python src/manage.py test users.tests.views.test_about app.tests.test_domain_vocabulary --parallel 1` -> 10 passed (OK)
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` -> passed
- `uv run --no-sync python src/manage.py check_migration_hygiene --strict` -> passed
- `uv run --no-sync ruff check src` -> 0 errors

## Contract Handoff
- Domain guide check: passed
- Verified OpenAPI regeneration: not applicable
- Contract-test outcome: passed