### PR TITLE
fix(db): holistic SQLite foreign-key self-healing, bounded logging, and zero-friction upgrades

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,6 +75,12 @@ if [ -z "$DB_HOST" ]; then
                     echo "[entrypoint] SQLite startup is paused because the integrity check failed; migrations and services were not started. The container will remain unhealthy and idle." >&2
                     ;;
             esac
+            decision_file="${DB_FILE}.integrity.decision"
+            # The check above consumes a choice it can act on. Anything left is
+            # stale, and a stale file would defeat the parking guard below and
+            # spin this loop without a bound. Clear it before serving the page,
+            # so only a choice made in this pass can resume startup.
+            rm -f "$decision_file"
             parking_pid=
             trap 'kill "$parking_pid" 2>/dev/null || :; wait "$parking_pid" 2>/dev/null || :; exit 0' TERM INT
             # Show the recovery page. It writes a copy beside the database, then
@@ -83,7 +89,6 @@ if [ -z "$DB_HOST" ]; then
             python -m config.sqlite_recovery_server "$DB_FILE" &
             parking_pid=$!
             wait "$parking_pid" || :
-            decision_file="${DB_FILE}.integrity.decision"
             if [ ! -f "$decision_file" ]; then
                 while :; do
                     sleep 86400 &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,18 +52,21 @@ if [ -z "$DB_HOST" ]; then
     # Check storage before migrations. Known disposable album credits are
     # repaired; other conflicts require an incident-scoped operator choice.
     if [ -f "$DB_FILE" ]; then
-        echo "[entrypoint] Checking SQLite storage and relationships for ${DB_FILE}" >&2
-        integrity_status=0
-        integrity_pid=
-        # One bound, used by the command and its operator message, so the two
-        # can never drift apart.
-        integrity_timeout=600
-        trap 'kill "$integrity_pid" 2>/dev/null || :; wait "$integrity_pid" 2>/dev/null || :; exit 0' TERM INT
-        timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
-        integrity_pid=$!
-        wait "$integrity_pid" || integrity_status=$?
-        trap - TERM INT
-        if [ "$integrity_status" -ne 0 ]; then
+        while :; do
+            echo "[entrypoint] Checking SQLite storage and relationships for ${DB_FILE}" >&2
+            integrity_status=0
+            integrity_pid=
+            # One bound, used by the command and its operator message, so the two
+            # can never drift apart.
+            integrity_timeout=600
+            trap 'kill "$integrity_pid" 2>/dev/null || :; wait "$integrity_pid" 2>/dev/null || :; exit 0' TERM INT
+            timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+            integrity_pid=$!
+            wait "$integrity_pid" || integrity_status=$?
+            trap - TERM INT
+            if [ "$integrity_status" -eq 0 ]; then
+                break
+            fi
             case "$integrity_status" in
                 124|143)
                     echo "[entrypoint] SQLite integrity check exceeded its ${integrity_timeout}s timeout; startup is paused before migrations and services. The container will remain unhealthy and idle." >&2
@@ -75,16 +78,21 @@ if [ -z "$DB_HOST" ]; then
             parking_pid=
             trap 'kill "$parking_pid" 2>/dev/null || :; wait "$parking_pid" 2>/dev/null || :; exit 0' TERM INT
             # Show the recovery page. It writes a copy beside the database, then
-            # serves it. If it stops, the container must stay alive and idle.
+            # serves it. If a choice is submitted, the server exits cleanly so
+            # the loop can apply the decision and continue to migrations.
             python -m config.sqlite_recovery_server "$DB_FILE" &
             parking_pid=$!
             wait "$parking_pid" || :
-            while :; do
-                sleep 86400 &
-                parking_pid=$!
-                wait "$parking_pid" || :
-            done
-        fi
+            decision_file="${DB_FILE}.integrity.decision"
+            if [ ! -f "$decision_file" ]; then
+                while :; do
+                    sleep 86400 &
+                    parking_pid=$!
+                    wait "$parking_pid" || :
+                done
+            fi
+            trap - TERM INT
+        done
     fi
 fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-APPS=(app users integrations lists events api)
+# "config" holds the settings, the startup integrity check and the recovery
+# page. Leaving it out let a helper that nothing called, and a report that
+# always raised, both ship under a green suite (PR #780).
+APPS=(app users integrations lists events api config)
 COMMON=(--parallel --buffer)
 
 case "${1:-}" in

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -455,13 +455,14 @@ else:
     }
 
     def configure_sqlite_connection(sender, connection, **_kwargs):
-        """Ensure SQLite connections wait for locks and use WAL."""
+        """Ensure SQLite connections wait for locks, enforce foreign keys, and use WAL."""
         if connection.vendor != "sqlite":
             return
 
         cursor = None
         try:
             cursor = connection.cursor()
+            cursor.execute("PRAGMA foreign_keys = ON")
             cursor.execute(f"PRAGMA journal_mode={SQLITE_JOURNAL_MODE}")
             actual_journal_mode = cursor.fetchone()[0]
             cursor.execute(f"PRAGMA synchronous={SQLITE_SYNCHRONOUS}")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -455,14 +455,19 @@ else:
     }
 
     def configure_sqlite_connection(sender, connection, **_kwargs):
-        """Ensure SQLite connections wait for locks, enforce foreign keys, and use WAL."""
+        """Ensure SQLite connections wait for locks and use WAL.
+
+        Foreign keys are not set here. Django's SQLite backend already runs
+        "PRAGMA foreign_keys = ON" as it opens each connection, and it turns
+        them off on purpose while a migration rewrites a table. A second copy
+        here would be dead on the first count and wrong on the second.
+        """
         if connection.vendor != "sqlite":
             return
 
         cursor = None
         try:
             cursor = connection.cursor()
-            cursor.execute("PRAGMA foreign_keys = ON")
             cursor.execute(f"PRAGMA journal_mode={SQLITE_JOURNAL_MODE}")
             actual_journal_mode = cursor.fetchone()[0]
             cursor.execute(f"PRAGMA synchronous={SQLITE_SYNCHRONOUS}")

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -425,6 +425,36 @@ def _check_disk_space(recovery_dir: Path, database_path: Path) -> None:
         raise OSError(message)
 
 
+def _report_corruption(db_path: str, reason: str) -> None:
+    """Publish the report that makes the recovery page show the damaged card.
+
+    A damaged file cannot be repaired by removing rows, so any choice left on
+    disk is stale. It is removed here; otherwise the entrypoint sees a choice
+    that no code path consumes and never parks.
+    """
+    with suppress(OSError):
+        _decision_path(db_path).unlink()
+    try:
+        _write_incident_report(
+            db_path,
+            {
+                # groups and samples are read without a default, so a report
+                # that omits them is never written and the page never appears.
+                "groups": [],
+                "samples": [],
+                "total_conflicts": 0,
+                "fingerprint": secrets.token_hex(32),
+                "can_quarantine": False,
+                "unsafe_reasons": [f"Physical corruption detected: {reason}"],
+            },
+            status="corrupt",
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        # The page is a courtesy; the log is the record. Say why it is missing
+        # rather than hiding the reason behind a bare except.
+        _log(f"[entrypoint] Could not publish the damaged-file report: {error}")
+
+
 def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
     """Create a consistent SQLite backup while the caller holds the write lock."""
     database_path = Path(db_path).resolve()
@@ -515,6 +545,10 @@ def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
             os.unlink(staging_name, dir_fd=recovery_descriptor)
             os.fsync(recovery_descriptor)
             succeeded = True
+            # Prune after the new copy is in place, never before. Pruning first
+            # would leave max_keep copies and then add one more, so the folder
+            # would settle one above the bound it is meant to hold.
+            _prune_recovery_backups(recovery_dir)
             return recovery_dir / final_name
         finally:
             if destination is not None:
@@ -968,34 +1002,22 @@ def check_database_integrity(db_path: str) -> None:
                 f"quick_check returned {status!r}",
             )
             _log(_CORRUPTION_HINT)
-            with suppress(Exception):
-                _write_incident_report(
-                    db_path,
-                    {
-                        "total_conflicts": 0,
-                        "status": "corrupt",
-                        "quick_check": status,
-                        "fingerprint": secrets.token_hex(32),
-                        "actions": [],
-                        "can_quarantine": False,
-                        "unsafe_reasons": [
-                            f"Physical corruption detected: quick_check returned {status!r}",
-                        ],
-                    },
-                    status="corrupt",
-                )
+            _report_corruption(db_path, f"quick_check returned {status!r}")
             sys.exit(1)
 
         _check_foreign_keys(conn, db_path)
     except sqlite3.DatabaseError as e:
         _log(f"[entrypoint] Database integrity check failed: {e}")
-        hint = (
-            _BUSY_HINT
-            if getattr(e, "sqlite_errorcode", None)
-            in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED}
-            else _CORRUPTION_HINT
-        )
-        _log(hint)
+        busy = getattr(e, "sqlite_errorcode", None) in {
+            sqlite3.SQLITE_BUSY,
+            sqlite3.SQLITE_LOCKED,
+        }
+        _log(_BUSY_HINT if busy else _CORRUPTION_HINT)
+        if not busy:
+            # A damaged file usually raises here rather than returning a
+            # quick_check string, so the recovery page needs the same report
+            # it gets from the returned-status path.
+            _report_corruption(db_path, str(e))
         sys.exit(1)
     finally:
         if conn is not None:

--- a/src/config/sqlite_integrity.py
+++ b/src/config/sqlite_integrity.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import secrets
+import shutil
 import sqlite3
 import stat
 import sys
@@ -28,7 +29,7 @@ _BUSY_HINT = (
 )
 _ALBUM_ARTIST_TABLE = "app_albumartist"
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
-_MAX_CONFLICT_SAMPLES = 20
+_MAX_CONFLICT_SAMPLES = 5
 _MAX_AFFECTED_TITLES = 5
 _REPORT_SUFFIX = ".integrity.json"
 _DECISION_SUFFIX = ".integrity.decision"
@@ -362,7 +363,8 @@ def _read_decision(db_path: str, incident: dict, incident_token: str) -> str | N
             "using halt",
         )
         return None
-    if decision.get("token") != incident_token:
+    token = decision.get("token")
+    if token and token != incident_token:
         _log("[entrypoint] The choice on file has an old code; using halt")
         return None
     action = decision.get("action")
@@ -375,21 +377,52 @@ def _selected_action(incident: dict, incident_token: str) -> str:
         return "halt"
 
     action, separator, supplied_token = configured.partition(":")
-    if action not in {"accept", "quarantine"} or not separator:
+    if action not in {"accept", "quarantine"}:
         _log(
             f"[entrypoint] Invalid {_ACTION_ENV}={configured!r}; using halt",
         )
         return "halt"
-    if supplied_token != incident_token:
-        # The operator must supply the one-time incident token, not the
-        # fingerprint; naming the fingerprint alone sends them to the wrong
-        # value and every retry halts again.
+    if separator and supplied_token != incident_token:
+        # The operator supplied a token, but it does not match current incident
         _log(
             f"[entrypoint] {_ACTION_ENV} does not carry the current incident "
             f"token for fingerprint {incident['fingerprint']}; using halt",
         )
         return "halt"
     return action
+
+
+def _prune_recovery_backups(recovery_dir: Path, max_keep: int = 10) -> None:
+    """Retain only the most recent recovery backups to bound disk usage."""
+    try:
+        backups = [
+            path
+            for path in recovery_dir.glob("*.sqlite3")
+            if path.is_file() and not path.is_symlink() and not path.name.startswith(".")
+        ]
+        if len(backups) <= max_keep:
+            return
+        backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for stale in backups[max_keep:]:
+            with suppress(OSError):
+                stale.unlink()
+    except OSError:
+        pass
+
+
+def _check_disk_space(recovery_dir: Path, database_path: Path) -> None:
+    """Verify available space before attempting to stage a backup."""
+    try:
+        free_bytes = shutil.disk_usage(recovery_dir).free
+    except (AttributeError, OSError):
+        return
+    db_size = database_path.stat().st_size
+    if free_bytes < db_size:
+        message = (
+            f"insufficient free disk space in {recovery_dir} "
+            f"({free_bytes} bytes free, {db_size} bytes needed for backup)"
+        )
+        raise OSError(message)
 
 
 def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
@@ -414,6 +447,7 @@ def _create_verified_backup(db_path: str, fingerprint: str) -> Path:
             message = "recovery directory is not a safe real directory"
             raise OSError(message)
         os.fchmod(recovery_descriptor, 0o700)
+        _check_disk_space(recovery_dir, database_path)
 
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
         final_name = (
@@ -795,7 +829,16 @@ def _check_foreign_keys(conn: sqlite3.Connection, db_path: str) -> None:
     only_album_artist = {
         group["table"] for group in incident["groups"]
     } == {_ALBUM_ARTIST_TABLE}
-    if action == "quarantine" or only_album_artist:
+    auto_repair_enabled = (
+        os.environ.get("FLOPPY_SQLITE_AUTO_REPAIR", "true").strip().lower()
+        not in {"0", "false", "no", "off"}
+    )
+    should_quarantine = (
+        action == "quarantine"
+        or (auto_repair_enabled and incident["can_quarantine"])
+        or only_album_artist
+    )
+    if should_quarantine:
         if not incident["can_quarantine"]:
             conn.rollback()
             _log(
@@ -818,11 +861,12 @@ def _check_foreign_keys(conn: sqlite3.Connection, db_path: str) -> None:
                     f"{remaining['total_conflicts']} conflict(s) remain after quarantine"
                 )
                 raise sqlite3.IntegrityError(message)
-            resolution = (
-                "automatic-album-artist"
-                if only_album_artist and action != "quarantine"
-                else "quarantine"
-            )
+            if only_album_artist and action != "quarantine" and not auto_repair_enabled:
+                resolution = "automatic-album-artist"
+            elif action == "quarantine":
+                resolution = "quarantine"
+            else:
+                resolution = "auto-repair"
             _write_incident_report(
                 db_path,
                 incident,
@@ -885,10 +929,15 @@ def _check_foreign_keys(conn: sqlite3.Connection, db_path: str) -> None:
                 )
             _log(f"[entrypoint] {message}")
             sys.exit(1)
-        if only_album_artist:
+        if only_album_artist and resolution == "automatic-album-artist":
             _log(
                 f"[entrypoint] Removed {deleted} orphaned album artist credit "
                 f"row(s) after backup to {backup_path}",
+            )
+        elif resolution == "auto-repair":
+            _log(
+                f"[entrypoint] Auto-repaired {deleted} orphaned child row(s); "
+                f"backup: {backup_path}",
             )
         else:
             _log(
@@ -910,7 +959,7 @@ def check_database_integrity(db_path: str) -> None:
     """Check SQLite storage and foreign keys before migrations."""
     conn = None
     try:
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(db_path, timeout=30.0)
         result = conn.execute("PRAGMA quick_check").fetchone()
         status = result[0] if result else None
         if status != "ok":
@@ -919,6 +968,22 @@ def check_database_integrity(db_path: str) -> None:
                 f"quick_check returned {status!r}",
             )
             _log(_CORRUPTION_HINT)
+            with suppress(Exception):
+                _write_incident_report(
+                    db_path,
+                    {
+                        "total_conflicts": 0,
+                        "status": "corrupt",
+                        "quick_check": status,
+                        "fingerprint": secrets.token_hex(32),
+                        "actions": [],
+                        "can_quarantine": False,
+                        "unsafe_reasons": [
+                            f"Physical corruption detected: quick_check returned {status!r}",
+                        ],
+                    },
+                    status="corrupt",
+                )
             sys.exit(1)
 
         _check_foreign_keys(conn, db_path)

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -146,6 +146,28 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
         )
         return _document(body)
 
+    if report.get("status") == "corrupt":
+        corruption_reasons = "".join(
+            f"<li><span>{html.escape(r)}</span></li>"
+            for r in report.get("unsafe_reasons", [])
+        )
+        parts = [
+            "<h1>Database File Damaged</h1>",
+            "<p>Floppy found physical corruption in the database file (quick_check failed). "
+            "Floppy will not modify the file to prevent further damage.</p>",
+            "<div class='card'><h2>What happened</h2>"
+            f"<ul>{corruption_reasons}</ul></div>",
+            "<div class='card'><h2>Download current copy</h2>"
+            "<p>Download a copy of the current file before restoring your backup.</p>"
+            "<p><a href='/backup'><button>Download Database Copy</button></a></p></div>",
+            "<div class='card'><h2>How to restore</h2>"
+            "<p>1. Stop the Floppy container.</p>"
+            "<p>2. Replace <code>db.sqlite3</code> with your known-good backup.</p>"
+            "<p>3. Start the Floppy container again.</p></div>",
+            _help_card(),
+        ]
+        return _document("".join(parts))
+
     total = _count(report.get("total_conflicts"))
     can_quarantine = bool(report.get("can_quarantine"))
     parts = [
@@ -166,15 +188,11 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
         )
         if can_quarantine:
             parts.append(
-                "<div class='card'><h2>Remove the affected entries</h2>"
-                "<p>Floppy saves a full backup first. Then it removes the "
-                f"{total} entries above and starts.</p>"
-                "<p class='note'>To confirm, copy the code from "
-                "<code>db.sqlite3.integrity.json</code> in the same folder as "
-                "your database.</p>"
+                "<div class='card'><h2>Remove the affected entries &amp; Start</h2>"
+                "<p>Floppy saves a verified backup first. Then it removes the "
+                f"{total} entries above and starts automatically.</p>"
                 "<form method='POST' action='/quarantine'>"
-                "<input name='token' placeholder='Paste the code' size='34'>"
-                "<button>Remove entries</button></form></div>",
+                "<button>Repair &amp; Start Floppy</button></form></div>",
             )
         else:
             parts.append(
@@ -191,8 +209,10 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
 
     parts.append(
         "<div class='card'><h2>Use a backup instead</h2>"
-        "<p>Stop Floppy. Replace <code>db.sqlite3</code> with your backup. "
-        "Start Floppy again.</p></div>",
+        "<p>Download a copy of your database, stop Floppy, replace "
+        "<code>db.sqlite3</code> with your backup, and start Floppy again.</p>"
+        "<p><a href='/backup'><button style='background:transparent;border:1px solid var(--border);color:var(--text);'>Download Database Copy</button></a></p>"
+        "</div>",
     )
     parts.append(_help_card())
     public = {
@@ -269,14 +289,50 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
         self.end_headers()
         self.wfile.write(payload)
 
     def do_GET(self) -> None:
         # Floppy is not able to serve requests, so the health check must fail.
         # A success here would report the container as healthy while it is not.
-        if self.path.split("?")[0] in _HEALTH_PATHS:
+        path = self.path.split("?")[0]
+        if path in _HEALTH_PATHS:
             self._send(503, "paused", "text/plain; charset=utf-8")
+            return
+        if path == "/backup":
+            if not self._is_same_origin():
+                self._send(403, "cross-site request", "text/plain; charset=utf-8")
+                return
+            db_file = Path(self.db_path).resolve()
+            if not db_file.is_file():
+                self._send(404, "database file not found", "text/plain; charset=utf-8")
+                return
+            try:
+                with db_file.open("rb") as f:
+                    content = f.read()
+            except OSError as error:
+                self._send(
+                    500,
+                    f"could not read database: {error}",
+                    "text/plain; charset=utf-8",
+                )
+                return
+            filename = f"floppy-backup-{db_file.name}"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/x-sqlite3")
+            self.send_header("Content-Length", str(len(content)))
+            self.send_header(
+                "Content-Disposition",
+                f'attachment; filename="{filename}"',
+            )
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+            self.send_header("Pragma", "no-cache")
+            self.send_header("Expires", "0")
+            self.end_headers()
+            self.wfile.write(content)
             return
         report = _read_incident_report(self.db_path)
         self._send(
@@ -328,10 +384,7 @@ class _Handler(BaseHTTPRequestHandler):
                 return
             supplied = (fields.get("token") or [""])[0].strip()
             expected = report.get("incident_token") or ""
-            if not report.get("can_quarantine") or not secrets.compare_digest(
-                supplied,
-                expected,
-            ):
+            if supplied and expected and not secrets.compare_digest(supplied, expected):
                 self._send(
                     403,
                     _document(
@@ -342,15 +395,39 @@ class _Handler(BaseHTTPRequestHandler):
                     "text/html; charset=utf-8",
                 )
                 return
+            if not report.get("can_quarantine"):
+                self._send(
+                    403,
+                    _document(
+                        "<h1>Cannot automatically repair</h1><p>These entries "
+                        "cannot be removed automatically.</p>",
+                    ),
+                    "text/html; charset=utf-8",
+                )
+                return
         _write_decision(self.db_path, report, action)
-        self._send(
-            200,
-            _document(
-                "<h1>Thank you. Restart Floppy now.</h1>"
-                "<p>Floppy applies your choice when it starts again.</p>",
-            ),
-            "text/html; charset=utf-8",
+        redirect_page = (
+            "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+            "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+            "<meta http-equiv='refresh' content='3;url=/'>"
+            "<title>Starting Floppy...</title>"
+            f"<style>{_STYLE}"
+            ".spinner{width:32px;height:32px;border:3px solid var(--border);border-top-color:var(--accent);"
+            "border-radius:50%;animation:spin 1s linear infinite;margin:1.5rem auto}"
+            "@keyframes spin{to{transform:rotate(360deg)}}"
+            "</style></head><body><main>"
+            "<div class='card' style='text-align:center;padding:2.5rem 1.5rem;'>"
+            "<div class='spinner'></div>"
+            "<h1 style='font-size:1.4rem;margin:0 0 0.5rem;'>Starting Floppy...</h1>"
+            "<p style='margin:0 0 1rem;'>Your choice is being applied now. The app will be ready in a few seconds.</p>"
+            "<p style='font-size:0.9rem;color:var(--muted);'>This page will refresh automatically, or "
+            "<a href='/'>click here to continue</a>.</p>"
+            "</div>"
+            "</main></body></html>"
         )
+        self._send(200, redirect_page, "text/html; charset=utf-8")
+        import threading
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
 
 
 def serve(db_path: str) -> None:

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -10,11 +10,17 @@ read what happened.
 
 from __future__ import annotations
 
+import base64
 import html
 import json
+import os
 import secrets
+import shutil
 import socket
 import sys
+import threading
+from contextlib import suppress
+from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
@@ -31,6 +37,13 @@ _PORT = 8000
 _HEALTH_PATHS = frozenset({"/health", "/health/"})
 _MAX_BODY_BYTES = 4096
 _SOCKET_TIMEOUT_SECONDS = 15
+_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+# This page has no sign-in. It runs before Django, on the port the app is
+# published on, so every request it answers is anonymous. A report with the
+# names redacted is safe to answer that way; the database file is not, because
+# it carries every account, session and integration secret. The download is
+# therefore off unless the operator turns it on for the length of the incident.
+_DOWNLOAD_ENV = "FLOPPY_SQLITE_ALLOW_BACKUP_DOWNLOAD"
 # The approval code proves that the person has read the report file. The page
 # must never show it, or the code proves only that they opened the page.
 _SECRET_REPORT_KEYS = frozenset({"actions", "incident_token"})
@@ -58,29 +71,56 @@ document.addEventListener('click',function(e){
 });
 """
 
+# The recovery server stops as soon as a choice is made, so every request here
+# fails until Floppy itself answers on this port. That is the signal to reload.
+_POLL_SCRIPT = """
+setInterval(function(){
+ fetch('/',{method:'HEAD',cache:'no-store'}).then(function(r){
+  if(r.ok){location.reload()}}).catch(function(){})
+},5000);
+"""
+
 # Copied from src/static/css/input.css. The page must not request an external
 # stylesheet, because it also opens as a file from the database folder.
 _STYLE = """
-:root{--page:#212529;--panel:#272c31;--text:#f3f4f6;--muted:#9ca3af;
---accent:#4a9eff;--border:#2c3136}
+/* Values taken from the app's --color-* tokens, so the page reads as the same
+   product. The app picks its theme from the signed-in user; nobody is signed
+   in here, so this follows the operating system instead. */
+:root{--page:#212529;--panel:#2a2f35;--text:#f3f4f6;--muted:#adb5bd;
+--accent:#4a9eff;--accent-strong:#1c5fb0;--border:#2c3136}
 @media (prefers-color-scheme: light){:root{--page:#f8f9fa;--panel:#fff;
---text:#1f2937;--muted:#4b5563;--accent:#2f80ed;--border:#dee2e6}}
+--text:#1f2937;--muted:#4b5563;--accent:#2f80ed;--accent-strong:#1a5fbf;
+--border:#dee2e6}}
 *{box-sizing:border-box}
 body{margin:0;padding:2.5rem 1.25rem;background:var(--page);color:var(--text);
 font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
 main{max-width:44rem;margin:0 auto}
+.masthead{display:flex;align-items:center;gap:.6rem;margin:0 0 1.5rem;
+font-size:1.15rem;font-weight:600;color:var(--text);letter-spacing:-.01em}
+.masthead img{border-radius:8px;flex:none}
 h1{font-size:1.5rem;margin:0 0 .5rem}
 p{margin:0 0 1rem;color:var(--muted)}
 .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;
 padding:1.25rem;margin:1rem 0}
 .card h2{font-size:1.05rem;margin:0 0 .35rem;color:var(--text)}
 ul{list-style:none;padding:0;margin:.5rem 0}
-li{display:flex;justify-content:space-between;gap:1rem;padding:.3rem 0;
+/* The two lists read differently: one is a table of counts, the other is an
+   ordered set of steps. Scope the row rule, or the steps inherit it. */
+ul li{display:flex;justify-content:space-between;gap:1rem;padding:.3rem 0;
 border-bottom:1px solid var(--border);color:var(--text)}
-li:last-child{border-bottom:0}
-li span:last-child{color:var(--muted);white-space:nowrap}
-button{background:var(--accent);color:#fff;border:0;border-radius:7px;
-padding:.6rem 1.1rem;font-size:1rem;cursor:pointer}
+ul li:last-child{border-bottom:0}
+ul li span:last-child{color:var(--muted);white-space:nowrap}
+ol{margin:.5rem 0;padding-left:1.3rem;color:var(--text)}
+ol li{padding:.2rem 0}
+/* #fff on --accent measures 2.75:1, below the 4.5:1 that body text needs.
+   The darker accent below carries white text at 5.3:1 in both schemes. */
+button,.button{background:var(--accent-strong);color:#fff;border:1px solid
+var(--accent-strong);border-radius:7px;padding:.6rem 1.1rem;font-size:1rem;
+cursor:pointer;display:inline-block;text-decoration:none;line-height:1.2}
+.button.secondary{background:transparent;color:var(--text);
+border-color:var(--muted)}
+button:focus-visible,.button:focus-visible,a:focus-visible{outline:3px solid
+var(--accent);outline-offset:2px}
 input{background:var(--page);color:var(--text);border:1px solid var(--border);
 border-radius:7px;padding:.55rem .7rem;font-size:1rem;margin-right:.5rem}
 code{background:var(--page);padding:.1rem .35rem;border-radius:4px;
@@ -91,6 +131,56 @@ border-radius:8px;padding:1rem;font-size:.85rem}
 .note{font-size:.9rem}
 a{color:var(--accent)}
 """
+
+
+@lru_cache(maxsize=4)
+def _asset_data_uri(name: str) -> str:
+    """Inline an app icon so the page carries its own copy.
+
+    Django is not running, so there is no static file server. The page is also
+    written beside the database and opened from there, where no server exists
+    at all. An inlined image is the only kind that survives both.
+    """
+    candidate = Path(__file__).resolve().parent.parent / "static" / "favicon" / name
+    try:
+        raw = candidate.read_bytes()
+    except OSError:
+        return ""
+    return "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+
+def _masthead() -> str:
+    """Show the Floppy mark, so the page reads as part of the app."""
+    icon = _asset_data_uri("android-chrome-192x192.png")
+    mark = (
+        f"<img src='{icon}' alt='' width='36' height='36'>" if icon else ""
+    )
+    return f"<header class='masthead'>{mark}<span>Floppy</span></header>"
+
+
+def _download_enabled() -> bool:
+    """Report whether the operator opened the database download."""
+    value = os.environ.get(_DOWNLOAD_ENV, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _backup_card() -> str:
+    """Offer the copy Floppy already made, or the download if it is open."""
+    if _download_enabled():
+        action = (
+            "<p><a class='button secondary' href='/backup'>"
+            "Download database copy</a></p>"
+        )
+    else:
+        action = (
+            "<p class='note'>Floppy writes a copy of the database to the "
+            "<code>sqlite-recovery</code> folder beside <code>db.sqlite3</code> "
+            "before it removes any entry. Copy the file from there.</p>"
+            f"<p class='note'>To download the file from this page instead, set "
+            f"<code>{_DOWNLOAD_ENV}=true</code> and start Floppy again. Keep it "
+            "off at other times, because this page has no sign-in.</p>"
+        )
+    return action
 
 
 def _count(value: object) -> int:
@@ -152,18 +242,18 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
             for r in report.get("unsafe_reasons", [])
         )
         parts = [
-            "<h1>Database File Damaged</h1>",
-            "<p>Floppy found physical corruption in the database file (quick_check failed). "
-            "Floppy will not modify the file to prevent further damage.</p>",
-            "<div class='card'><h2>What happened</h2>"
+            "<h1>Floppy cannot read the database file.</h1>",
+            "<p>The file is damaged. Floppy changed nothing, because a write "
+            "can damage it more. Replace the file with a backup.</p>",
+            "<div class='card'><h2>What Floppy found</h2>"
             f"<ul>{corruption_reasons}</ul></div>",
-            "<div class='card'><h2>Download current copy</h2>"
-            "<p>Download a copy of the current file before restoring your backup.</p>"
-            "<p><a href='/backup'><button>Download Database Copy</button></a></p></div>",
-            "<div class='card'><h2>How to restore</h2>"
-            "<p>1. Stop the Floppy container.</p>"
-            "<p>2. Replace <code>db.sqlite3</code> with your known-good backup.</p>"
-            "<p>3. Start the Floppy container again.</p></div>",
+            "<div class='card'><h2>Keep a copy of the damaged file</h2>"
+            "<p>Keep the damaged file before you replace it. A repair tool can "
+            "still read data from it.</p>" + _backup_card() + "</div>",
+            "<div class='card'><h2>How to restore</h2><ol>"
+            "<li>Stop Floppy.</li>"
+            "<li>Replace <code>db.sqlite3</code> with your known-good backup.</li>"
+            "<li>Start Floppy.</li></ol></div>",
             _help_card(),
         ]
         return _document("".join(parts))
@@ -180,19 +270,21 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
 
     if interactive:
         parts.append(
-            "<div class='card'><h2>Start anyway, keep everything</h2>"
+            "<div class='card'><h2>Keep the entries, then start</h2>"
             "<p>Floppy starts and changes no data. The affected entries stay "
             "hidden until you repair them.</p>"
-            "<form method='POST' action='/accept'><button>Start Floppy</button>"
-            "</form></div>",
+            "<form method='POST' action='/accept'>"
+            "<button>Keep everything and start Floppy</button></form></div>",
         )
         if can_quarantine:
             parts.append(
-                "<div class='card'><h2>Remove the affected entries &amp; Start</h2>"
-                "<p>Floppy saves a verified backup first. Then it removes the "
-                f"{total} entries above and starts automatically.</p>"
+                "<div class='card'><h2>Remove the entries, then start</h2>"
+                "<p>Floppy saves a backup of the database first. Then it "
+                f"removes the {total} entries above and starts. You cannot "
+                "undo this, but the backup keeps the entries.</p>"
                 "<form method='POST' action='/quarantine'>"
-                "<button>Repair &amp; Start Floppy</button></form></div>",
+                f"<button>Remove {total} entries and start Floppy</button>"
+                "</form></div>",
             )
         else:
             parts.append(
@@ -208,11 +300,10 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
         )
 
     parts.append(
-        "<div class='card'><h2>Use a backup instead</h2>"
-        "<p>Download a copy of your database, stop Floppy, replace "
-        "<code>db.sqlite3</code> with your backup, and start Floppy again.</p>"
-        "<p><a href='/backup'><button style='background:transparent;border:1px solid var(--border);color:var(--text);'>Download Database Copy</button></a></p>"
-        "</div>",
+        "<div class='card'><h2>Use a backup instead</h2><ol>"
+        "<li>Stop Floppy.</li>"
+        "<li>Replace <code>db.sqlite3</code> with your backup.</li>"
+        "<li>Start Floppy.</li></ol>" + _backup_card() + "</div>",
     )
     parts.append(_help_card())
     public = {
@@ -230,6 +321,27 @@ def render_page(report: dict | None, *, interactive: bool) -> str:
     return _document("".join(parts))
 
 
+def _waiting_page() -> str:
+    """Confirm the choice and wait for Floppy, without promising a time.
+
+    Floppy applies the choice, then runs migrations. On a large database that
+    takes minutes, so this page must not reload on a timer: it would land on a
+    connection error and read as a failed repair. It asks the server instead,
+    and reloads only once the server answers.
+    """
+    body = (
+        "<div class='card'>"
+        "<h1>Floppy has your choice.</h1>"
+        "<p role='status'>Floppy is applying it, then starting. This can take "
+        "several minutes on a large database. You can leave this page open.</p>"
+        "<p class='note'>This page opens Floppy when Floppy is ready. If it "
+        "stays on this message, look at the container log.</p>"
+        "<p><a class='button' href='/'>Open Floppy</a></p>"
+        "</div>"
+    )
+    return _document(body, script=_POLL_SCRIPT)
+
+
 def _help_card() -> str:
     """Offer the places where a person can get help."""
     links = " · ".join(
@@ -244,13 +356,16 @@ def _help_card() -> str:
     )
 
 
-def _document(body: str) -> str:
+def _document(body: str, script: str = _COPY_SCRIPT) -> str:
+    icon = _asset_data_uri("favicon-32x32.png")
+    link = f"<link rel='icon' type='image/png' href='{icon}'>" if icon else ""
     return (
         "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
         "<meta name='viewport' content='width=device-width,initial-scale=1'>"
         "<title>Floppy needs a decision</title>"
-        f"<style>{_STYLE}</style></head><body><main>{body}</main>"
-        f"<script>{_COPY_SCRIPT}</script></body></html>"
+        f"{link}<style>{_STYLE}</style></head><body>"
+        f"<main>{_masthead()}{body}</main>"
+        f"<script>{script}</script></body></html>"
     )
 
 
@@ -303,36 +418,7 @@ class _Handler(BaseHTTPRequestHandler):
             self._send(503, "paused", "text/plain; charset=utf-8")
             return
         if path == "/backup":
-            if not self._is_same_origin():
-                self._send(403, "cross-site request", "text/plain; charset=utf-8")
-                return
-            db_file = Path(self.db_path).resolve()
-            if not db_file.is_file():
-                self._send(404, "database file not found", "text/plain; charset=utf-8")
-                return
-            try:
-                with db_file.open("rb") as f:
-                    content = f.read()
-            except OSError as error:
-                self._send(
-                    500,
-                    f"could not read database: {error}",
-                    "text/plain; charset=utf-8",
-                )
-                return
-            filename = f"floppy-backup-{db_file.name}"
-            self.send_response(200)
-            self.send_header("Content-Type", "application/x-sqlite3")
-            self.send_header("Content-Length", str(len(content)))
-            self.send_header(
-                "Content-Disposition",
-                f'attachment; filename="{filename}"',
-            )
-            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
-            self.send_header("Pragma", "no-cache")
-            self.send_header("Expires", "0")
-            self.end_headers()
-            self.wfile.write(content)
+            self._send_backup()
             return
         report = _read_incident_report(self.db_path)
         self._send(
@@ -340,6 +426,39 @@ class _Handler(BaseHTTPRequestHandler):
             render_page(report, interactive=True),
             "text/html; charset=utf-8",
         )
+
+    def _send_backup(self) -> None:
+        """Send the database file, if the operator opened the download.
+
+        The file is sent in parts. Reading it into memory first would need as
+        much memory as the database is large, and the container that serves
+        this page is already the one that failed to start.
+        """
+        if not _download_enabled():
+            self._send(404, "not found", "text/plain; charset=utf-8")
+            return
+        if not self._is_same_origin():
+            self._send(403, "cross-site request", "text/plain; charset=utf-8")
+            return
+        db_file = Path(self.db_path).resolve()
+        try:
+            size = db_file.stat().st_size
+            handle = db_file.open("rb")
+        except OSError as error:
+            self._send(404, f"could not read database: {error}", "text/plain; charset=utf-8")
+            return
+        with handle:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/x-sqlite3")
+            self.send_header("Content-Length", str(size))
+            self.send_header(
+                "Content-Disposition",
+                f'attachment; filename="floppy-backup-{db_file.name}"',
+            )
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+            self.end_headers()
+            with suppress(OSError):
+                shutil.copyfileobj(handle, self.wfile, _DOWNLOAD_CHUNK_BYTES)
 
     def _read_body(self) -> dict | None:
         """Read a small form body. Refuse a large or malformed one."""
@@ -388,9 +507,9 @@ class _Handler(BaseHTTPRequestHandler):
                 self._send(
                     403,
                     _document(
-                        "<h1>That code is not correct.</h1><p>Copy the code from "
-                        "<code>db.sqlite3.integrity.json</code>. No entry was "
-                        "changed.</p>",
+                        "<h1>That code is not correct.</h1><p>The code belongs "
+                        "to an earlier problem. Open this page again to get the "
+                        "current one. No entry was changed.</p>",
                     ),
                     "text/html; charset=utf-8",
                 )
@@ -406,27 +525,11 @@ class _Handler(BaseHTTPRequestHandler):
                 )
                 return
         _write_decision(self.db_path, report, action)
-        redirect_page = (
-            "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
-            "<meta name='viewport' content='width=device-width,initial-scale=1'>"
-            "<meta http-equiv='refresh' content='3;url=/'>"
-            "<title>Starting Floppy...</title>"
-            f"<style>{_STYLE}"
-            ".spinner{width:32px;height:32px;border:3px solid var(--border);border-top-color:var(--accent);"
-            "border-radius:50%;animation:spin 1s linear infinite;margin:1.5rem auto}"
-            "@keyframes spin{to{transform:rotate(360deg)}}"
-            "</style></head><body><main>"
-            "<div class='card' style='text-align:center;padding:2.5rem 1.5rem;'>"
-            "<div class='spinner'></div>"
-            "<h1 style='font-size:1.4rem;margin:0 0 0.5rem;'>Starting Floppy...</h1>"
-            "<p style='margin:0 0 1rem;'>Your choice is being applied now. The app will be ready in a few seconds.</p>"
-            "<p style='font-size:0.9rem;color:var(--muted);'>This page will refresh automatically, or "
-            "<a href='/'>click here to continue</a>.</p>"
-            "</div>"
-            "</main></body></html>"
-        )
-        self._send(200, redirect_page, "text/html; charset=utf-8")
-        import threading
+        self._send(200, _waiting_page(), "text/html; charset=utf-8")
+        # The response is written above, but the socket is closed when this
+        # process ends. Flush first, or the page never reaches the browser.
+        with suppress(OSError):
+            self.wfile.flush()
         threading.Thread(target=self.server.shutdown, daemon=True).start()
 
 

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -21,6 +21,15 @@ _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
 
 
 class SqliteIntegrityTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.env_patcher = mock.patch.dict(os.environ, {"FLOPPY_SQLITE_AUTO_REPAIR": "false"})
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+        super().tearDown()
+
     def create_orphan_database(
         self,
         tmp_dir,
@@ -119,7 +128,7 @@ class SqliteIntegrityTests(SimpleTestCase):
 
             self.assertEqual(ctx.exception.code, 1)
             output = stderr.getvalue()
-            self.assertEqual(output.count("foreign key check failed"), 20)
+            self.assertEqual(output.count("foreign key check failed"), 5)
             self.assertIn("1000 foreign key conflict(s)", output)
             self.assertIn("FLOPPY_SQLITE_CONFLICT_ACTION=accept:", output)
             self.assertIn("FLOPPY_SQLITE_CONFLICT_ACTION=quarantine:", output)
@@ -138,7 +147,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     }
                 ],
             )
-            self.assertEqual(len(report["samples"]), 20)
+            self.assertEqual(len(report["samples"]), 5)
             self.assertEqual(len(report["fingerprint"]), 64)
             self.assertEqual(len(report["incident_token"]), 32)
 
@@ -1297,4 +1306,96 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(report["status"], "blocked")
             self.assertIn(f"accept:{report['incident_token']}", output)
             self.assertEqual(report["affected"], [])
+
+    def test_default_auto_repair_removes_orphans_and_boots(self):
+        """When auto-repair is enabled (default), startup cleans safe orphans and continues."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_orphan_database(tmp_dir, rows=5)
+
+            with (
+                mock.patch.dict(os.environ, {"FLOPPY_SQLITE_AUTO_REPAIR": "true"}),
+                mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+            ):
+                check_database_integrity(db_path)
+
+            output = stderr.getvalue()
+            self.assertIn("Auto-repaired 5 orphaned child row(s)", output)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM child").fetchone()[0], 0)
+            self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
+            conn.close()
+
+            report = self.read_incident_report(db_path)
+            self.assertEqual(report["status"], "resolved")
+            self.assertEqual(report["resolution"], "auto-repair")
+            self.assertEqual(report["deleted_rows"], 5)
+
+            backup_path = Path(report["backup_path"])
+            self.assertTrue(backup_path.is_file())
+            backup = sqlite3.connect(backup_path)
+            self.assertEqual(backup.execute("SELECT COUNT(*) FROM child").fetchone()[0], 5)
+            backup.close()
+
+    def test_auto_repair_handles_multiple_arbitrary_tables(self):
+        """Auto-repair cleans multiple damaged child tables atomically."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            conn = sqlite3.connect(db_path)
+            conn.executescript(
+                """
+                PRAGMA foreign_keys=ON;
+                CREATE TABLE p1 (id INTEGER PRIMARY KEY);
+                CREATE TABLE p2 (id INTEGER PRIMARY KEY);
+                CREATE TABLE c1 (id INTEGER PRIMARY KEY, p1_id INTEGER REFERENCES p1(id));
+                CREATE TABLE c2 (id INTEGER PRIMARY KEY, p2_id INTEGER REFERENCES p2(id));
+                INSERT INTO p1 VALUES (10);
+                INSERT INTO p2 VALUES (20);
+                INSERT INTO c1 VALUES (1, 10);
+                INSERT INTO c2 VALUES (2, 20);
+                """
+            )
+            conn.commit()
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute("DELETE FROM p1 WHERE id = 10")
+            conn.execute("DELETE FROM p2 WHERE id = 20")
+            conn.commit()
+            conn.close()
+
+            with (
+                mock.patch.dict(os.environ, {"FLOPPY_SQLITE_AUTO_REPAIR": "true"}),
+                mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+            ):
+                check_database_integrity(db_path)
+
+            output = stderr.getvalue()
+            self.assertIn("Auto-repaired 2 orphaned child row(s)", output)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM c1").fetchone()[0], 0)
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM c2").fetchone()[0], 0)
+            self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
+            conn.close()
+
+    def test_prune_recovery_backups_bounds_retention(self):
+        """_prune_recovery_backups keeps only max_keep newest files."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recovery_dir = Path(tmp_dir) / "sqlite-recovery"
+            recovery_dir.mkdir()
+            for i in range(15):
+                file_path = recovery_dir / f"db-backup-{i:02d}.sqlite3"
+                file_path.write_text("backup")
+                # Set distinct mtimes
+                os.utime(file_path, (1000 + i * 10, 1000 + i * 10))
+
+            sqlite_integrity._prune_recovery_backups(recovery_dir, max_keep=10)
+
+            remaining = sorted(p.name for p in recovery_dir.glob("*.sqlite3"))
+            self.assertEqual(len(remaining), 10)
+            # The 5 oldest (00 to 04) must have been pruned
+            self.assertNotIn("db-backup-00.sqlite3", remaining)
+            self.assertNotIn("db-backup-04.sqlite3", remaining)
+            self.assertIn("db-backup-14.sqlite3", remaining)
+            self.assertIn("db-backup-05.sqlite3", remaining)
+
 

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -30,6 +30,17 @@ class SqliteIntegrityTests(SimpleTestCase):
         self.env_patcher.stop()
         super().tearDown()
 
+    def unused_path(self):
+        """Name a database the test never opens, outside the working tree.
+
+        The connection is mocked, so the file is never read. The path still
+        decides where a report is written, and a bare name writes it into
+        whichever directory the suite was started from.
+        """
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        return str(Path(tmp_dir.name) / "unused.sqlite3")
+
     def create_orphan_database(
         self,
         tmp_dir,
@@ -1170,7 +1181,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertRaises(SystemExit) as ctx,
             mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
         ):
-            check_database_integrity("irrelevant.sqlite3")
+            check_database_integrity(self.unused_path())
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertIn("Stop other Floppy processes", stderr.getvalue())
@@ -1197,7 +1208,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertRaises(SystemExit) as ctx,
             mock.patch("sys.stderr"),
         ):
-            check_database_integrity("irrelevant.sqlite3")
+            check_database_integrity(self.unused_path())
 
         self.assertEqual(ctx.exception.code, 1)
         fake_conn.close.assert_called_once()
@@ -1211,7 +1222,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertRaises(SystemExit) as ctx,
             mock.patch("sys.stderr"),
         ):
-            check_database_integrity("irrelevant.sqlite3")
+            check_database_integrity(self.unused_path())
 
         self.assertEqual(ctx.exception.code, 1)
         fake_conn.close.assert_called_once()
@@ -1222,7 +1233,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertRaises(SystemExit) as ctx,
             mock.patch("sys.stderr"),
         ):
-            check_database_integrity("irrelevant.sqlite3")
+            check_database_integrity(self.unused_path())
 
         self.assertEqual(ctx.exception.code, 1)
 
@@ -1231,7 +1242,7 @@ class SqliteIntegrityTests(SimpleTestCase):
         fake_conn.execute.return_value.fetchone.return_value = ("ok",)
 
         with mock.patch("sqlite3.connect", return_value=fake_conn):
-            check_database_integrity("irrelevant.sqlite3")
+            check_database_integrity(self.unused_path())
 
         fake_conn.close.assert_called_once()
 
@@ -1397,5 +1408,49 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertNotIn("db-backup-04.sqlite3", remaining)
             self.assertIn("db-backup-14.sqlite3", remaining)
             self.assertIn("db-backup-05.sqlite3", remaining)
+
+    def test_repeated_repairs_do_not_grow_the_recovery_folder(self):
+        """Retention must run during a repair, not only when called by hand."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            recovery_dir = Path(tmp_dir) / "sqlite-recovery"
+            for _ in range(13):
+                Path(tmp_dir, "db.sqlite3").unlink(missing_ok=True)
+                db_path = self.create_orphan_database(tmp_dir, rows=1)
+                with (
+                    mock.patch.dict(os.environ, {"FLOPPY_SQLITE_AUTO_REPAIR": "true"}),
+                    mock.patch("sys.stderr", new_callable=io.StringIO),
+                ):
+                    check_database_integrity(db_path)
+
+            self.assertLessEqual(len(list(recovery_dir.glob("*.sqlite3"))), 10)
+
+    def test_a_damaged_file_clears_a_choice_no_code_path_can_apply(self):
+        """A choice removes rows. A damaged file has no rows to remove.
+
+        The entrypoint parks only while no choice is on disk. A choice left by
+        a repair that cannot run would keep the boot loop turning forever.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            conn = sqlite3.connect(db_path)
+            conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            conn.commit()
+            conn.close()
+            raw = bytearray(Path(db_path).read_bytes())
+            raw[100:400] = b"\x00" * 300
+            Path(db_path).write_bytes(bytes(raw))
+
+            decision = Path(f"{db_path}.integrity.decision")
+            decision.write_text('{"action":"quarantine","fingerprint":"old"}')
+
+            with (
+                mock.patch("sys.stderr", new_callable=io.StringIO),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                check_database_integrity(db_path)
+
+            self.assertEqual(ctx.exception.code, 1)
+            self.assertFalse(decision.exists())
+            self.assertEqual(self.read_incident_report(db_path)["status"], "corrupt")
 
 

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import sqlite3
 import tempfile
 import threading
@@ -175,7 +176,10 @@ class RecoveryPageTests(SimpleTestCase):
             response = self.post(f"{base}/quarantine")
             self.assertEqual(response.status, 200)
             body = response.read().decode()
-            self.assertIn("Starting Floppy...", body)
+            self.assertIn("Floppy has your choice.", body)
+            # The app needs minutes to migrate and start. A timed reload would
+            # land on a connection error and read as a failed repair.
+            self.assertNotIn("http-equiv='refresh'", body)
 
             decision = json.loads(
                 Path(f"{db_path}.integrity.decision").read_text(),
@@ -331,10 +335,17 @@ class RecoveryPageTests(SimpleTestCase):
             report = self.block_startup(db_path)
             page = recovery.render_page(report, interactive=True)
             # The page also opens from disk, where a subresource request cannot
-            # resolve. Styles and scripts stay inline. A link is different: the
-            # person clicks it, so the page requests nothing.
-            for marker in ("src=", "<link ", "@import"):
-                self.assertNotIn(marker, page)
+            # resolve. Styles, scripts and images stay inline. A link is
+            # different: the person clicks it, so the page requests nothing.
+            self.assertNotIn("@import", page)
+            fetched = re.findall(r"src='([^']*)'", page)
+            fetched += re.findall(r"<link[^>]*href='([^']*)'", page)
+            self.assertTrue(fetched, "expected the page to carry its own icon")
+            for reference in fetched:
+                self.assertTrue(
+                    reference.startswith("data:"),
+                    f"{reference[:40]} is requested when the page opens",
+                )
 
     def test_the_page_never_shows_the_approval_code(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -442,6 +453,21 @@ class RecoveryPageTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 403)
             self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
 
+    def test_backup_download_is_closed_unless_the_operator_opens_it(self):
+        """The page has no sign-in, so the database must not be the default."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(f"{base}/backup")  # noqa: S310
+            self.assertEqual(ctx.exception.code, 404)
+            page = urllib.request.urlopen(f"{base}/").read().decode()  # noqa: S310
+            self.assertNotIn("href='/backup'", page)
+            self.assertIn("FLOPPY_SQLITE_ALLOW_BACKUP_DOWNLOAD", page)
+
+    @mock.patch.dict(os.environ, {"FLOPPY_SQLITE_ALLOW_BACKUP_DOWNLOAD": "true"})
     def test_backup_download_serves_sqlite_file(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_incident(tmp_dir)
@@ -469,8 +495,23 @@ class RecoveryPageTests(SimpleTestCase):
             "can_quarantine": False,
         }
         page = recovery.render_page(report, interactive=True)
-        self.assertIn("Database File Damaged", page)
+        self.assertIn("Floppy cannot read the database file.", page)
         self.assertIn("Physical corruption detected", page)
-        self.assertIn("Download Database Copy", page)
+        self.assertIn("sqlite-recovery", page)
         self.assertNotIn("<form", page)
+
+    def test_the_page_carries_the_floppy_mark_and_icon(self):
+        """No static file server runs here, so both must be inlined."""
+        page = recovery.render_page(None, interactive=False)
+        self.assertIn("rel='icon'", page)
+        self.assertIn("data:image/png;base64,", page)
+        self.assertIn("class='masthead'", page)
+        self.assertNotIn("{% static", page)
+
+    @mock.patch.dict(os.environ, {"FLOPPY_SQLITE_ALLOW_BACKUP_DOWNLOAD": "true"})
+    def test_no_control_nests_inside_a_link(self):
+        """A button inside a link is announced twice by a screen reader."""
+        report = {"total_conflicts": 2, "can_quarantine": True, "affected": []}
+        page = recovery.render_page(report, interactive=True)
+        self.assertIsNone(re.search(r"<a\b[^>]*>\s*<button", page))
 

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -19,6 +19,15 @@ from config.sqlite_integrity import check_database_integrity
 
 
 class RecoveryPageTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.env_patcher = mock.patch.dict(os.environ, {"FLOPPY_SQLITE_AUTO_REPAIR": "false"})
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+        super().tearDown()
+
     def create_incident(self, tmp_dir, *, rows=3, with_titles=True):
         """Create a database whose episodes point at a season that is gone."""
         db_path = str(Path(tmp_dir) / "db.sqlite3")
@@ -139,7 +148,7 @@ class RecoveryPageTests(SimpleTestCase):
             self.assertEqual(decision["fingerprint"], report["fingerprint"])
             self.assertEqual(decision["token"], report["incident_token"])
 
-    def test_quarantine_without_the_code_changes_nothing(self):
+    def test_quarantine_with_wrong_code_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_incident(tmp_dir)
             self.block_startup(db_path)
@@ -156,6 +165,34 @@ class RecoveryPageTests(SimpleTestCase):
                 3,
             )
             conn.close()
+
+    def test_1_click_quarantine_records_the_choice(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            report = self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            response = self.post(f"{base}/quarantine")
+            self.assertEqual(response.status, 200)
+            body = response.read().decode()
+            self.assertIn("Starting Floppy...", body)
+
+            decision = json.loads(
+                Path(f"{db_path}.integrity.decision").read_text(),
+            )
+            self.assertEqual(decision["action"], "quarantine")
+            self.assertEqual(decision["fingerprint"], report["fingerprint"])
+
+    def test_recovery_server_sends_no_cache_headers(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            with urllib.request.urlopen(f"{base}/") as response:  # noqa: S310
+                self.assertEqual(response.status, 200)
+                self.assertIn("no-store", response.headers.get("Cache-Control", ""))
+                self.assertIn("no-cache", response.headers.get("Pragma", ""))
 
     def test_quarantine_with_the_code_records_the_choice(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -404,4 +441,36 @@ class RecoveryPageTests(SimpleTestCase):
                 urllib.request.urlopen(request)  # noqa: S310
             self.assertEqual(ctx.exception.code, 403)
             self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
+
+    def test_backup_download_serves_sqlite_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self.create_incident(tmp_dir)
+            self.block_startup(db_path)
+            base = self.serve(db_path)
+
+            with urllib.request.urlopen(f"{base}/backup") as response:  # noqa: S310
+                self.assertEqual(response.status, 200)
+                self.assertEqual(response.headers.get("Content-Type"), "application/x-sqlite3")
+                self.assertIn("attachment", response.headers.get("Content-Disposition", ""))
+                body = response.read()
+                self.assertGreater(len(body), 0)
+                # Verify downloaded content is valid sqlite file
+                backup_dest = Path(tmp_dir) / "downloaded.sqlite3"
+                backup_dest.write_bytes(body)
+                conn = sqlite3.connect(backup_dest)
+                result = conn.execute("PRAGMA quick_check").fetchone()
+                self.assertEqual(result[0], "ok")
+                conn.close()
+
+    def test_corrupt_status_renders_physical_corruption_card(self):
+        report = {
+            "status": "corrupt",
+            "unsafe_reasons": ["Physical corruption detected: quick_check returned 'malformed'"],
+            "can_quarantine": False,
+        }
+        page = recovery.render_page(report, interactive=True)
+        self.assertIn("Database File Damaged", page)
+        self.assertIn("Physical corruption detected", page)
+        self.assertIn("Download Database Copy", page)
+        self.assertNotIn("<form", page)
 


### PR DESCRIPTION
## Problem

Floppy instances on SQLite fail to start when historical data holds foreign key
conflicts (#731). Earlier attempts fixed part of the symptom and added new
failure modes:

1. **One table only** (#737). Orphan removal covered `app_albumartist`. A
   conflict in any other table exited 1, the container restarted, and the loop
   wrote about 5.7 GB of log.
2. **A code the operator had to find** (#741, #756). Recovery needed a 32
   character token read out of `db.sqlite3.integrity.json` and pasted into a
   web form.
3. **A container that never resumed.** The entrypoint parked in
   `sleep 86400` and never re-checked the database, so a choice made in the
   browser did nothing until the operator restarted the container by hand.
4. **Backups without a bound.** Each repair wrote another copy and removed none.

## Solution

### 1. Repair on start, for any table (`src/config/sqlite_integrity.py`)

- Removes orphaned child rows in every safe child table before migrations run,
  not only in `app_albumartist`.
- On by default (`FLOPPY_SQLITE_AUTO_REPAIR=true`). Set it to `false` to keep
  the choice in the browser.
- Copies the database to `db/sqlite-recovery/` and reads the copy back with
  `PRAGMA quick_check` before it changes a row. A copy that does not verify
  stops the repair.
- Checks free disk space before it stages the copy.
- Keeps the 10 most recent copies and removes the rest, after each new copy is
  in place.
- Prints at most 5 conflict samples, so a large incident cannot flood the log.
- Publishes a report when the file itself is damaged, so the recovery page can
  explain that case instead of offering a repair that cannot work.

### 2. A recovery page with no code to copy (`src/config/sqlite_recovery_server.py`)

- One button for each choice, each one naming its outcome: "Keep everything and
  start Floppy", or "Remove N entries and start Floppy". No token field.
- A separate page for a damaged file, with the steps to restore a backup.
- Carries the Floppy mark and icon, inlined, because no static file server runs
  at this point and the page is also opened from disk.
- Answers with `Cache-Control: no-store`, so a proxy or an installed PWA cannot
  serve a stale copy of an incident.
- After a choice, the page says the work takes minutes and opens Floppy once the
  port answers. It does not reload on a timer into a connection error.
- `GET /backup` sends the database file, in parts rather than into memory. It is
  **off unless `FLOPPY_SQLITE_ALLOW_BACKUP_DOWNLOAD=true`**: this page has no
  sign-in and listens on the published port, so an anonymous request must not be
  able to take the file that holds every account and integration secret. The
  automatic copy in `sqlite-recovery/` covers the ordinary case.

### 3. An entrypoint that resumes (`entrypoint.sh`)

- Replaces `sleep 86400` with a loop that notices `.integrity.decision`,
  re-runs the check to apply it, and continues into `manage.py migrate`.
- Clears a stale choice before it serves the page, so only a choice made in the
  current pass can resume startup. Without this the loop has no bound: a damaged
  file never consumes the choice, and the parking guard never fires.

### 4. Test coverage that runs (`scripts/test.sh`)

- Adds `config` to the default suite. The 121 tests covering settings, the
  startup integrity check and the recovery page have never run on a pull
  request.

## Post-mortem

Four defects reached review with every check green, and the reason is the same
for all four: **CI does not run the tests for this code.**

`.github/workflows/app-tests.yml` runs
`manage.py test app users integrations lists events`. `config` is not in that
list, and `config` is where every file in this change lives. The "3,745 tests
passed" figure in the earlier description came from a suite that executes no
line this PR touches.

What got through:

| Defect | Why the suite missed it |
|---|---|
| `_prune_recovery_backups` was never called | A test called the helper directly. Nothing tested that a repair calls it. 13 repairs left 13 copies. |
| The damaged-file report always raised `KeyError: 'groups'` inside `suppress(Exception)` | A test rendered the page from a hand-built dict. Nothing tested the writer, so the card was unreachable. |
| A stale choice file made the boot loop unbounded | The loop is shell. No test covers it. Reproduced at 69 iterations and 417 log lines in 25 seconds. |
| `GET /backup` returned the whole database to any anonymous client | A test asserted the download works. None asserted who is allowed to have it. |

Two patterns worth carrying forward:

- **A test that calls a helper directly does not prove anything calls the
  helper.** Three of the four passed exactly that way. Where a bound matters,
  assert the bound through the public path.
- **`suppress(Exception)` around a write turns a crash into a missing feature.**
  The corruption card looked implemented for as long as nobody produced a
  corrupt file. It now logs the reason instead.

This branch does **not** carry the CI change. `check-workflow-changes`
(`app-tests.yml:31`) fails any pull request that touches
`.github/workflows/**`, by design. The one line still needs to land, through
whatever route that guard allows:

```yaml
            app users integrations lists events config \
```

`scripts/test.sh` now includes `config`, so the local suite covers it in the
meantime.

## Verification

| Check | Result |
|---|---|
| `config` suite | 121 passed |
| Fast suite | 3743 passed, 2 skipped |
| `ruff check src` | clean |
| `check_migration_hygiene --strict` | clean |
| `sh -n entrypoint.sh` | clean |

Behaviour confirmed against synthetic damaged databases, not only in tests:

| Behaviour | Before | After |
|---|---|---|
| Copies kept after 13 repairs | 13 | 10 |
| Loop iterations in 25 s with a stale choice | 69 | 0, container parks |
| `GET /backup`, anonymous | 200, full database | 404 |
| Damaged file reaches the recovery page | never | yes |
| Primary button contrast | 2.75:1 | 6.34 dark, 6.12 light |

Full QA report, with reproductions: `.gstack/qa-reports/qa-report-pr780-2026-08-15.md`

## Screenshots


---

Fixes #731
Follows #734, #737, #739, #741, #745, #756
