### PR TITLE
Fix run-floppy browser launch and document the .env secret shadow

### DIFF
--- a/.claude/skills/run-floppy/SKILL.md
+++ b/.claude/skills/run-floppy/SKILL.md
@@ -25,7 +25,7 @@ uv run --project .. --no-sync bash ../.claude/skills/run-floppy/scripts/serve.sh
 `serve.sh` and `smoke.py` encode everything below. Read on when you need to
 deviate — a different tier, real background tasks, a specific page.
 
-## The three things that go wrong
+## The four things that go wrong
 
 ### 1. Login returns 403, and it is not CSRF
 
@@ -109,6 +109,27 @@ looking in the wrong place.
 `/health/` to confirm the port really is quiet — reporting failure if it isn't
 rather than assuming.
 
+### 4. The repo `.env` silently wins over the secret env vars you set
+
+There is an untracked `.env` at the repo root, and it sets `SECRET`.
+`settings.py` reads `SECRET_KEY = config("SECRET", ...)` first and only falls
+back to `SECRET_FILE` when that is empty. python-decouple checks the real
+environment before `.env`, so `SECRET_FILE=... python ...` looks like it works
+and quietly loads the `.env` value instead — nothing errors, the key is just not
+the one you meant.
+
+`env -u SECRET` does **not** help: unsetting the variable makes decouple fall
+through to `.env`. Set it to empty instead, which is falsy and wins:
+
+```bash
+SECRET= SECRET_FILE=/path/to/secret uv run --project .. --no-sync python -c "
+import django; django.setup()
+from django.conf import settings; print(repr(settings.SECRET_KEY))"
+```
+
+Same trap for any other `.env` key when you are checking config precedence:
+assert the value you expect, don't assume the env var won.
+
 ## Choosing a resource tier
 
 `config/runtime_profile.py` detects the host's memory, swap and CPU and picks a
@@ -144,10 +165,14 @@ FLOPPY_PROCESS_ROLE=background uv run --project .. --no-sync celery --app config
 
 ## Driving the browser
 
-There is no `chromium-cli` here. Playwright's Python bindings and a pinned
-Chromium are preinstalled under `/opt/pw-browsers/chromium-*/chrome-linux/chrome`
-— glob it rather than hardcoding, the version directory changes. Never run
-`playwright install`.
+There is no `chromium-cli` here. Playwright's Python bindings are installed, and
+a Chromium already exists — on some machines pinned under
+`/opt/pw-browsers/chromium-*/chrome-linux*/chrome` (glob it, the version dir
+changes), otherwise in Playwright's own cache at `~/.cache/ms-playwright`.
+`smoke.py` prefers the `/opt` one and falls back to letting Playwright resolve
+the cached one, so normally you need no flags. Never run `playwright install` —
+if no browser is found, point `PLAYWRIGHT_BROWSERS_PATH` at a cache that has one
+or pass `--chromium /path/to/chrome`.
 
 `scripts/smoke.py` logs in and sweeps the pages that exercise the cache-heavy
 views, reporting HTTP status, whether a server-error page rendered, and console

--- a/.claude/skills/run-floppy/scripts/smoke.py
+++ b/.claude/skills/run-floppy/scripts/smoke.py
@@ -51,15 +51,17 @@ DEFAULT_PAGES = [
 ERROR_MARKERS = ("Server Error", "Internal Server Error", "Traceback")
 
 
-def find_chromium() -> str:
-    """Return the preinstalled Chromium path (the version dir is not stable)."""
-    matches = sorted(glob.glob("/opt/pw-browsers/chromium-*/chrome-linux/chrome"))
-    if not matches:
-        sys.exit(
-            "No Chromium under /opt/pw-browsers. Do not run `playwright install`; "
-            "set PLAYWRIGHT_BROWSERS_PATH or pass --chromium."
-        )
-    return matches[-1]
+def find_chromium() -> str | None:
+    """Return the preinstalled Chromium path, or None to let Playwright resolve it.
+
+    Some machines ship Chromium under /opt/pw-browsers (version dir and
+    chrome-linux/chrome-linux64 both vary, so glob). Elsewhere Playwright finds
+    its own download in ~/.cache/ms-playwright - passing None uses that. Never
+    run `playwright install`; if neither exists, Playwright's launch error says
+    so and the fix is to point PLAYWRIGHT_BROWSERS_PATH at an existing cache.
+    """
+    matches = sorted(glob.glob("/opt/pw-browsers/chromium-*/chrome-linux*/chrome"))
+    return matches[-1] if matches else None
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
Two dev-tooling fixes found while running `/gstack-qa` on #776. No application code is touched; this only changes the `run-floppy` skill.

**1. `smoke.py` could not launch a browser that was already installed.**
`find_chromium()` hard-exited when `/opt/pw-browsers` was missing, which is the case on machines where Playwright uses its own cache. Two things were wrong: the path is environment-specific, and the glob assumed the older `chrome-linux/chrome` layout while current Playwright ships `chrome-linux64/chrome`.

It now returns `None` instead of exiting, which is Playwright's default for `executable_path` and lets it resolve the browser it already downloaded (`~/.cache/ms-playwright`). The `/opt` path is still preferred when present, with the glob widened to match both layouts. `playwright install` is still never run, and `PLAYWRIGHT_BROWSERS_PATH` / `--chromium` remain the documented escape hatches.

**2. Documented a trap that silently produces wrong results.**
The untracked repo-root `.env` sets `SECRET`, and `settings.py` reads `config("SECRET", ...)` before falling back to `SECRET_FILE`. python-decouple checks `os.environ` before `.env`, so `SECRET_FILE=... python ...` looks like it works while quietly loading the `.env` value instead. Nothing errors; the key is just not the one you meant.

The non-obvious part: `env -u SECRET` makes it worse, because unsetting the variable causes decouple to fall through to `.env`. You need `SECRET=` (empty), which is falsy and wins. This cost a debug cycle during QA of #776, which is specifically about secret loading.

## Validation
- `uv run --no-sync python ../.claude/skills/run-floppy/scripts/smoke.py --base http://localhost:8299` — full sweep, 15/15 pages HTTP 200, no console errors, 15 screenshots written. Screenshots were opened to confirm real styled rendering rather than blank frames.
- Nothing was downloaded and `playwright install` was not run.
- No Python under `src/` changed, so the test suite is unaffected.

## Contract Handoff
- Domain guide regeneration/check outcome: not applicable
- Verified OpenAPI regeneration outcome: not applicable
- Contract-test outcome: not applicable

## Human Review
- [x] Pending human review.
- [ ] Completed — reviewer/evidence: <!-- link or concise evidence -->

## Gstack QA
- [x] Pending `/gstack-qa`.
- [ ] Completed — report/outcome: <!-- not applicable, this is tooling-only -->

## AI Assistance
Generated with Claude Code (claude-opus-5). Verified by running the fixed script end to end against a live local server.

## Notes
- Split out of #776 to keep that PR scoped to the container-bootstrap fix, per `CONTRIBUTING.md`.
