### PR TITLE
Limit export history to seven days

### DIFF
--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1933,9 +1933,11 @@ class User(AbstractUser):
 
         # Get task results for this user
         task_result_filter_text = f"'user_id': {self.id},"
+        seven_days_ago = timezone.now() - timedelta(days=7)
         task_results = TaskResult.objects.filter(
             task_kwargs__contains=task_result_filter_text,
             task_name=export_task_name,
+            date_done__gte=seven_days_ago,
         ).order_by("-date_done")
 
         results = []

--- a/src/users/tests/test_models.py
+++ b/src/users/tests/test_models.py
@@ -1002,6 +1002,54 @@ class UserGetImportTasksTests(TestCase):
         self.assertEqual(len(lastfm_results), 0)
 
 
+class UserGetExportTasksTests(TestCase):
+    """Tests for the User.get_export_tasks method."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="exporter",
+            password="12345",
+        )
+
+    @patch("users.helpers.process_task_result")
+    def test_get_export_tasks_only_includes_last_seven_days(
+        self,
+        mock_process_task_result,
+    ):
+        """Export history excludes completed tasks older than seven days."""
+        processed_task = MagicMock(summary="Exported data", errors=[])
+        mock_process_task_result.return_value = processed_task
+        task_kwargs = f"{{'user_id': {self.user.id}, 'media_types': []}}"
+
+        recent_task = TaskResult.objects.create(
+            task_id="recent-export",
+            task_name="Scheduled backup export",
+            task_kwargs=task_kwargs,
+            status="SUCCESS",
+            result="{}",
+        )
+        TaskResult.objects.filter(pk=recent_task.pk).update(
+            date_done=timezone.now() - timedelta(days=6),
+        )
+        recent_task.refresh_from_db()
+        old_task = TaskResult.objects.create(
+            task_id="old-export",
+            task_name="Scheduled backup export",
+            task_kwargs=task_kwargs,
+            status="SUCCESS",
+            result="{}",
+        )
+        TaskResult.objects.filter(pk=old_task.pk).update(
+            date_done=timezone.now() - timedelta(days=8),
+        )
+
+        export_tasks = self.user.get_export_tasks()
+
+        self.assertEqual(len(export_tasks["results"]), 1)
+        self.assertEqual(export_tasks["results"][0]["date"], recent_task.date_done)
+        mock_process_task_result.assert_called_once_with(recent_task)
+
+
 class UserResolveWatchDateTests(TestCase):
     """Tests for the User.resolve_watch_date method."""
 


### PR DESCRIPTION
## Summary

- Limit scheduled export history to the seven-day window described by the UI.
- Add regression coverage for recent and expired export results.

## Problem

The export page says it shows activity from the last seven days, but scheduled export results were not date-filtered, so older backups remained visible.

## Solution

Filter scheduled export task results by `date_done` using the same seven-day cutoff pattern as import history. Add a regression test covering a recent result and one older than seven days.

## AI Assistance

Generated with OpenAI Codex (`gpt-5.6-sol`, Codex 5.6 SOL). Reviewed against the repository contribution guidelines and validated with the checks below.

## Validation

- `scripts/test.sh users.tests.test_models.UserGetExportTasksTests` — passed
- `scripts/test.sh users.tests.test_models` — 43 tests passed
- `uv run --no-sync ruff check src` — passed
- `git diff --check` — passed
- `scripts/test.sh` — attempted; the macOS parallel runner aborted while reporting Linux entrypoint/path test failures unrelated to the changed files. The required focused tests above passed; upstream Linux CI is awaiting maintainer approval.
- `uv run --no-sync python src/manage.py check_migration_hygiene --strict` — not applicable to this non-schema change and could not run because a fork checkout has no `upstream/dev`, `origin/dev`, or local `dev` ref.

## Contract Handoff

- Domain guide regeneration/check outcome: Not applicable — no domain vocabulary changed.
- Verified OpenAPI regeneration outcome: Not applicable — no API contract changed.
- Contract-test outcome: Not applicable — no domain or API contract changed.

## Screenshots

Not applicable — this is a backend queryset fix with no template, CSS, layout, or UI markup changes.

## Human Review

- [x] Pending human review.
- [ ] Completed — reviewer/evidence:

## Gstack QA

- [x] Pending `/gstack-qa`.
- [ ] Completed — report/outcome:

## Migration Sync Gate

Not applicable — this is not an `upstream` → `latest` sync PR and changes no migrations.

## Notes

- Fixes #749
