### PR TITLE
Fix FURB171 lint failure blocking pushes to latest

### DIFF
--- a/src/app/media_list_filters.py
+++ b/src/app/media_list_filters.py
@@ -738,7 +738,7 @@ def _sort_value(entry, sort, next_episode):
     item = entry.item
     if sort in {"title", ""}:
         return getattr(item, "title", "").lower()
-    if sort in {"score"}:
+    if sort == "score":
         score = getattr(media, "aggregated_score", None)
         return score if score is not None else getattr(media, "score", None)
     if sort == "critic_rating":


### PR DESCRIPTION
## What

One line in `_sort_value`:

```diff
-    if sort in {"score"}:
+    if sort == "score":
```

## Why

Lint has been failing on every push to `latest` since [`8a3613b7`](https://github.com/dannyvfilms/Floppy/commit/8a3613b776268d6193f0b69bf94e4a587355e1f6) ("Expand media-list API filter parity"), including the most recent [run 31905292741](https://github.com/dannyvfilms/Floppy/actions/runs/31905292741) on #776, which is unrelated to that change:

```
FURB171 Membership test against single-item container
   --> src/app/media_list_filters.py:741:8
```

The Lint workflow only gates *changed lines* on `pull_request` events but runs the full `ruff check src` on pushes to `latest`. `8a3613b7` was pushed directly to `latest` with no PR, so the changed-lines gate never ran on it and the violation only surfaced afterwards — on somebody else's push.

This was the only violation in the repo; `ruff check src` is clean with it fixed.

## Verification

- `ruff check src` → `All checks passed!` (full repo, not just changed lines)
- `python manage.py test app.tests.views.test_media_list` → 87 tests, OK
- Ran the app locally and checked the sort actually still works, since `_sort_value` is on the media-list render path:
  - `/medialist/movie?sort=score` → 9.5, 7.1, 5.5, 3.2, 1.0
  - `/medialist/movie?sort=score&direction=asc` → 1.0, 3.2, 5.5, 7.1, 9.5
  - `_sort_value(entry, "score", None)` returns the score branch as before; `title` / `""` / unknown-sort branches unchanged
- Full page sweep (home, all media lists, history, statistics, calendar, discover, all settings) → all HTTP 200, no new console errors

`sort == "score"` and `sort in {"score"}` are semantically identical, so this is a no-op at runtime; the verification above is to prove that rather than assume it.

## Note

The underlying gap is that direct pushes to `latest` skip the changed-lines lint gate entirely. Fixing that means branch protection or a workflow change, which is out of scope here — CI edits fail by policy in this repo and shouldn't be bundled with code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)