### PR TITLE
Remove unused LOGIN_REQUIRED_EXEMPT setting (#592)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,8 @@ Models/migrations and divergent UI normally require manual adaptation. Provider 
 - `docs/agents/music_integration.md`: music-specific data model and UI integration notes.
 - `docs/agents/pocketcasts_workflow.md`: Pocket Casts import/schedule workflow details.
 - `docs/agents/migration_sync_playbook.md`: hard-gate flow for adapting accepted upstream migration outcomes to Floppy's current graph.
+- `docs/agents/view_authentication.md`: guide for view authentication and declaring public route exemptions.
+
 
 ## Local Commands
 - Install locked dev dependencies: `uv sync --locked`

--- a/docs/agents/view_authentication.md
+++ b/docs/agents/view_authentication.md
@@ -1,0 +1,129 @@
+# View Authentication and Public Route Exemption
+
+This guide explains how Floppy controls access to HTTP views and routes.
+
+## Architecture
+
+Floppy enforces authentication for all views by default.
+
+The application configures Django's core middleware in `src/config/settings.py`:
+
+```python
+MIDDLEWARE = [
+    ...,
+    "django.contrib.auth.middleware.LoginRequiredMiddleware",
+    ...,
+]
+```
+
+`LoginRequiredMiddleware` redirects unauthenticated (anonymous) requests to `/accounts/login/` unless a view explicitly declares an exemption.
+
+```
+       HTTP Request
+            │
+            ▼
+┌───────────────────────────────────────┐
+│       AuthenticationMiddleware        │
+│       (Populates request.user)        │
+└───────────────────┬───────────────────┘
+                    │
+                    ▼
+┌───────────────────────────────────────┐
+│        LoginRequiredMiddleware        │
+│  Is view exempt via @login_not_required?
+└───────┬───────────────────────┬───────┘
+        │ Yes                   │ No
+        ▼                       ▼
+┌───────────────┐       ┌───────────────────────────────┐
+│ Execute View  │       │ Is request.user authenticated? │
+└───────────────┘       └───────┬───────────────┬───────┘
+                                │ Yes           │ No
+                                ▼               ▼
+                        ┌───────────────┐ ┌────────────────────────┐
+                        │ Execute View  │ │ 302 Redirect to Login  │
+                        └───────────────┘ └────────────────────────┘
+```
+
+## How to Make a View Public
+
+To make a view accessible without authentication, use the `@login_not_required` decorator from `django.contrib.auth.decorators`.
+
+### 1. Function-Based Views
+
+Apply `@login_not_required` directly to the view function:
+
+```python
+from django.contrib.auth.decorators import login_not_required
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+
+
+@login_not_required
+@require_GET
+def public_endpoint(request):
+    """Return data accessible without authentication."""
+    return JsonResponse({"status": "ok"})
+```
+
+### 2. Class-Based Views in `urls.py`
+
+Wrap `View.as_view()` with `login_not_required` in the URL pattern definition:
+
+```python
+from django.contrib.auth.decorators import login_not_required
+from django.urls import path
+from myapp.views import PublicDataView
+
+urlpatterns = [
+    path("public-data/", login_not_required(PublicDataView.as_view()), name="public_data"),
+]
+```
+
+### 3. Class-Based Views via Method Decorator
+
+Apply `@method_decorator(login_not_required, name="dispatch")` to the class:
+
+```python
+from django.contrib.auth.decorators import login_not_required
+from django.utils.decorators import method_decorator
+from django.views import View
+
+
+@method_decorator(login_not_required, name="dispatch")
+class PublicPageView(View):
+    def get(self, request):
+        ...
+```
+
+## Retired Setting: `LOGIN_REQUIRED_EXEMPT`
+
+Previous iterations included a setting named `LOGIN_REQUIRED_EXEMPT` in `settings.py`.
+
+- Django's built-in `LoginRequiredMiddleware` does **not** read any setting or list of regex paths.
+- Route-level exemption lists in settings are unsupported and have been removed.
+- Adding a route path to settings will not make it public. You must use `@login_not_required`.
+
+## Established Public Routes
+
+The following endpoints in Floppy are intentionally public:
+
+| Route Path / Pattern | Purpose | Exemption Mechanism |
+|---|---|---|
+| `/health/` | Liveness probe for container checks | `login_not_required(MainView.as_view())` in `config/urls.py` |
+| `/ping/` | Fast ping endpoint | `login_not_required(...)` in `config/urls.py` |
+| `/serviceworker.js` | PWA offline service worker | `@login_not_required` on `service_worker` in `app/views.py` |
+| `/list/<reference>/rss` | Public list RSS feeds | `@login_not_required` on `list_rss_feed` in `lists/feeds.py` |
+| `/list/<reference>/json` | Public list JSON export | `@login_not_required` on `list_json` in `lists/feeds.py` |
+| `/list/<reference>` | Public list detail page | `@login_not_required` on `list_detail` in `lists/views.py` |
+| `/list/<reference>/export` | Public list CSV export | `@login_not_required` on `list_export_csv` in `lists/views.py` |
+| `/api/schema/`, `/api/docs/` | OpenAPI schema and Swagger UI | `@login_not_required` on API contract views |
+| `/accounts/login/`, `/signup/` | Authentication workflows | Handled by `django-allauth` account views |
+
+## Testing Requirements
+
+When you create a public view:
+
+1. Add a test sending an unauthenticated request (`self.client.get(...)` without `force_login` or `login`).
+2. Assert the response returns HTTP 200 (or the expected status code).
+3. Assert the response does not return HTTP 302 redirecting to `/accounts/login/`.
+4. Run `SECRET=test-only scripts/test.sh config.tests.test_login_required`.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1666,11 +1666,3 @@ REDIRECT_LOGIN_TO_SSO = config("REDIRECT_LOGIN_TO_SSO", default=False, cast=bool
 
 DEMO_ACCOUNT_ENABLED = config("DEMO_ACCOUNT_ENABLED", default=True, cast=bool)
 
-# Configure LoginRequiredMiddleware to exclude static files
-LOGIN_REQUIRED_EXEMPT = [
-    r"^/static/.*$",
-    r"^/favicon\.ico$",
-    r"^/health/.*$",
-    r"^/list/[^/]+/rss/?$",  # Public list RSS feeds
-    r"^/list/[^/]+/json/?$",  # Public list JSON exports
-]

--- a/src/config/tests/test_login_required.py
+++ b/src/config/tests/test_login_required.py
@@ -1,0 +1,146 @@
+"""Tests for authentication posture and anonymous route access.
+
+Verifies that:
+1. Dead LOGIN_REQUIRED_EXEMPT configuration is not present.
+2. Global LoginRequiredMiddleware protects authenticated routes by default.
+3. Intended public routes explicitly allow anonymous access via @login_not_required.
+"""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models import Item
+from app.models.choices import MediaTypes, Sources
+from lists.models import CustomList, CustomListItem
+
+
+class LoginRequiredConfigurationTests(TestCase):
+    """Test suite for global authentication settings and route policies."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="auth-test-user",
+            password="test-pass-123",
+        )
+        self.public_list = CustomList.objects.create(
+            name="Public Test List",
+            description="A list open to the public",
+            owner=self.user,
+            visibility="public",
+            public_slug="public-test-slug",
+        )
+        self.private_list = CustomList.objects.create(
+            name="Private Test List",
+            description="A list restricted to owner",
+            owner=self.user,
+            visibility="private",
+            public_slug="private-test-slug",
+        )
+        self.movie_item = Item.objects.create(
+            media_id="12345",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Public Movie Item",
+        )
+        CustomListItem.objects.create(
+            custom_list=self.public_list,
+            item=self.movie_item,
+        )
+
+    def test_login_required_exempt_setting_is_removed(self):
+        """LOGIN_REQUIRED_EXEMPT setting must not exist on settings."""
+        self.assertFalse(
+            hasattr(settings, "LOGIN_REQUIRED_EXEMPT"),
+            "LOGIN_REQUIRED_EXEMPT is dead configuration and must remain removed.",
+        )
+
+    def test_anonymous_health_and_ping_probes_return_200(self):
+        """Liveness health probes must remain accessible without authentication."""
+        for path in ["/health/", "/ping/"]:
+            response = self.client.get(path)
+            self.assertEqual(
+                response.status_code,
+                200,
+                f"Expected HTTP 200 for anonymous GET to {path}, got {response.status_code}",
+            )
+
+    def test_anonymous_full_health_check_bypasses_login_gate(self):
+        """Full health check endpoint must execute without redirecting to login."""
+        response = self.client.get("/health/full/")
+        self.assertNotEqual(
+            response.status_code,
+            302,
+            "Full health check must not redirect to login gate",
+        )
+        self.assertIn(response.status_code, (200, 500))
+
+    def test_anonymous_service_worker_returns_200(self):
+        """Service worker script must remain accessible without authentication."""
+        response = self.client.get(reverse("service_worker"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/javascript")
+
+    def test_anonymous_api_schema_and_docs_return_200(self):
+        """OpenAPI schema and documentation endpoints must be accessible without login."""
+        for endpoint in [reverse("schema"), reverse("openapi-contract"), reverse("swagger-ui")]:
+            response = self.client.get(endpoint)
+            self.assertEqual(
+                response.status_code,
+                200,
+                f"Expected HTTP 200 for anonymous GET to {endpoint}, got {response.status_code}",
+            )
+
+    def test_anonymous_public_list_detail_returns_200(self):
+        """Public list details must remain accessible by ID and slug without authentication."""
+        for ref in [str(self.public_list.id), self.public_list.public_slug]:
+            response = self.client.get(reverse("list_detail", args=[ref]))
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "Public Test List")
+
+    def test_anonymous_public_list_rss_feed_returns_200(self):
+        """Public list RSS feeds must remain accessible by ID and slug without authentication."""
+        for ref in [str(self.public_list.id), self.public_list.public_slug]:
+            response = self.client.get(reverse("list_rss", args=[ref]))
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b"rss", response.content)
+
+    def test_anonymous_public_list_json_export_returns_200(self):
+        """Public list JSON exports must remain accessible by ID and slug without authentication."""
+        for ref in [str(self.public_list.id), self.public_list.public_slug]:
+            response = self.client.get(reverse("list_json", args=[ref]) + "?arr=radarr")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response["Content-Type"], "application/json")
+
+    def test_anonymous_public_list_csv_export_returns_200(self):
+        """Public list CSV exports must remain accessible without authentication."""
+        for ref in [str(self.public_list.id), self.public_list.public_slug]:
+            response = self.client.get(reverse("list_export_csv", args=[ref]))
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response["Content-Type"], "text/csv")
+
+    def test_anonymous_private_list_endpoints_return_404(self):
+        """Private lists must return 404 to anonymous requests."""
+        for ref in [str(self.private_list.id), self.private_list.public_slug]:
+            self.assertEqual(self.client.get(reverse("list_detail", args=[ref])).status_code, 404)
+            self.assertEqual(self.client.get(reverse("list_rss", args=[ref])).status_code, 404)
+            self.assertEqual(self.client.get(reverse("list_json", args=[ref]) + "?arr=radarr").status_code, 404)
+            self.assertEqual(self.client.get(reverse("list_export_csv", args=[ref])).status_code, 404)
+
+    def test_anonymous_protected_routes_redirect_to_login(self):
+        """Protected application routes must redirect anonymous requests to the login page."""
+        protected_routes = [
+            reverse("lists"),
+            reverse("list_create"),
+            reverse("account"),
+            reverse("ui_preferences"),
+        ]
+        for url in protected_routes:
+            response = self.client.get(url)
+            self.assertEqual(
+                response.status_code,
+                302,
+                f"Expected HTTP 302 redirect for anonymous GET to {url}, got {response.status_code}",
+            )
+            self.assertIn("/accounts/login/", response["Location"])


### PR DESCRIPTION
## Problem
`LOGIN_REQUIRED_EXEMPT` in `settings.py` lists routes that appear to bypass `LoginRequiredMiddleware`, but application code never reads this setting. Django core `LoginRequiredMiddleware` checks for the `@login_not_required` decorator on view functions rather than a settings-based URL regex list.

This unused setting creates a misleading knob that can confuse contributors into believing that adding routes to `settings.py` changes runtime access control.

## Solution
- Remove the unused `LOGIN_REQUIRED_EXEMPT` setting from `src/config/settings.py`.
- Add a focused regression test suite in `src/config/tests/test_login_required.py` verifying that `LOGIN_REQUIRED_EXEMPT` is removed, intended public routes (health probes, service worker, public list RSS/JSON/CSV feeds, API docs) allow anonymous access, private lists return 404, and protected routes enforce 302 login redirects.
- Create `docs/agents/view_authentication.md` to document the default authentication model and explicit `@login_not_required` requirement in ASD-STE100 Simplified Technical English.
- Register `docs/agents/view_authentication.md` in `AGENTS.md`.

## Relationships
- Fixes #592
- Behavior prerequisite: #590 / merged PR #612 (service-worker route-level exemption)
- Historical context & feed surfaces: #341, #417, #635
- Runtime smoke boundary: #646 / PR #656

## Post-Mortem
| Dimension | Details |
|---|---|
| **Incident / Debt Summary** | Stale `LOGIN_REQUIRED_EXEMPT` setting gave the false impression that URL patterns in settings controlled authentication bypass. |
| **Root Cause** | Legacy pattern from third-party login middleware packages that does not apply to Django core `LoginRequiredMiddleware`. |
| **Trigger** | Discovered during service-worker investigation (#590 / PR #612). |
| **Resolution** | Removed dead configuration, added regression tests for all intended anonymous endpoints, and documented the `@login_not_required` requirement. |
| **Blast Radius** | Zero runtime regression. All public routes already declare `@login_not_required`. |

## Validation
- `SECRET=test-only scripts/test.sh config.tests.test_login_required`: 11/11 tests passed in 2.92s.
- `SECRET=test-only scripts/test.sh`: 3,738/3,738 tests passed.
- `uv run --no-sync ruff check src`: All checks passed with zero errors.
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check`: Vocabulary valid.
- `SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml`: Valid schema.
- Headless browser QA verified HTTP 200 on `/accounts/login/` and `/api/docs/`, and HTTP 302 redirect from `/lists` to `/accounts/login/?next=/lists`.

## AI Assistance
Generated with Antigravity (Gemini 3.7 Flash). Reviewed and tested manually.