### PR TITLE
Preserve SECRET_FILE environment variable during container bootstrap

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,10 +123,10 @@ if [ -e "$DATA_DIR" ] && ! timeout 600 chown abc:abc -- "$DATA_DIR"; then
     exit 1
 fi
 
-SECRET_FILE="${DATA_DIR}/secret_key"
-if { [ -e "$SECRET_FILE" ] || [ -L "$SECRET_FILE" ]; } && \
-   ! timeout 600 chown -h abc:abc -- "$SECRET_FILE"; then
-    echo "[entrypoint] Cannot set ownership for generated secret ${SECRET_FILE} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
+generated_secret_file="${DATA_DIR}/secret_key"
+if { [ -e "$generated_secret_file" ] || [ -L "$generated_secret_file" ]; } && \
+   ! timeout 600 chown -h abc:abc -- "$generated_secret_file"; then
+    echo "[entrypoint] Cannot set ownership for generated secret ${generated_secret_file} with PUID=${PUID} and PGID=${PGID}. Fix the mount permissions or the IDs." >&2
     exit 1
 fi
 
@@ -155,10 +155,10 @@ fi
 if [ -e "$LOG_DIR_PATH" ] && ! timeout 600 chown abc:abc -- "$LOG_DIR_PATH"; then
     echo "[entrypoint] WARNING: chown of ${LOG_DIR_PATH} failed or timed out (stalled mount?); continuing" >&2
 fi
-LOG_FILE="${LOG_DIR_PATH}/floppy.log"
-if { [ -e "$LOG_FILE" ] || [ -L "$LOG_FILE" ]; } && \
-   ! timeout 600 chown -h abc:abc -- "$LOG_FILE"; then
-    echo "[entrypoint] WARNING: chown of ${LOG_FILE} failed or timed out (stalled mount?); continuing" >&2
+log_file_path="${LOG_DIR_PATH}/floppy.log"
+if { [ -e "$log_file_path" ] || [ -L "$log_file_path" ]; } && \
+   ! timeout 600 chown -h abc:abc -- "$log_file_path"; then
+    echo "[entrypoint] WARNING: chown of ${log_file_path} failed or timed out (stalled mount?); continuing" >&2
 fi
 
 # Bound recursive ownership fixes for the image-managed service directories: a

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -215,6 +215,38 @@ class DataPathSettingsTests(SimpleTestCase):
             )
             self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
 
+    def test_configured_secret_file_is_used_when_secret_is_empty(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            secret_file = root / "custom_secret"
+            secret_file.write_text("custom-secret-value\n", encoding="utf-8")
+            environment = {
+                "PATH": os.environ["PATH"],
+                "PYTHONPATH": str(SRC),
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "SECRET": "",
+                "SECRET_FILE": str(secret_file),
+                "FLOPPY_DATA_DIR": str(data_dir),
+                "LOG_DIR": str(root / "logs"),
+            }
+
+            result = subprocess.run(  # noqa: S603 - test-controlled executable
+                [sys.executable, "-c", DOCKER_SECRET_PROBE],
+                cwd=root,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip().splitlines()[-1],
+                "custom-secret-value",
+            )
+            self.assertFalse((data_dir / "secret_key").exists())
+
     def test_generated_secret_failure_names_the_path_and_next_action(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             blocked_parent = Path(temp_dir) / "not-a-directory"
@@ -345,13 +377,19 @@ if [ -n "$FAIL_CHOWN_PATH" ] && [ "$last" = "$FAIL_CHOWN_PATH" ]; then
 fi
 """,
         )
-        for command in ("groupmod", "usermod", "supervisord"):
+        for command in ("groupmod", "usermod"):
             self.write_command(
                 fake_bin / command,
                 f"""#!/bin/sh
 {{ printf '{command}'; printf ' <%s>' "$@"; printf '\n'; }} >> "$FAKE_LOG"
 """,
             )
+        self.write_command(
+            fake_bin / "supervisord",
+            """#!/bin/sh
+{ printf 'supervisord'; printf ' <%s>' "$@"; printf ' [SECRET_FILE=%s]' "$SECRET_FILE"; printf '\n'; } >> "$FAKE_LOG"
+""",
+        )
 
         environment = {
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
@@ -514,3 +552,26 @@ fi
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertNotIn("FLOPPY_DB_PATH", result.stderr)
             self.assertNotIn("/db.sqlite3", commands)
+
+    def test_secret_file_environment_variable_is_preserved_for_supervisord(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            data_dir.mkdir()
+            custom_secret = root / "secrets" / "my_secret"
+            custom_secret.parent.mkdir()
+            custom_secret.write_text("custom-secret-key\n", encoding="utf-8")
+
+            result, commands = self.run_entrypoint(
+                root,
+                FLOPPY_DATA_DIR=str(data_dir),
+                SECRET="",
+                SECRET_FILE=str(custom_secret),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(
+                f"supervisord <-c> </etc/supervisord.conf> [SECRET_FILE={custom_secret}]",
+                commands,
+            )
+


### PR DESCRIPTION
## Problem
When running the container with `SECRET_FILE` set in the environment (e.g. `SECRET_FILE: /run/secrets/floppy_secret` via Docker secrets), the application crashed on boot with:
`FileNotFoundError: [Errno 2] No such file or directory: '/floppy/db/secret_key'`

In `entrypoint.sh`, the ownership routine assigned `SECRET_FILE="${DATA_DIR}/secret_key"`. `SECRET_FILE` is already exported when an operator passes it in, and in POSIX sh assigning to an exported variable updates the exported value, so `supervisord` and every child process (`gunicorn`, `celery`) inherited the overwritten path.

Fixes #775

## Solution
- Renamed internal shell variables in `entrypoint.sh` from `SECRET_FILE` to `generated_secret_file` and `LOG_FILE` to `log_file_path` so exported environment variables are preserved.
- Added regression tests in `src/app/tests/test_data_paths.py` verifying that `SECRET_FILE` is retained through container bootstrap and correctly loaded in settings.

## Validation
Author:
- `SECRET=test-only scripts/test.sh app.tests.test_data_paths config.tests.test_settings_secrets` (20/20 passed)
- `SECRET=test-only scripts/test.sh` (3,743 passed, 0 failures)
- `uv run --no-sync ruff check src` (Passed)
- `/bin/sh -n entrypoint.sh` (Passed)

After merging `latest` (2 commits: #773, #774) into this branch:
- `SECRET=test-only scripts/test.sh` — **3745 tests, OK (skipped=2), exit 0**
- `uv run --no-sync ruff check src` — All checks passed
- `/bin/sh -n entrypoint.sh` — OK
- Merge was conflict-free; `entrypoint.sh` and `test_data_paths.py` are unchanged by it.

## Contract Handoff
- Domain guide regeneration/check outcome: not applicable (no API/domain surface changed)
- Verified OpenAPI regeneration outcome: not applicable
- Contract-test outcome: not applicable

## Human Review
- [x] Pending human review.
- [ ] Completed — reviewer/evidence: <!-- link or concise evidence -->

## Gstack QA
- [ ] Pending `/gstack-qa`.
- [x] Completed — report/outcome: **No defects found. Verdict: ship.**

Verification beyond re-running the author's commands:

**The regression test is real.** Reverting `entrypoint.sh` to `origin/latest` makes `test_secret_file_environment_variable_is_preserved_for_supervisord` fail with exactly the reported bug (`SECRET_FILE=.../data/secret_key` instead of the operator's path); it passes on the fix. The second new test was mutation-tested by breaking `settings.py:160` (`SECRET_KEY = secret("SECRET_FILE")` → `None`) and it correctly failed. Both new tests are genuine guards.

**Root cause is fully covered.** Audited every uppercase assignment in `entrypoint.sh` against every env read in the app. Path variables already use safe internal names (`DATA_DIR_INPUT`/`DATA_DIR`, `LOG_DIR_INPUT`/`LOG_DIR_PATH`, `DB_FILE_INPUT`/`DB_FILE`), `PUID`/`PGID` use `${VAR:-default}`, and the app has no env reads of `DATA_DIR`, `DB_FILE`, `DB_PARENT`, `LOG_DIR_PATH`, `PUID` or `PGID`. `SECRET_FILE` and `LOG_FILE` were the only two leaks and both are fixed.

**End-to-end boot in the reported configuration.** Booted the app with `SECRET` empty and `SECRET_FILE` pointing at a `0444` read-only file, matching how Docker mounts `/run/secrets/*`. `SECRET_KEY` loaded from the file, login succeeded and the session persisted (proving the key signs, not merely loads), pages rendered styled with data, and 10/10 sampled pages returned HTTP 200.

Also confirmed the operator's secret file is never chmod'ed: `SECRET_FILE` is read via `secret()` / `read_text()`, while the `os.fchmod(fd, 0o600)` in `_read_docker_secret()` applies only to the container-generated `${FLOPPY_DATA_DIR}/secret_key`. A root-owned read-only Docker secret is safe.

Not covered: no Docker daemon was available, so `entrypoint.sh` was not executed inside a real container. The shell logic is exercised by the repo's existing entrypoint harness (fake `chown`/`groupmod`/`usermod`/`supervisord` on `PATH`), which the new regression test extends.

## AI Assistance
- Original fix and tests: generated with Antigravity (Gemini 3.7 Flash). Reviewed and tested manually.
- QA verification, the `latest` merge, and this description: Claude Code (claude-opus-5).

## Notes
- Fixes #775
