### PR TITLE
test: wait for home page load after login in Playwright integration test

### DIFF
--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -100,6 +100,7 @@ class IntegrationTest(StaticLiveServerTestCase):
             self.credentials["password"],
         )
         self.page.get_by_role("button", name="Sign in").click()
+        expect(self.page.locator("#global-search")).to_be_visible()
 
     def search_and_submit(self, query):
         """Run a global search via the submit button.


### PR DESCRIPTION
## Summary
- Await `#global-search` visibility in `IntegrationTest.setUp()` following sign-in button click.
- Eliminates race condition where subsequent tests evaluate JS on an unmounted/transitioning document, preventing `TypeError: Cannot read properties of null (reading 'appendChild')`.
- Refs #624

## Post-Mortem / Root Cause Analysis (Bug Fixes)
- **Problem**: In Playwright, `locator.click()` resolves immediately without awaiting form submission/redirect. In `test_home_row_load_more_guard_and_progress`, the test executed `page.evaluate()` while the document was unmounting during the login redirect, leading to `document.body == null`.
- **Prevention**: Explicitly asserting `expect(self.page.locator("#global-search")).to_be_visible()` in `setUp()` guarantees navigation completes before tests begin.

## AI Assistance & Workflows
- **AI Model**: Gemini 2.5 Flash
- **Workflows & Tools**: Antigravity /investigate, /qa, /devex-review

## Validation
- `uv run --no-sync ruff check src` passed (0 errors).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` passed.
- `uv run --no-sync python src/manage.py check_migration_hygiene --strict` passed.
- `SECRET=test-only scripts/test.sh app.tests.test_integration` passed (7/7 Playwright tests in 18.08s).
- `SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` passed (46/46 tests).