### PR TITLE
test: wait for home page load after login in lists integration test

### DIFF
--- a/src/lists/tests/test_integration.py
+++ b/src/lists/tests/test_integration.py
@@ -103,6 +103,7 @@ class IntegrationTest(StaticLiveServerTestCase):
             self.credentials["password"],
         )
         self.page.get_by_role("button", name="Sign in").click()
+        expect(self.page.locator("#global-search")).to_be_visible()
 
     def search_and_submit(self, query):
         """Run a global search via the submit button.


### PR DESCRIPTION
## BLUF

`lists.tests.test_integration.py` had the same unguarded post-login race that PR #768 fixed in `app.tests.test_integration.py`. One-line fix, same pattern.

## Investigation

The CI-observed failure (`test_home_row_load_more_guard_and_progress`, `Cannot read properties of null (reading 'appendChild')`) traced to `setUp()` clicking "Sign in" and returning without waiting for the resulting navigation to finish. The test's first Playwright action was a raw `page.evaluate()` DOM manipulation — no actionability wait — so a null `document.body` on a mid-navigation document threw immediately. PR #768 fixed it by waiting for `#global-search` visibility right after the click.

Repo-wide sweep for `name="Sign in"` found exactly three files:

| File | Same unguarded `setUp()`? | Visibly broken? |
|---|---|---|
| `app/tests/test_integration.py` | had it | yes — fixed in #768 |
| `lists/tests/test_integration.py` | **had it** | no — masked, see below |
| `app/tests/test_media_list_browser_benchmarks.py` | no | not applicable |

`lists/tests/test_integration.py` never surfaced a visible failure because its first post-setUp action is a locator-based `.click()`, which Playwright auto-retries against actionability — the same race, self-healing by luck rather than by a real wait. `test_media_list_browser_benchmarks.py` is genuinely unaffected: its first action is its own `goto(wait_until="networkidle")`, which already waits out any race regardless of `setUp()`'s state, so it needs no change.

## Fix

One line, matching #768's exact pattern: `expect(self.page.locator("#global-search")).to_be_visible()` after the sign-in click. No shared base class — two call sites duplicating one already-established line matches AGENTS.md's anti-abstraction rule better than a new base class would.

## Validation

- `SECRET=test-only manage.py test lists.tests.test_integration app.tests.test_integration`: 9/9 OK, run 3 times for stability
- `SECRET=test-only scripts/test.sh`: **3711 tests, OK (2 skipped)**, exit 0
- `ruff check`: All checks passed
- Diff: 1 file, 1 line

## Human Review

- [ ] Pending

## Migration Sync Gate

Not applicable: no migration changes.
