### PR TITLE
feat(api): publish a JSON-LD domain context (W2)

### DIFF
--- a/HANDOFF-QA.md
+++ b/HANDOFF-QA.md
@@ -1,0 +1,218 @@
+# QA handoff — Floppy API grounding contracts
+
+Written 2026-08-14 for the QA agent taking over. Everything you need is here;
+you should not need to reconstruct history.
+
+## Repo and branch layout
+
+| What | Where |
+|---|---|
+| Main checkout | `/home/ryan/code/Floppy` (branch `feat/591-pin-zxing`, untouched) |
+| This work | `/home/ryan/code/floppy-jsonld` (branch `feat/jsonld-domain-context`) |
+| Base of this branch | `origin/codex/openapi-grounding-contracts` @ `6a667843` = PR #742 head |
+| Upstream target | `latest` |
+
+`feat/jsonld-domain-context` is **stacked on PR #742**. It cannot target
+`latest` directly, because it imports `src/app/domain_vocabulary.py`, which
+#742 introduces. Review it as a stacked PR with base
+`codex/openapi-grounding-contracts`.
+
+Test env: run `uv sync` in the worktree first. Test command is
+`SECRET=test-only scripts/test.sh` (the `SECRET` prefix is mandatory; without
+it settings refuse to load).
+
+## Background: what shipped before you
+
+### PR #742 — verified API grounding contracts (already reviewed, conflicts resolved)
+
+Publishes a committed 41-operation OpenAPI subset, a generated domain
+vocabulary, an offline API docs page, MCP hardening, and drift-gate tests.
+
+- Conflicts against `latest` were resolved by merging `origin/latest`
+  (`8a26dcd0`). The merge was textually clean, zero conflicted files. Pushed as
+  `6a667843`. GitHub now reports `MERGEABLE`.
+- Full review evidence, including a drift-gate mutation proof and measured
+  token costs, is at
+  `~/.gstack/projects/dannyvfilms-Floppy/ryan-pr-742-conflicts-review-test-outcome-20260814-1500.md`.
+  **Read that file before re-reviewing #742** so you do not repeat work.
+- Known non-issue: `app.tests.test_data_paths.DataPathSettingsTests.test_generated_secret_uses_the_configured_data_directory`
+  fails **locally only**. python-decouple walks up out of any worktree nested
+  under `/home/ryan/code/Floppy` and finds that repo's `.env`, which sets
+  `SECRET`, so the probe never generates `secret_key`. CI clones fresh and
+  passes. Not caused by either PR. Do not "fix" it as part of this work.
+
+### The governing design
+
+`~/.gstack/projects/dannyvfilms-Floppy/ryan-fix-boosted-nav-entrance-guard-self-match-design-20260813-152535.md`
+(status APPROVED). Workstreams: W0 spike, W1 trustworthy OpenAPI, W2 JSON-LD,
+W3 AsyncAPI, W4 handoff surfaces. #742 delivered W0 + W1 + focused W4.
+
+Constraints that still bind and that QA should check against:
+
+- Zero new **runtime** dependencies. Test-only deps must stay out of the image
+  (`Dockerfile` runs `uv sync --no-default-groups`).
+- Release-gating tests must live under `src/app/tests/`, because
+  `.github/workflows/app-tests.yml` runs `test app users integrations lists
+  events` and **omits the `api` label**. A gate under `src/api/tests/` does not
+  protect PRs.
+- Do not edit `.github/workflows/**` — CI fails PRs that touch it.
+- Baseline Zero: ruff, lint and tests stay at zero failures.
+- `/api/docs/` must make zero external network requests and must not trigger
+  schema generation.
+
+## What this branch (W2 — JSON-LD) adds
+
+Two commits:
+
+- `39a79d31` — generate the context from the vocabulary
+- `1c6dc98c` — serve it and expose it to MCP
+
+Changes:
+
+| File | Change |
+|---|---|
+| `src/app/domain_vocabulary.py` | `render_jsonld_context()`, `class_name()`, `property_name()`, `CONTEXT_PATH`, namespace constants; `main()` now writes/checks both artifacts; relationship labels validated unique |
+| `src/api/contracts/context.jsonld` | **new** generated artifact (JSON-LD 1.1) |
+| `src/api/contract_views.py` | `jsonld_context` view — `application/ld+json`, byte-derived ETag, 1h public cache |
+| `src/config/urls.py` | route `api/context.jsonld`, name `jsonld-context` |
+| `mcp_server/floppy_mcp/client.py` | `fetch_public_contract()` — unauthenticated fetch for public contract paths outside `/api/v1/` |
+| `mcp_server/floppy_mcp/server.py` | optional `floppy://domain-context` resource |
+| `src/templates/users/about.html` | "Domain Context (JSON-LD)" link |
+| `src/templates/api/docs.html` | domain-context entry on the offline index |
+| `src/app/tests/test_api_contracts.py` | `JSONLDContextTests` — 8 gates |
+| `src/users/tests/views/test_about.py` | expects the new link; still asserts AsyncAPI absent |
+| `pyproject.toml` / `uv.lock` | `pyld==2.0.4` in the **test** group only |
+
+Design decisions worth knowing before you judge the code:
+
+- The context reads **only** `key`, `relationships`, `schema_org`. Definitions,
+  aliases and bounded contexts stay prose. This is revised premise P2: one
+  vocabulary, separately maintained contracts, no projection engine. A test
+  asserts prose fields never appear in the artifact.
+- Class terms are PascalCase from the key (`media_type` → `MediaType`);
+  property terms are camelCase from the relationship label. Where a
+  `schema_org` mapping exists the class expands to the schema.org IRI
+  (`Item` → `https://schema.org/CreativeWork`); otherwise it stays in
+  `https://github.com/dannyvfilms/Floppy/ns#`.
+- The MCP resource is **optional by construction**. No tool reads it. A test
+  asserts that when the context 404s, the resource returns a structured error
+  *and* a normal `search_media` call still succeeds.
+
+### Verification already done (do not redo)
+
+- `app.tests.test_api_contracts` + `test_domain_vocabulary` + `users.tests.views.test_about`: **54/54 OK**
+- `mcp_server/tests`: **58/58 passed**
+- `ruff check src mcp_server/floppy_mcp mcp_server/tests`: **All checks passed**
+- Drift-gate mutation proof: changing `floppy:consumption` → `floppy:MUTATED`
+  in the committed context failed `test_committed_context_matches_the_vocabulary_renderer`
+  and `test_pyld_expands_the_context_to_absolute_iris`; restoring made them green.
+  **The gate is load-bearing.**
+- PyLD expansion verified to produce absolute IRIs.
+
+## What is NOT done — your work starts here
+
+### 1. Full-suite confirmation
+
+A full `SECRET=test-only scripts/test.sh` run was started on this branch but its
+result is not recorded here. Re-run it and report. Expect ~3630 tests and the
+one known environmental `test_data_paths` failure described above. Any *other*
+failure is real.
+
+### 2. Browser QA of the new surfaces
+
+Not done at all for this branch. Needed:
+
+- `/api/context.jsonld` — returns 200, `application/ld+json`, correct bytes,
+  ETag revalidation gives 304, HEAD works. Unit tests cover this; confirm in a
+  browser against a running instance.
+- `/api/docs/` — the new "Domain context (JSON-LD)" entry renders, the link
+  resolves, and the page still makes **zero external requests**. Check the
+  network log explicitly.
+- Settings → About — the new link renders with the right label and icon
+  a11y attributes (`aria-hidden="true"`, `focusable="false"`), and the group
+  still reads as one capability.
+- Re-check 320px and 375px layouts, keyboard focus and skip link, dark mode,
+  and reduced motion on `/api/docs/`, since a row was added.
+- Confirm `/floppy` subpath rendering still produces correct URLs.
+
+### 3. Package-size gate
+
+The design requires recording artifact bytes and a before/after container image
+comparison, failing at 1 MiB or 0.1% growth, whichever is smaller. The new
+`context.jsonld` is small (~700 bytes) but the gate has not been run for this
+branch. PyLD must **not** appear in the image — verify with a clean Podman/Docker
+build that `uv sync --no-default-groups` excluded it.
+
+### 4. Open the PR
+
+Not opened yet. Base must be `codex/openapi-grounding-contracts`, not `latest`.
+
+## W3 — AsyncAPI, parked
+
+A drafted `channel_registry.py` is at `/tmp/claude-1000/w3-park/channel_registry.py`.
+It is **not committed, not tested, and not reviewed** — treat it as a sketch.
+
+Verified facts it encodes, which you can trust because they were traced in
+source:
+
+- Seven inbound message routes reaching six `WEBHOOK_PROCESSORS`:
+  `webhook/plex/<token>`, `webhook/jellyfin/<token>`, `webhook/emby/<token>`,
+  `webhook/jellyseerr/<token>`, `webhook/seerr/global/`, `webhook/kodi/<token>`,
+  and `stremio-addon/<token>/subtitles/<type>/<id>.json` (a GET subtitles
+  request used as a throttled playback-start signal — **not** a webhook).
+- ListenBrainz has a separate inbound surface at
+  `/apis/listenbrainz/1/submit-listens`, handled synchronously, not via
+  `process_webhook`.
+- Three Celery queues: `celery` (background, default priority 5), `interactive`
+  (priority 0), `discover`. Priorities from `CELERY_TASK_ROUTES` in
+  `src/config/settings.py:1331-1389`.
+- `celery_queue_plan()` in `src/config/runtime_profile.py:372` has three
+  branches but only **two are reachable**: `minimal` → one combined worker on
+  `celery,interactive,discover`; `constrained` and `standard` → background
+  worker on `celery,discover` plus an isolated `interactive` worker. The
+  three-worker branch is dead code for the current tier set. **Do not document
+  a three-worker split as real.**
+
+Still required before W3 can ship, per the design:
+
+- Pin the official AsyncAPI 3.0 JSON Schema as a test fixture **outside `src/`**
+  and validate with the already-installed `jsonschema` (4.26.0). No `npx`, no
+  runtime dependency, no workflow change. Fetching that schema needs the
+  maintainer's go-ahead.
+- Celery messages must declare `application/x-python-serialize` and must **not**
+  claim a portable JSON payload schema; logical task arguments go in
+  `x-floppy-*` metadata only.
+- Exclude polling importers, Apprise destinations and base classes. A large or
+  inaccurate AsyncAPI document is worse than none (design premise P7).
+- Invert `assertNotContains(response, "AsyncAPI")` in
+  `src/users/tests/views/test_about.py` only when the artifact actually ships.
+
+## Standing decision you should not silently reverse
+
+The grounding evaluation **failed** its preregistered gate: treatment medians
+were Q1 `0`, Q2 `1`, Q3 `1` against a required `2`
+(`docs/agents/evals/grounding_questions.md:502`). W2 and W3 were both recorded
+`DEFER` on that evidence.
+
+The maintainer has since explicitly chosen to build W2 and W3 anyway. That is a
+deliberate scope override, not an oversight, and it is why this branch exists.
+Record it honestly in any PR body: the formats ship because the maintainer asked
+for them, **not** because the evaluation justified them. Do not restate the
+failed evaluation as a success.
+
+## Open review questions carried over from #742
+
+These were raised and left open. They apply to the stack, not just #742.
+
+1. `src/api/contract_views.py` reads contracts at **module import**, so a
+   missing artifact fails app startup rather than returning the 404 the design's
+   failure-mode table promised. This branch follows the same pattern for
+   `context.jsonld`, which doubles the blast radius. Worth a decision.
+2. `src/api/schema_contract.py:786-811` depends on drf-spectacular **private
+   API** (`GENERATOR_STATS._error_cache`, `._warn_cache`, `patched_settings`).
+   Pinned at `drf-spectacular==0.29.0`, so it will not break silently, but the
+   next upgrade can break the gate. The risk is not commented anywhere.
+3. `mcp_server/floppy_mcp/server.py` treats a lookup HTTP 500 as "absent" when
+   `source == "manual"` and proceeds to write. Deliberate and tested
+   (`mcp_server/tests/test_tools.py:127`, commit `27cc61c4`), but the adjacent
+   comment explains only the 404 case. Documentation gap.

--- a/HANDOFF-QA.md
+++ b/HANDOFF-QA.md
@@ -62,16 +62,17 @@ Constraints that still bind and that QA should check against:
 
 ## What this branch (W2 — JSON-LD) adds
 
-Two commits:
+Three commits:
 
 - `39a79d31` — generate the context from the vocabulary
 - `1c6dc98c` — serve it and expose it to MCP
+- `eca2292d` — close the review findings (see "Review round already applied")
 
 Changes:
 
 | File | Change |
 |---|---|
-| `src/app/domain_vocabulary.py` | `render_jsonld_context()`, `class_name()`, `property_name()`, `CONTEXT_PATH`, namespace constants; `main()` now writes/checks both artifacts; relationship labels validated unique |
+| `src/app/domain_vocabulary.py` | `render_jsonld_context()`, `class_name()`, `property_name()`, `CONTEXT_PATH`, namespace constants; `main()` now writes/checks both artifacts; projected property names validated unique |
 | `src/api/contracts/context.jsonld` | **new** generated artifact (JSON-LD 1.1) |
 | `src/api/contract_views.py` | `jsonld_context` view — `application/ld+json`, byte-derived ETag, 1h public cache |
 | `src/config/urls.py` | route `api/context.jsonld`, name `jsonld-context` |
@@ -79,8 +80,10 @@ Changes:
 | `mcp_server/floppy_mcp/server.py` | optional `floppy://domain-context` resource |
 | `src/templates/users/about.html` | "Domain Context (JSON-LD)" link |
 | `src/templates/api/docs.html` | domain-context entry on the offline index |
-| `src/app/tests/test_api_contracts.py` | `JSONLDContextTests` — 8 gates |
+| `src/app/tests/test_api_contracts.py` | `JSONLDContextTests` — 10 gates |
 | `src/users/tests/views/test_about.py` | expects the new link; still asserts AsyncAPI absent |
+| `src/app/tests/test_domain_vocabulary.py` | `--check` now covers context drift; tests isolated from committed artifacts |
+| `mcp_server/tests/test_tools.py` | resource success + failure-does-not-block-tools |
 | `pyproject.toml` / `uv.lock` | `pyld==2.0.4` in the **test** group only |
 
 Design decisions worth knowing before you judge the code:
@@ -100,25 +103,42 @@ Design decisions worth knowing before you judge the code:
 
 ### Verification already done (do not redo)
 
-- `app.tests.test_api_contracts` + `test_domain_vocabulary` + `users.tests.views.test_about`: **54/54 OK**
+- Full fast suite on this branch: **3636 tests, OK (1 skipped)**. Note
+  `test_data_paths` **passes here**, because this worktree lives at
+  `/home/ryan/code/floppy-jsonld`, outside the main repo, so python-decouple
+  never finds `/home/ryan/code/Floppy/.env`. That confirms the root cause.
+- `app.tests.test_api_contracts` + `test_domain_vocabulary` + `users.tests.views.test_about`: **56/56 OK**
 - `mcp_server/tests`: **58/58 passed**
 - `ruff check src mcp_server/floppy_mcp mcp_server/tests`: **All checks passed**
 - Drift-gate mutation proof: changing `floppy:consumption` → `floppy:MUTATED`
   in the committed context failed `test_committed_context_matches_the_vocabulary_renderer`
   and `test_pyld_expands_the_context_to_absolute_iris`; restoring made them green.
   **The gate is load-bearing.**
-- PyLD expansion verified to produce absolute IRIs.
+- PyLD expansion verified across **every** class and relationship in the
+  vocabulary (not a subset).
+
+### Review round already applied
+
+An independent review (Gemini 3.7 via `agy`) found three real defects, all
+fixed in `eca2292d`:
+
+1. `validate_terms()` checked **raw** relationship labels for uniqueness while
+   the context maps the **projected** camelCase name. `"has user"` and
+   `"Has  user"` both render as `hasUser`, so a collision could have silently
+   collapsed two relationships into one property IRI. Now validated on the
+   projected name, with a proof case.
+2. `fetch_public_contract()` did not follow redirects, so an instance behind a
+   proxy doing http→https would have returned redirect HTML as the context body.
+3. The `--check` gate never covered `context.jsonld` alone, and the entry-point
+   tests patched only `GUIDE_PATH`, so `main([])` **wrote the real committed
+   artifact** during a test run. Both fixed; tests are now isolated.
+
+It also named two gate gaps, both closed: property terms are now asserted to be
+`@id`-typed, and PyLD expansion covers the whole vocabulary.
 
 ## What is NOT done — your work starts here
 
-### 1. Full-suite confirmation
-
-A full `SECRET=test-only scripts/test.sh` run was started on this branch but its
-result is not recorded here. Re-run it and report. Expect ~3630 tests and the
-one known environmental `test_data_paths` failure described above. Any *other*
-failure is real.
-
-### 2. Browser QA of the new surfaces
+### 1. Browser QA of the new surfaces
 
 Not done at all for this branch. Needed:
 
@@ -135,7 +155,7 @@ Not done at all for this branch. Needed:
   and reduced motion on `/api/docs/`, since a row was added.
 - Confirm `/floppy` subpath rendering still produces correct URLs.
 
-### 3. Package-size gate
+### 2. Package-size gate
 
 The design requires recording artifact bytes and a before/after container image
 comparison, failing at 1 MiB or 0.1% growth, whichever is smaller. The new
@@ -143,7 +163,7 @@ comparison, failing at 1 MiB or 0.1% growth, whichever is smaller. The new
 branch. PyLD must **not** appear in the image — verify with a clean Podman/Docker
 build that `uv sync --no-default-groups` excluded it.
 
-### 4. Open the PR
+### 3. Open the PR
 
 Not opened yet. Base must be `codex/openapi-grounding-contracts`, not `latest`.
 

--- a/mcp_server/floppy_mcp/client.py
+++ b/mcp_server/floppy_mcp/client.py
@@ -129,7 +129,11 @@ async def fetch_public_contract(path: str) -> str:
     rare reads and the shared client's base URL is pinned to ``/api/v1/``.
     """
     url = f"{_base_url()}/{path.lstrip('/')}"
-    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+    # An instance behind a proxy commonly redirects http->https or
+    # normalizes the path; without this the body would be redirect HTML.
+    async with httpx.AsyncClient(
+        timeout=DEFAULT_TIMEOUT, follow_redirects=True
+    ) as client:
         response = await client.get(url)
         if response.is_error:
             raise FloppyAPIError(response.status_code, response.text)

--- a/mcp_server/floppy_mcp/client.py
+++ b/mcp_server/floppy_mcp/client.py
@@ -121,6 +121,21 @@ class FloppyClient:
         return body
 
 
+async def fetch_public_contract(path: str) -> str:
+    """Fetch a public contract artifact served outside ``/api/v1/``.
+
+    Contract routes (``/api/context.jsonld``, ``/api/openapi.yaml``) are public
+    and read-only, so no token is sent. Uses a one-off client because these are
+    rare reads and the shared client's base URL is pinned to ``/api/v1/``.
+    """
+    url = f"{_base_url()}/{path.lstrip('/')}"
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+        response = await client.get(url)
+        if response.is_error:
+            raise FloppyAPIError(response.status_code, response.text)
+        return response.text
+
+
 _client: FloppyClient | None = None
 
 

--- a/mcp_server/floppy_mcp/server.py
+++ b/mcp_server/floppy_mcp/server.py
@@ -8,12 +8,18 @@ FLOPPY_TOKEN environment variables (see client.py).
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
 
-from .client import FloppyAPIError, FloppyConfigError, get_client
+from .client import (
+    FloppyAPIError,
+    FloppyConfigError,
+    fetch_public_contract,
+    get_client,
+)
 
 mcp = FastMCP(
     name="floppy",
@@ -40,6 +46,22 @@ async def _call(method: str, path: str, **kwargs: Any) -> Any:
         return await get_client().request(method, path, **kwargs)
     except (FloppyAPIError, FloppyConfigError, httpx.RequestError) as exc:
         return _error_payload(exc)
+
+
+@mcp.resource("floppy://domain-context")
+async def domain_context() -> str:
+    """Return the instance's JSON-LD domain context.
+
+    Optional grounding aid: it types Floppy's own nouns (Item, Consumption,
+    Media type, Celery queue) and maps them to schema.org where an equivalent
+    exists. No tool reads this resource, so an instance that cannot serve it
+    still supports every tool - a fetch failure returns a structured error
+    here and nowhere else.
+    """
+    try:
+        return await fetch_public_contract("api/context.jsonld")
+    except (FloppyAPIError, FloppyConfigError, httpx.RequestError) as exc:
+        return json.dumps(_error_payload(exc))
 
 
 # The REST API's wire format for status is a numeric code, not the display

--- a/mcp_server/tests/test_tools.py
+++ b/mcp_server/tests/test_tools.py
@@ -424,3 +424,30 @@ async def test_connection_error_is_surfaced_not_raised(api_base_url):
         )
         result = await server.get_home()
         assert result == {"error": True, "detail": "Connection failed"}
+
+
+async def test_domain_context_resource_returns_the_served_context():
+    with respx.mock:
+        respx.get("https://floppy.test/api/context.jsonld").mock(
+            return_value=Response(200, text='{"@context": {"@version": 1.1}}'),
+        )
+        body = await server.domain_context()
+        assert json.loads(body)["@context"]["@version"] == 1.1
+
+
+async def test_domain_context_resource_reports_failure_without_blocking_tools():
+    """A missing context must degrade to a structured error, not an exception."""
+    with respx.mock:
+        respx.get("https://floppy.test/api/context.jsonld").mock(
+            return_value=Response(404, text="not found"),
+        )
+        respx.get("https://floppy.test/api/v1/search/movie").mock(
+            return_value=ok({"results": []}),
+        )
+
+        error = json.loads(await server.domain_context())
+        assert error["error"] is True
+        assert error["status_code"] == 404
+
+        # The tool path is unaffected by the resource failure.
+        assert await server.search_media("movie", "matrix") == {"results": []}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ lint = [
 test = [
     "coverage==7.13.5",
     "fakeredis[lua]==2.35.1",
+    # Expands the committed JSON-LD context in tests. Test-only on purpose: the
+    # Docker build runs `uv sync --no-default-groups`, so this never reaches the
+    # production image and runtime dependencies stay at zero.
+    "pyld==2.0.4",
     "pytest-django==4.12.0",
     "pytest-playwright==0.7.2",
     "tblib==3.2.2",

--- a/src/api/contract_views.py
+++ b/src/api/contract_views.py
@@ -12,12 +12,21 @@ from django.views.decorators.http import condition, require_safe
 from app.domain_vocabulary import render_glossary_rows
 from app.helpers import build_absolute_app_url
 
-OPENAPI_CONTRACT = (settings.BASE_DIR / "api" / "contracts" / "openapi.yaml").read_bytes()
+_CONTRACTS_DIR = settings.BASE_DIR / "api" / "contracts"
+
+OPENAPI_CONTRACT = (_CONTRACTS_DIR / "openapi.yaml").read_bytes()
 OPENAPI_CONTRACT_ETAG = f'"{sha256(OPENAPI_CONTRACT).hexdigest()}"'
+
+JSONLD_CONTEXT = (_CONTRACTS_DIR / "context.jsonld").read_bytes()
+JSONLD_CONTEXT_ETAG = f'"{sha256(JSONLD_CONTEXT).hexdigest()}"'
 
 
 def _contract_etag(_request):
     return OPENAPI_CONTRACT_ETAG
+
+
+def _context_etag(_request):
+    return JSONLD_CONTEXT_ETAG
 
 
 def _api_example_url(route_name):
@@ -47,3 +56,15 @@ def api_docs(request):
 def openapi_contract(_request):
     """Serve the committed OpenAPI contract with public cache validation."""
     return FileResponse(BytesIO(OPENAPI_CONTRACT), content_type="application/yaml")
+
+
+@login_not_required
+@require_safe
+@cache_control(public=True, max_age=3600)
+@condition(etag_func=_context_etag)
+def jsonld_context(_request):
+    """Serve the committed JSON-LD domain context.
+
+    The representation does not vary by host, so no ``Vary: Host`` is needed.
+    """
+    return FileResponse(BytesIO(JSONLD_CONTEXT), content_type="application/ld+json")

--- a/src/api/contracts/context.jsonld
+++ b/src/api/contracts/context.jsonld
@@ -1,0 +1,32 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "floppy": "https://github.com/dannyvfilms/Floppy/ns#",
+    "schema": "https://schema.org/",
+    "Item": "schema:CreativeWork",
+    "Consumption": "floppy:consumption",
+    "MediaType": "floppy:media_type",
+    "CeleryQueue": "floppy:celery_queue",
+    "hasUserTrackingRecord": {
+      "@id": "floppy:hasUserTrackingRecord",
+      "@type": "@id"
+    },
+    "isClassifiedBy": {
+      "@id": "floppy:isClassifiedBy",
+      "@type": "@id"
+    },
+    "tracks": {
+      "@id": "floppy:tracks",
+      "@type": "@id"
+    },
+    "classifies": {
+      "@id": "floppy:classifies",
+      "@type": "@id"
+    },
+    "processesCalendarUpdatesFor": {
+      "@id": "floppy:processesCalendarUpdatesFor",
+      "@type": "@id"
+    }
+  }
+}

--- a/src/app/domain_vocabulary.py
+++ b/src/app/domain_vocabulary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -102,6 +103,14 @@ def validate_terms(terms: tuple[DomainTerm, ...]) -> None:
                 msg = f"Relationship target {target!r} does not resolve from {term.key!r}."
                 raise ValueError(msg)
 
+    # The JSON-LD context maps every relationship label to one property IRI, so
+    # a duplicate label across terms would silently collapse two relationships
+    # into one. Reject it here rather than emitting an ambiguous @context.
+    labels = [relationship for term in terms for relationship, _ in term.relationships]
+    if len(labels) != len(set(labels)):
+        msg = "Domain relationship labels must be unique."
+        raise ValueError(msg)
+
 
 validate_terms(DOMAIN_TERMS)
 
@@ -110,6 +119,21 @@ GENERATED_WARNING = (
     "<!-- GENERATED FILE. DO NOT EDIT. Run "
     "`PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary` to regenerate. -->"
 )
+
+CONTEXT_PATH = Path(__file__).resolve().parents[1] / "api" / "contracts" / "context.jsonld"
+FLOPPY_NAMESPACE = "https://github.com/dannyvfilms/Floppy/ns#"
+SCHEMA_ORG_NAMESPACE = "https://schema.org/"
+
+
+def class_name(key: str) -> str:
+    """Return the PascalCase JSON-LD class term for a vocabulary key."""
+    return "".join(part.capitalize() for part in key.split("_"))
+
+
+def property_name(relationship: str) -> str:
+    """Return the camelCase JSON-LD property term for a relationship label."""
+    head, *tail = relationship.split()
+    return head.lower() + "".join(part.capitalize() for part in tail)
 
 
 def render_glossary_rows() -> tuple[dict[str, str], ...]:
@@ -156,19 +180,54 @@ def render_agent_guide() -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_jsonld_context() -> str:
+    """Render the JSON-LD 1.1 context from linked-data fields only.
+
+    Reads ``key``, ``relationships``, and ``schema_org``. Definitions, aliases,
+    and bounded contexts are prose and stay out of the linked-data artifact.
+    """
+    context: dict[str, object] = {
+        "@version": 1.1,
+        "@protected": True,
+        "floppy": FLOPPY_NAMESPACE,
+        "schema": SCHEMA_ORG_NAMESPACE,
+    }
+    for term in DOMAIN_TERMS:
+        # A schema.org mapping makes the class term expand to the interoperable
+        # IRI; otherwise it stays in Floppy's own namespace.
+        context[class_name(term.key)] = (
+            term.schema_org.replace(SCHEMA_ORG_NAMESPACE, "schema:")
+            if term.schema_org
+            else f"floppy:{term.key}"
+        )
+    for term in DOMAIN_TERMS:
+        for relationship, _ in term.relationships:
+            name = property_name(relationship)
+            context[name] = {"@id": f"floppy:{name}", "@type": "@id"}
+
+    return json.dumps({"@context": context}, indent=2, sort_keys=False) + "\n"
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Write the generated guide or check it for drift."""
+    """Write the generated artifacts or check them for drift."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--check", action="store_true")
     args = parser.parse_args(argv)
-    rendered = render_agent_guide().encode("utf-8")
+    artifacts = (
+        (GUIDE_PATH, render_agent_guide().encode("utf-8")),
+        (CONTEXT_PATH, render_jsonld_context().encode("utf-8")),
+    )
 
     if args.check:
-        if not GUIDE_PATH.exists():
-            return 1
-        return int(GUIDE_PATH.read_bytes() != rendered)
+        return int(
+            any(
+                not path.exists() or path.read_bytes() != rendered
+                for path, rendered in artifacts
+            )
+        )
 
-    GUIDE_PATH.write_bytes(rendered)
+    for path, rendered in artifacts:
+        path.write_bytes(rendered)
     return 0
 
 

--- a/src/app/domain_vocabulary.py
+++ b/src/app/domain_vocabulary.py
@@ -77,6 +77,17 @@ DOMAIN_TERMS: tuple[DomainTerm, ...] = (
 )
 
 
+def class_name(key: str) -> str:
+    """Return the PascalCase JSON-LD class term for a vocabulary key."""
+    return "".join(part.capitalize() for part in key.split("_"))
+
+
+def property_name(relationship: str) -> str:
+    """Return the camelCase JSON-LD property term for a relationship label."""
+    head, *tail = relationship.split()
+    return head.lower() + "".join(part.capitalize() for part in tail)
+
+
 def validate_terms(terms: tuple[DomainTerm, ...]) -> None:
     """Reject ambiguous terms and unresolved relationships."""
     keys = [term.key.casefold() for term in terms]
@@ -104,11 +115,16 @@ def validate_terms(terms: tuple[DomainTerm, ...]) -> None:
                 raise ValueError(msg)
 
     # The JSON-LD context maps every relationship label to one property IRI, so
-    # a duplicate label across terms would silently collapse two relationships
-    # into one. Reject it here rather than emitting an ambiguous @context.
-    labels = [relationship for term in terms for relationship, _ in term.relationships]
-    if len(labels) != len(set(labels)):
-        msg = "Domain relationship labels must be unique."
+    # a collision across terms would silently collapse two relationships into
+    # one. Check the *projected* property name, not the raw label: "has user"
+    # and "Has  user" are different labels that both render as `hasUser`.
+    properties = [
+        property_name(relationship)
+        for term in terms
+        for relationship, _ in term.relationships
+    ]
+    if len(properties) != len(set(properties)):
+        msg = "Domain relationship labels must render unique property names."
         raise ValueError(msg)
 
 
@@ -123,17 +139,6 @@ GENERATED_WARNING = (
 CONTEXT_PATH = Path(__file__).resolve().parents[1] / "api" / "contracts" / "context.jsonld"
 FLOPPY_NAMESPACE = "https://github.com/dannyvfilms/Floppy/ns#"
 SCHEMA_ORG_NAMESPACE = "https://schema.org/"
-
-
-def class_name(key: str) -> str:
-    """Return the PascalCase JSON-LD class term for a vocabulary key."""
-    return "".join(part.capitalize() for part in key.split("_"))
-
-
-def property_name(relationship: str) -> str:
-    """Return the camelCase JSON-LD property term for a relationship label."""
-    head, *tail = relationship.split()
-    return head.lower() + "".join(part.capitalize() for part in tail)
 
 
 def render_glossary_rows() -> tuple[dict[str, str], ...]:

--- a/src/app/tests/test_api_contracts.py
+++ b/src/app/tests/test_api_contracts.py
@@ -35,6 +35,7 @@ from app.domain_vocabulary import (
     FLOPPY_NAMESPACE,
     SCHEMA_ORG_NAMESPACE,
     class_name,
+    property_name,
     render_glossary_rows,
     render_jsonld_context,
 )
@@ -692,6 +693,52 @@ class JSONLDContextTests(SimpleTestCase):
         self.assertTrue(mapped)
         for mapping in mapped:
             self.assertIn(mapping, context.values())
+
+    def test_every_relationship_has_an_id_typed_property_term(self):
+        context = self._context()
+        relationships = [
+            relationship
+            for term in DOMAIN_TERMS
+            for relationship, _ in term.relationships
+        ]
+        self.assertTrue(relationships)
+
+        for relationship in relationships:
+            name = property_name(relationship)
+            with self.subTest(relationship=relationship):
+                self.assertEqual(
+                    context[name],
+                    {"@id": f"floppy:{name}", "@type": "@id"},
+                )
+
+    def test_pyld_expands_every_class_and_relationship(self):
+        """Cover the whole vocabulary, not a hand-picked subset."""
+        from pyld import jsonld
+
+        context = self._context()
+        document = {"@context": context, "@type": class_name(DOMAIN_TERMS[0].key)}
+        for term in DOMAIN_TERMS:
+            for relationship, target in term.relationships:
+                document[property_name(relationship)] = {
+                    "@type": class_name(target),
+                }
+
+        expanded = jsonld.expand(document)[0]
+
+        for term in DOMAIN_TERMS:
+            for relationship, target in term.relationships:
+                name = property_name(relationship)
+                expected = (
+                    DOMAIN_TERMS[
+                        [t.key for t in DOMAIN_TERMS].index(target)
+                    ].schema_org
+                    or f"{FLOPPY_NAMESPACE}{target}"
+                )
+                with self.subTest(relationship=relationship):
+                    self.assertEqual(
+                        expanded[f"{FLOPPY_NAMESPACE}{name}"][0]["@type"],
+                        [expected],
+                    )
 
     def test_pyld_expands_the_context_to_absolute_iris(self):
         from pyld import jsonld

--- a/src/app/tests/test_api_contracts.py
+++ b/src/app/tests/test_api_contracts.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import json
 from unittest.mock import patch
 from urllib.parse import urljoin
 
@@ -29,9 +30,17 @@ from api.schema_contract import (
     generate_static_schema_contract,
     normalize_schema_findings,
 )
-from app.domain_vocabulary import render_glossary_rows
+from app.domain_vocabulary import (
+    DOMAIN_TERMS,
+    FLOPPY_NAMESPACE,
+    SCHEMA_ORG_NAMESPACE,
+    class_name,
+    render_glossary_rows,
+    render_jsonld_context,
+)
 
 OPENAPI_CONTRACT_PATH = settings.BASE_DIR / "api" / "contracts" / "openapi.yaml"
+JSONLD_CONTEXT_PATH = settings.BASE_DIR / "api" / "contracts" / "context.jsonld"
 
 
 class OfflineAPIDocsTests(SimpleTestCase):
@@ -636,6 +645,107 @@ class OpenAPIArtifactTests(SimpleTestCase):
                     if method != "delete" and status.startswith("2"):
                         with self.subTest(path=path, method=method, status=status):
                             self.assertIn("schema", response["content"]["application/json"])
+
+
+class JSONLDContextTests(SimpleTestCase):
+    """Gate the committed JSON-LD context and its public route."""
+
+    def _context(self):
+        return json.loads(JSONLD_CONTEXT_PATH.read_text(encoding="utf-8"))["@context"]
+
+    def test_committed_context_matches_the_vocabulary_renderer(self):
+        self.assertEqual(
+            JSONLD_CONTEXT_PATH.read_bytes(),
+            render_jsonld_context().encode("utf-8"),
+        )
+
+    def test_context_is_jsonld_11_with_the_stable_project_namespace(self):
+        context = self._context()
+
+        self.assertEqual(context["@version"], 1.1)
+        self.assertEqual(context["floppy"], FLOPPY_NAMESPACE)
+        self.assertEqual(context["schema"], SCHEMA_ORG_NAMESPACE)
+        self.assertEqual(FLOPPY_NAMESPACE, "https://github.com/dannyvfilms/Floppy/ns#")
+
+    def test_context_reads_linked_data_fields_only(self):
+        """Definitions, aliases and bounded contexts stay out of the artifact."""
+        raw = JSONLD_CONTEXT_PATH.read_text(encoding="utf-8")
+
+        for term in DOMAIN_TERMS:
+            with self.subTest(term=term.key):
+                self.assertNotIn(term.definition, raw)
+                self.assertNotIn(f'"{term.bounded_context}"', raw)
+                for alias in term.aliases:
+                    self.assertNotIn(f'"{alias}"', raw)
+
+    def test_every_term_has_a_context_entry_and_schema_org_is_mapped(self):
+        context = self._context()
+
+        for term in DOMAIN_TERMS:
+            with self.subTest(term=term.key):
+                self.assertIn(class_name(term.key), context)
+        mapped = {
+            term.schema_org.replace(SCHEMA_ORG_NAMESPACE, "schema:")
+            for term in DOMAIN_TERMS
+            if term.schema_org
+        }
+        self.assertTrue(mapped)
+        for mapping in mapped:
+            self.assertIn(mapping, context.values())
+
+    def test_pyld_expands_the_context_to_absolute_iris(self):
+        from pyld import jsonld
+
+        expanded = jsonld.expand(
+            {
+                "@context": self._context(),
+                "@type": "Item",
+                "hasUserTrackingRecord": {"@type": "Consumption"},
+                "isClassifiedBy": {"@type": "MediaType"},
+            },
+        )
+
+        self.assertEqual(expanded[0]["@type"], ["https://schema.org/CreativeWork"])
+        self.assertEqual(
+            expanded[0][f"{FLOPPY_NAMESPACE}hasUserTrackingRecord"][0]["@type"],
+            [f"{FLOPPY_NAMESPACE}consumption"],
+        )
+        self.assertEqual(
+            expanded[0][f"{FLOPPY_NAMESPACE}isClassifiedBy"][0]["@type"],
+            [f"{FLOPPY_NAMESPACE}media_type"],
+        )
+
+    def test_context_route_is_public_and_serves_the_committed_bytes(self):
+        response = self.client.get(reverse("jsonld-context"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/ld+json")
+        self.assertEqual(
+            b"".join(response.streaming_content),
+            JSONLD_CONTEXT_PATH.read_bytes(),
+        )
+        self.assertEqual(
+            set(response["Cache-Control"].split(", ")),
+            {"public", "max-age=3600"},
+        )
+
+    def test_context_route_supports_etag_revalidation_and_head(self):
+        first = self.client.get(reverse("jsonld-context"))
+
+        matched = self.client.get(
+            reverse("jsonld-context"), HTTP_IF_NONE_MATCH=first["ETag"]
+        )
+        self.assertEqual(matched.status_code, 304)
+
+        missed = self.client.get(
+            reverse("jsonld-context"), HTTP_IF_NONE_MATCH='"stale"'
+        )
+        self.assertEqual(missed.status_code, 200)
+
+        self.assertEqual(self.client.head(reverse("jsonld-context")).status_code, 200)
+
+    def test_context_route_rejects_unsafe_methods(self):
+        self.assertEqual(self.client.post(reverse("jsonld-context")).status_code, 405)
 
 
 class SchemaFindingContractTests(SimpleTestCase):

--- a/src/app/tests/test_domain_vocabulary.py
+++ b/src/app/tests/test_domain_vocabulary.py
@@ -103,18 +103,60 @@ class DomainVocabularyTests(SimpleTestCase):
         with TemporaryDirectory() as directory:
             guide_path = Path(directory) / "domain_model.md"
             guide_path.write_bytes(crlf_bytes)
-            with patch.object(domain_vocabulary, "GUIDE_PATH", guide_path):
+            context_path = Path(directory) / "context.jsonld"
+            context_path.write_bytes(
+                domain_vocabulary.render_jsonld_context().encode("utf-8")
+            )
+            with (
+                patch.object(domain_vocabulary, "GUIDE_PATH", guide_path),
+                patch.object(domain_vocabulary, "CONTEXT_PATH", context_path),
+            ):
                 self.assertEqual(domain_vocabulary.main(["--check"]), 1)
 
-    def test_module_entry_point_writes_and_checks_the_guide(self):
+    def test_module_entry_point_writes_and_checks_both_artifacts(self):
+        """Patch both paths so the run cannot touch the committed artifacts."""
         with TemporaryDirectory() as directory:
             guide_path = Path(directory) / "domain_model.md"
-            with patch.object(domain_vocabulary, "GUIDE_PATH", guide_path):
+            context_path = Path(directory) / "context.jsonld"
+            with (
+                patch.object(domain_vocabulary, "GUIDE_PATH", guide_path),
+                patch.object(domain_vocabulary, "CONTEXT_PATH", context_path),
+            ):
                 self.assertEqual(domain_vocabulary.main(["--check"]), 1)
                 self.assertEqual(domain_vocabulary.main([]), 0)
                 self.assertEqual(
                     guide_path.read_bytes(),
                     domain_vocabulary.render_agent_guide().encode("utf-8"),
                 )
+                self.assertEqual(
+                    context_path.read_bytes(),
+                    domain_vocabulary.render_jsonld_context().encode("utf-8"),
+                )
+                self.assertEqual(domain_vocabulary.main(["--check"]), 0)
+
                 guide_path.write_bytes(b"drift\n")
+                self.assertEqual(domain_vocabulary.main(["--check"]), 1)
+
+    def test_check_detects_context_drift_on_its_own(self):
+        """Guide in sync, context drifted: --check must still fail."""
+        with TemporaryDirectory() as directory:
+            guide_path = Path(directory) / "domain_model.md"
+            context_path = Path(directory) / "context.jsonld"
+            guide_path.write_bytes(
+                domain_vocabulary.render_agent_guide().encode("utf-8")
+            )
+            with (
+                patch.object(domain_vocabulary, "GUIDE_PATH", guide_path),
+                patch.object(domain_vocabulary, "CONTEXT_PATH", context_path),
+            ):
+                # Missing context file.
+                self.assertEqual(domain_vocabulary.main(["--check"]), 1)
+
+                context_path.write_bytes(
+                    domain_vocabulary.render_jsonld_context().encode("utf-8")
+                )
+                self.assertEqual(domain_vocabulary.main(["--check"]), 0)
+
+                # Drifted context file.
+                context_path.write_bytes(b'{"@context": {}}\n')
                 self.assertEqual(domain_vocabulary.main(["--check"]), 1)

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -19,7 +19,7 @@ from django.views.static import serve
 from drf_spectacular.views import SpectacularAPIView
 from health_check.views import MainView
 
-from api.contract_views import api_docs, openapi_contract
+from api.contract_views import api_docs, jsonld_context, openapi_contract
 from users.views import CustomSignupView, CustomSocialSignupView
 
 handler400 = "app.error_views.bad_request"
@@ -33,6 +33,7 @@ urlpatterns = [
     path("apis/listenbrainz/1/", include("api.listenbrainz_urls")),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/openapi.yaml", openapi_contract, name="openapi-contract"),
+    path("api/context.jsonld", jsonld_context, name="jsonld-context"),
     path("api/docs/", api_docs, name="swagger-ui"),
     path("", include("app.urls")),
     path("", include("integrations.urls")),

--- a/src/templates/api/docs.html
+++ b/src/templates/api/docs.html
@@ -198,6 +198,12 @@
           </h3>
           <p>The reviewed, committed, versioned subset contains 41 operations for supported integrations and MCP grounding.</p>
         </article>
+        <article id="domain-context" class="schema-entry">
+          <h3>
+            <a href="{% url 'jsonld-context' %}">Domain context (JSON-LD)</a>
+          </h3>
+          <p>The JSON-LD 1.1 context types Floppy's domain nouns and maps them to schema.org where an equivalent exists.</p>
+        </article>
       </section>
     </main>
     <footer>

--- a/src/templates/users/about.html
+++ b/src/templates/users/about.html
@@ -66,6 +66,12 @@
             <span>Verified API Schema</span>
           </a>
 
+          <a href="{% url 'jsonld-context' %}"
+             class="flex items-center gap-2 text-indigo-400 hover:text-indigo-300 transition-colors">
+            {% include "app/icons/page.svg" with classes="w-4 h-4" %}
+            <span>Domain Context (JSON-LD)</span>
+          </a>
+
           <a href="{% url 'schema' %}"
              class="flex items-center gap-2 text-indigo-400 hover:text-indigo-300 transition-colors">
             {% include "app/icons/page.svg" with classes="w-4 h-4" %}

--- a/src/users/tests/views/test_about.py
+++ b/src/users/tests/views/test_about.py
@@ -21,6 +21,7 @@ class AboutViewTests(TestCase):
         expected_links = {
             "API Reference": reverse("swagger-ui"),
             "Verified API Schema": reverse("openapi-contract"),
+            "Domain Context (JSON-LD)": reverse("jsonld-context"),
             "Full Diagnostic API Schema": reverse("schema"),
         }
         api_links = [
@@ -40,5 +41,6 @@ class AboutViewTests(TestCase):
                 icon = link.find("svg")
                 self.assertEqual(icon.get("aria-hidden"), "true")
                 self.assertEqual(icon.get("focusable"), "false")
-        self.assertNotContains(response, "JSON-LD")
+        # AsyncAPI (W3) is not shipped yet, so About must not advertise it.
+        # The rule is unchanged: link only artifacts that actually exist.
         self.assertNotContains(response, "AsyncAPI")

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,15 @@ filecache = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
+]
+
+[[package]]
 name = "celery"
 version = "5.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -780,6 +789,7 @@ dev = [
     { name = "fakeredis", extra = ["lua"] },
     { name = "pip-audit" },
     { name = "pre-commit" },
+    { name = "pyld" },
     { name = "pytest-django" },
     { name = "pytest-playwright" },
     { name = "ruff" },
@@ -795,6 +805,7 @@ lint = [
 test = [
     { name = "coverage" },
     { name = "fakeredis", extra = ["lua"] },
+    { name = "pyld" },
     { name = "pytest-django" },
     { name = "pytest-playwright" },
     { name = "tblib" },
@@ -845,6 +856,7 @@ dev = [
     { name = "fakeredis", extras = ["lua"], specifier = "==2.35.1" },
     { name = "pip-audit", specifier = "==2.10.1" },
     { name = "pre-commit", specifier = "==4.5.1" },
+    { name = "pyld", specifier = "==2.0.4" },
     { name = "pytest-django", specifier = "==4.12.0" },
     { name = "pytest-playwright", specifier = "==0.7.2" },
     { name = "ruff", specifier = "==0.15.8" },
@@ -860,6 +872,7 @@ lint = [
 test = [
     { name = "coverage", specifier = "==7.13.5" },
     { name = "fakeredis", extras = ["lua"], specifier = "==2.35.1" },
+    { name = "pyld", specifier = "==2.0.4" },
     { name = "pytest-django", specifier = "==4.12.0" },
     { name = "pytest-playwright", specifier = "==0.7.2" },
     { name = "tblib", specifier = "==3.2.2" },
@@ -892,6 +905,15 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
+]
 
 [[package]]
 name = "frozenlist"
@@ -1177,6 +1199,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
     { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
     { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
 ]
 
 [[package]]
@@ -1668,6 +1716,20 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyld"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "frozendict" },
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/0b/d97dddcc079d4961aa38bec1ad444b8a3e39ea0fd5627682cac25d452c82/PyLD-2.0.4.tar.gz", hash = "sha256:311e350f0dbc964311c79c28e86f84e195a81d06fef5a6f6ac2a4f6391ceeacc", size = 70976, upload-time = "2024-02-16T17:35:51.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/cd/80760be197a4bd08e7c136ef4bcb4a2c63fc799d8d91f4c177b21183135e/PyLD-2.0.4-py3-none-any.whl", hash = "sha256:6dab9905644616df33f8755489fc9b354ed7d832d387b7d1974b4fbd3b8d2a89", size = 70868, upload-time = "2024-02-16T17:35:49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## BLUF

Adds W2 of the grounding design: a JSON-LD 1.1 domain context generated from the existing controlled vocabulary, served at `/api/context.jsonld`, and exposed as an **optional** `floppy://domain-context` MCP resource. Zero new runtime dependencies.

**Stacked on #742.** Base is `codex/openapi-grounding-contracts`, not `latest`, because this imports `src/app/domain_vocabulary.py` which #742 introduces.

## Scope honesty

The design gated W2 on a grounding evaluation. **That evaluation failed** its preregistered bar (treatment medians Q1 `0`, Q2 `1`, Q3 `1` against a required `2` — `docs/agents/evals/grounding_questions.md:502`), and W2 was recorded `DEFER`.

This ships because the maintainer explicitly chose to build it anyway. That is a deliberate scope override, not new evidence. The failed evaluation is not restated as a success.

## What changed

- `render_jsonld_context()` in `src/app/domain_vocabulary.py` renders the context from **linked-data fields only** (`key`, `relationships`, `schema_org`). Definitions, aliases and bounded contexts stay prose — revised premise P2, one vocabulary, separately maintained contracts, no projection engine. A test asserts prose fields never leak into the artifact.
- `src/api/contracts/context.jsonld` is committed and byte-gated against the renderer.
- `/api/context.jsonld` serves it with `application/ld+json`, a byte-derived ETag and a one-hour public cache, mirroring the OpenAPI contract route. Host does not affect the representation, so no `Vary: Host`.
- Optional `floppy://domain-context` MCP resource. **No tool reads it**, so an instance that cannot serve it still supports every tool; a fetch failure returns a structured error. A test asserts a normal `search_media` call still succeeds while the context 404s.
- Linked from Settings → About and the offline API index. AsyncAPI is still absent, and `test_about.py` still asserts it — About links only artifacts that ship.

Class terms are PascalCase from the key (`media_type` → `MediaType`); property terms are camelCase from the relationship label. Where a `schema_org` mapping exists the class expands to the interoperable IRI (`Item` → `https://schema.org/CreativeWork`); otherwise it stays in `https://github.com/dannyvfilms/Floppy/ns#`.

## Package size

`pyld==2.0.4` is in the **test** dependency group only. The Docker build runs `uv sync --no-default-groups`, so it never reaches the production image. Net new runtime dependencies: **zero**. The artifact itself is ~700 bytes.

## Validation

- `SECRET=test-only scripts/test.sh`: **3639 tests, OK (1 skipped)**, exit 0
- `uv run --project mcp_server --extra dev pytest -q mcp_server/tests`: **58/58 passed**
- `ruff check src mcp_server/floppy_mcp mcp_server/tests`: **All checks passed**
- `git diff --check`: clean
- Drift-gate mutation proof: changing `floppy:consumption` → `floppy:MUTATED` in the committed context failed `test_committed_context_matches_the_vocabulary_renderer` and the PyLD expansion gate; restoring made them green. The gate is load-bearing, not decorative.
- PyLD expands **every** class and relationship in the vocabulary to the expected absolute IRIs.
- No model or migration changes.

## Review round already applied

An independent cross-model review (Gemini 3.7) found three real defects, all fixed in `eca2292d`:

1. `validate_terms()` checked **raw** relationship labels for uniqueness while the context maps the **projected** camelCase name. `"has user"` and `"Has  user"` both render as `hasUser`, so a collision could have silently collapsed two relationships into one property IRI. Now validated on the projected name.
2. `fetch_public_contract()` did not follow redirects, so an instance behind a proxy doing http→https would have returned redirect HTML as the context body.
3. The `--check` gate never covered `context.jsonld` on its own, and the entry-point tests patched only `GUIDE_PATH`, so `main([])` **wrote the real committed artifact** during a test run. Fixed and isolated.

It also named two gate gaps, both closed: property terms are now asserted `@id`-typed, and PyLD expansion covers the whole vocabulary rather than a hand-picked three.

## Remaining risk

- `src/api/contract_views.py` reads contracts at **module import**, so a missing artifact fails app startup rather than returning a 404. This follows the existing OpenAPI pattern from #742 and widens its blast radius by one file. Flagged for a decision rather than changed unilaterally.
- Browser QA of the new surfaces is **not done**. `HANDOFF-QA.md` on this branch lists exactly what is left: `/api/context.jsonld` in a browser, the new docs-index row at 320/375px, dark mode, keyboard focus, the zero-external-request check, and the container package-size gate.
- Rollback is isolated: drop the route, the view and the artifact. No migrations, no persisted-data changes.

## Human Review

- [ ] Pending

## Migration Sync Gate

Not applicable: not an `upstream` -> `latest` sync PR, no migration changes.
