### PR TITLE
Include Kodi's 80 percent watch threshold

### DIFF
--- a/src/integrations/tests/test_webhooks_kodi.py
+++ b/src/integrations/tests/test_webhooks_kodi.py
@@ -318,6 +318,10 @@ class KodiProcessorUnitTests(TestCase):
         payload = {"event": "stop", "progress": {"percent": 85.0}}
         self.assertTrue(self.processor._is_played(payload))
 
+    def test_is_played_stop_at_threshold(self):
+        payload = {"event": "stop", "progress": {"percent": 80.0}}
+        self.assertTrue(self.processor._is_played(payload))
+
     def test_is_played_stop_below_threshold(self):
         payload = {"event": "stop", "progress": {"percent": 50.0}}
         self.assertFalse(self.processor._is_played(payload))

--- a/src/integrations/webhooks/kodi.py
+++ b/src/integrations/webhooks/kodi.py
@@ -50,7 +50,7 @@ class KodiWebhookProcessor(BaseWebhookProcessor):
             return True
         if payload.get("event") == KodiEvent.PLAYBACK_STOP:
             percent = payload.get("progress", {}).get("percent", 0)
-            if percent and percent > PERCENT_COMPLETE_THRESHOLD:
+            if percent and percent >= PERCENT_COMPLETE_THRESHOLD:
                 return True
         return False
 


### PR DESCRIPTION
## Summary

- Treat Kodi stop events at the documented 80% completion threshold as watched.
- Add exact-boundary regression coverage beside the existing above/below cases.

## Problem

The Kodi integration page says playback is marked watched when it reaches 80%, but the processor used a strict greater-than comparison. A `stop` event reporting exactly `80.0` percent therefore remained in progress.

## Solution

Make the existing threshold comparison inclusive. Preserve the current behavior for values below and above the threshold and for Kodi `end` events.

## AI Assistance

Generated with OpenAI Codex (`gpt-5.6-sol`, Codex 5.6 SOL). Reviewed against the repository contribution guidelines and validated with the checks below.

## Validation

- `scripts/test.sh integrations.tests.test_webhooks_kodi.KodiProcessorUnitTests` — 11 tests passed
- `uv run --no-sync ruff check src` — passed
- `git diff --check` — passed

## Contract Handoff

- Domain guide regeneration/check outcome: Not applicable — no domain vocabulary changed.
- Verified OpenAPI regeneration outcome: Not applicable — no API contract changed.
- Contract-test outcome: Not applicable — no domain or API contract changed.

## Screenshots

Not applicable — this is a backend webhook boundary fix with no template, CSS, layout, or UI markup changes.

## Human Review

- [x] Pending human review.
- [ ] Completed — reviewer/evidence:

## Gstack QA

- [x] Pending `/gstack-qa`.
- [ ] Completed — report/outcome:

## Migration Sync Gate

Not applicable — this is not an `upstream` → `latest` sync PR and changes no migrations.

## Notes

- Fixes #784
- Refs #278 for the original Kodi HTTP Scrobbler integration.
- Refs #417 for the Umbrella/Kodi API consumer context without expanding that completed scope.
