### PR TITLE
🔒 Redact secrets before runtime log output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,8 @@ Models/migrations and divergent UI normally require manual adaptation. Provider 
 - `docs/agents/pocketcasts_workflow.md`: Pocket Casts import/schedule workflow details.
 - `docs/agents/migration_sync_playbook.md`: hard-gate flow for adapting accepted upstream migration outcomes to Floppy's current graph.
 - `docs/agents/view_authentication.md`: guide for view authentication and declaring public route exemptions.
+- `docs/architecture/log-redaction.md`: the log boundary contract — where credentials are removed, what the rules match, and what they do not cover.
+- `docs/architecture/theming.md`: the theme resolution contract and the six theme states any colour change must hold.
 
 
 ## Local Commands
@@ -368,5 +370,6 @@ Notes:
 
 ## Security / Safety Notes
 - `.env` contains secrets and API keys; do not commit it.
+- A process-wide log record factory redacts credentials before any handler writes them (`src/app/log_safety.py`, installed by `src/config/__init__.py`). Do not move the installation later in the start sequence, and do not widen its `except` clause: both faults are silent. See `docs/architecture/log-redaction.md`.
 - Docker entrypoint runs migrations and changes ownership inside the container (`entrypoint.sh`).
 - Docker compose stores data in `./db`; local dev SQLite lives under `src/db/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,8 @@ Review and commit generated artifact changes. If regeneration makes no change, r
 
 **Colour and theming:** Colour goes through the `--color-*` tokens, never a raw palette utility and never Tailwind's `dark:` variant, which reads the OS instead of the user's chosen theme. There are six theme states to hold, not two. See [docs/architecture/theming.md](docs/architecture/theming.md); `src/app/tests/test_theme_tokens.py` enforces the two rules that are easiest to break.
 
+**Logging:** Call `logger.info("...", value)` as usual. A process-wide log record factory redacts credentials before any handler writes them, so you do not need a wrapper or a manual sanitizer. Two things still need care: a rule matches the *name* of a value, so give secrets a name that ends in `token`, `secret`, `password`, `api_key` or similar, and never log a raw response body or a full URL — use `safe_url()`. See [docs/architecture/log-redaction.md](docs/architecture/log-redaction.md); `src/app/tests/test_log_safety.py` enforces the rules that are easiest to break.
+
 **Lint cleanup:** If you spot pre-existing ruff/lint violations while working, do not fix them in the same PR. Either open a separate lint-only PR (welcome and easy to review) or leave a note. Fixing unrelated lint mid-feature PR inflates the diff and obscures the actual change.
 
 ---

--- a/README.md
+++ b/README.md
@@ -546,6 +546,24 @@ uv run --no-sync gunicorn --config python:config.gunicorn config.wsgi:applicatio
 Do not start the service with bare `gunicorn config.wsgi:application`; that
 skips the shipped configuration and its process lifecycle hooks.
 
+Gunicorn does not write a request access log. A request line holds the query
+string, and a query string can hold an OAuth code or an integration token, so
+the container writes one access line at the Nginx boundary instead, with the
+query string and the referrer removed. Gunicorn still writes its error log.
+
+A source-based deployment therefore gets its request log from its own reverse
+proxy. Configure that proxy to leave the query string out of its log format.
+The container's format is in `nginx.conf`:
+
+```nginx
+log_format floppy_safe '$remote_addr [$time_local] '
+                       '"$request_method $uri $server_protocol" '
+                       '$status $body_bytes_sent';
+```
+
+Application logs are separate and are always redacted before they are written.
+See [docs/architecture/log-redaction.md](docs/architecture/log-redaction.md).
+
 ### Upgrading container images
 
 The migration conflict involving `0147_item_calendar_checked_at` and

--- a/docs/architecture/log-redaction.md
+++ b/docs/architecture/log-redaction.md
@@ -75,7 +75,7 @@ enforce these rules.
 
 A value is a credential when its name **ends** with one of these keywords:
 `token`, `secret`, `password`, `passwd`, `apikey`, `api_key`, `api-key`,
-`sessionid`, `client_id`.
+`sessionid`.
 
 Match the keyword, not a list of full names. The same credential reaches the
 log in many spellings, and a list of full names cannot hold all of them:
@@ -99,6 +99,21 @@ readable: `status_code=200`, `error_code=RATE_LIMIT`, `token_count=512` and
 `code` would remove all of them. Nginx removes query strings from the request
 log, and Django logs the request path without the query, so an authorization
 code has no ordinary route into the log. Do not put one in a log message.
+
+**OAuth `client_id` parameters.** A `client_id` identifies the application, not
+the user, so it is not a secret and it stays readable. One case needs care.
+Trakt sends Floppy's `client_id` a second time as a `trakt-api-key` header, and
+Floppy loads that value from the `TRAKT_API_FILE` secret family. The header form
+stays redacted, because `trakt-api-key` ends in a keyword:
+
+```text
+headers={'trakt-api-key': '[REDACTED]'}      redacted
+?client_id=floppy-web&state=abc              not redacted
+```
+
+The second form is an authorize URL that Floppy builds as a redirect target.
+It reaches a log by the same narrow route an authorization `code` does, and the
+same instruction applies: do not put one in a log message. Use `safe_url()`.
 
 **Values whose name gives no clue.** A rule matches a name, not a value. Write
 `logger.info("plex sync failed for %s", safe_url(url))`, not the raw response

--- a/docs/architecture/log-redaction.md
+++ b/docs/architecture/log-redaction.md
@@ -1,0 +1,142 @@
+# Log redaction
+
+Floppy removes credentials from log output before a handler writes the output.
+This page records the contract, because the boundary is easy to move by
+accident and a fault in it is silent: the log looks correct, and the secret is
+in it.
+
+## Where the boundary is
+
+`src/config/__init__.py` installs a log record factory during process start.
+Python calls this factory for every log record, in every process: Django,
+Celery, the Gunicorn workers, and background tasks.
+
+```text
+HTTP request
+     |
+     v
+Nginx (port 8000) -----> access log: "$request_method $uri $server_protocol"
+     |                   Query strings and referrers are not written.
+     v
+Gunicorn (port 8001) --> accesslog = None. Nginx owns the request log.
+     |                   Gunicorn still writes its error log.
+     v
+Django / Celery / workers
+     |
+     |  logger.info("...", value)
+     v
+install_redacting_log_record_factory()   <- src/app/log_safety.py
+     |  1. Renders the "%" arguments one time.
+     |  2. Redacts the rendered text.
+     |  3. Redacts the traceback text and clears record.exc_info.
+     |  4. Redacts record.stack_info.
+     |  5. On any error, replaces the message and keeps nothing.
+     v
+Handlers: console (stdout) and the rotating file (floppy.log)
+```
+
+The factory runs before the handlers. Therefore the redaction applies to
+container output, to the log file on disk, and to the sanitized log download in
+Settings > Advanced. A handler cannot see the original text.
+
+## Three rules that are easy to break
+
+**Install the factory before the handlers run.** `config/__init__.py` is the
+first module Django, Celery, and Gunicorn import. Move the installation later,
+and the records that the start sequence writes are not redacted.
+
+**Keep the failure closed.** `config/__init__.py` accepts one import fault: an
+absent `app` package, which the isolated data path checks produce on purpose.
+It raises every other fault. A broad `except` gives a process that starts
+normally and writes unredacted logs, with no warning.
+
+**Do not send the original record to a handler.** If the factory cannot render
+or redact a message, it replaces the message with `Log message redaction
+failed` and clears the exception and stack fields. An unrendered record must
+not reach a handler.
+
+`src/app/tests/test_log_safety.py` and
+`src/app/tests/test_data_paths.py::test_config_import_reports_a_missing_log_safety_dependency`
+enforce these rules.
+
+## What the rules match
+
+`redact_secrets()` in `src/app/log_safety.py` applies these rules in order.
+
+| Rule | Example input | Output |
+|---|---|---|
+| `Bearer` credential | `Authorization: Bearer abc123` | `Authorization: [REDACTED]` |
+| `Basic` credential | `Basic dXNlcjpwYXNz` | `Basic [REDACTED]` |
+| Header value | `Cookie: sessionid=abc; csrftoken=d` | `Cookie: [REDACTED]` |
+| URL credentials | `postgres://user:pw@db:5432/floppy` | `postgres://[REDACTED]:[REDACTED]@db:5432/floppy` |
+| List value | `{'password': ['pw']}` | `{'password': [REDACTED]}` |
+| Quoted value | `{"api_key": "two words"}` | `{"api_key": "[REDACTED]"}` |
+| Unquoted value | `?X-Plex-Token=abc&size=10` | `?X-Plex-Token=[REDACTED]&size=10` |
+
+A value is a credential when its name **ends** with one of these keywords:
+`token`, `secret`, `password`, `passwd`, `apikey`, `api_key`, `api-key`,
+`sessionid`, `client_id`.
+
+Match the keyword, not a list of full names. The same credential reaches the
+log in many spellings, and a list of full names cannot hold all of them:
+
+| Spelling | Where it comes from |
+|---|---|
+| `access_token` | Trakt, AniList, Simkl |
+| `authToken`, `accessToken` | Plex, Jellyfin clients |
+| `X-Plex-Token`, `X-Api-Key` | provider request headers |
+| `TMDB_API_KEY` | environment variable dumps |
+| `webhook_secret` | integration webhooks |
+
+The keyword must be the last part of the name, so diagnostic fields stay
+readable: `status_code=200`, `error_code=RATE_LIMIT`, `token_count=512` and
+`tokenizer_config=default` are not changed.
+
+## What the rules do not cover
+
+**OAuth `code` parameters.** `code` is too general to match. `status_code`,
+`error_code` and `country_code` are common in diagnostic output, and a rule for
+`code` would remove all of them. Nginx removes query strings from the request
+log, and Django logs the request path without the query, so an authorization
+code has no ordinary route into the log. Do not put one in a log message.
+
+**Values whose name gives no clue.** A rule matches a name, not a value. Write
+`logger.info("plex sync failed for %s", safe_url(url))`, not the raw response
+body.
+
+**Prose after a header name.** The header rules take the rest of the line, so
+`Authorization: Bearer abc sent to trakt` becomes `Authorization: [REDACTED]`
+and the words `sent to trakt` are lost. This is deliberate. A header value has
+no reliable end delimiter, and a shorter match leaves part of the credential.
+Put diagnostic context in a separate log call.
+
+**Other processes.** Nginx writes its own access log, so `nginx.conf` holds the
+`floppy_safe` log format. A new process that writes output without the Python
+logging module needs its own boundary.
+
+## Cost
+
+The factory renders and redacts every record that passes the logger level.
+Measured on a 62,668 line corpus:
+
+| Path | Cost |
+|---|---|
+| One log record | about 25 us, or about 40,000 records per second on one core |
+| The 5 MiB log download | about 1.5 s |
+
+Two properties keep the cost predictable. Each rule reads the text one time.
+No rule lets two parts of a pattern match the same characters, because that
+makes the engine try every split and turns one long line into seconds of
+processor time.
+
+`test_redact_secrets_stays_fast_on_a_long_url_like_line` guards this.
+
+## Adding a keyword
+
+1. Add the keyword to `_SECRET_NAME_KEYWORDS` in `src/app/log_safety.py`.
+2. Confirm that the keyword cannot be the last part of a diagnostic name.
+   `code` fails this test. `token` passes it.
+3. Add the spelling to
+   `test_redact_secrets_strips_every_credential_name_spelling`.
+4. Add any diagnostic name that is now at risk to
+   `test_redact_secrets_keeps_names_that_only_end_in_a_keyword_word`.

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,7 +13,13 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /dev/stdout combined;
+    # Keep one access log at the reverse-proxy boundary. Query strings and
+    # referrers can contain OAuth codes or integration tokens, so do not write
+    # them to container output.
+    log_format floppy_safe '$remote_addr [$time_local] '
+                           '"$request_method $uri $server_protocol" '
+                           '$status $body_bytes_sent';
+    access_log /dev/stdout floppy_safe;
 
     sendfile on;
     tcp_nodelay on;

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -107,9 +107,13 @@ def install_redacting_log_record_factory() -> None:
             if record.stack_info:
                 record.stack_info = redact_secrets(record.stack_info)
         except Exception:
-            # Logging must not interrupt the operation it is reporting. The
-            # formatter still receives the original record if redaction fails.
-            pass
+            # Do not send the original record to a handler when rendering or
+            # redaction fails. Logging must not expose data or interrupt work.
+            record.msg = "Log message redaction failed"
+            record.args = ()
+            record.exc_info = None
+            record.exc_text = None
+            record.stack_info = None
         return record
 
     setattr(redacting_factory, _REDACTING_FACTORY_MARKER, True)

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -27,7 +27,6 @@ _SECRET_NAME_KEYWORDS = (
     "api_key",
     "api-key",
     "sessionid",
-    "client_id",
 )
 # Match the keyword alone and let the name prefix stay where it is. The rules
 # below require a "=" or a ":" directly after the keyword, so the keyword must

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -12,26 +12,29 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
 
-# Query/form/header param names that commonly carry secrets across Floppy's
+# Keywords that end the name of a value that carries a secret across Floppy's
 # integrations (Plex, Jellyfin, Trakt, TMDB, Last.fm, Koito, Pocket Casts,
-# gpodder, Stremio). Matches "name=value" (URL/form encoded) up to the next
-# delimiter, or "Name: value" (header style) to end of line.
-_SECRET_PARAM_NAMES = (
+# gpodder, Stremio). Match the keyword at the end of the name and allow any
+# prefix, because the same credential reaches the log in many spellings:
+# "access_token", "authToken", "X-Plex-Token", "X-Api-Key", "TMDB_API_KEY".
+# A list of exact spellings cannot cover them and lets secrets through.
+_SECRET_NAME_KEYWORDS = (
     "token",
-    "access_token",
-    "refresh_token",
-    "api_key",
-    "apikey",
-    "client_secret",
-    "client_id",
+    "secret",
     "password",
     "passwd",
-    "secret",
-    "x-plex-token",
+    "apikey",
+    "api_key",
+    "api-key",
     "sessionid",
-    "csrftoken",
+    "client_id",
 )
-_SECRET_NAME_PATTERN = "|".join(re.escape(name) for name in _SECRET_PARAM_NAMES)
+# The prefix stops at the delimiters that separate one field from the next, so
+# "token_count=512" and "status_code=200" stay readable: the keyword must be
+# the last part of the name, immediately before the "=" or ":".
+_SECRET_NAME_PATTERN = r"[\w.-]*(?:{})".format(
+    "|".join(re.escape(keyword) for keyword in _SECRET_NAME_KEYWORDS),
+)
 
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
@@ -53,26 +56,36 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         r"\1[REDACTED]:[REDACTED]@",
     ),
     (
+        # List values, such as the QueryDict repr Django writes for form data:
+        # {'password': ['secret']}. Redact the full list. Without this rule the
+        # unquoted rule below stops at the first quote and leaves the value.
+        re.compile(
+            rf"(?i)({_SECRET_NAME_PATTERN})([\"']?\s*[=:]\s*)\[[^\]\r\n]*\]",
+        ),
+        r"\1\2[REDACTED]",
+    ),
+    (
         # Quoted JSON, Python repr, and assignment values can contain spaces.
         re.compile(
-            rf'(?i)\b({_SECRET_NAME_PATTERN})(["\']?\s*[=:]\s*)'
+            rf'(?i)({_SECRET_NAME_PATTERN})(["\']?\s*[=:]\s*)'
             r'"(?:\\.|[^"\\\r\n])*"',
         ),
         r'\1\2"[REDACTED]"',
     ),
     (
         re.compile(
-            rf"(?i)\b({_SECRET_NAME_PATTERN})([\"']?\s*[=:]\s*)"
+            rf"(?i)({_SECRET_NAME_PATTERN})([\"']?\s*[=:]\s*)"
             r"'(?:\\.|[^'\\\r\n])*'",
         ),
         r"\1\2'[REDACTED]'",
     ),
     (
         # Unquoted URL, form, header, and assignment values stop at the next
-        # delimiter. Quoted values are handled by the two patterns above.
+        # delimiter. Quoted and list values are handled by the rules above, so
+        # this rule does not start on a quote or a bracket.
         re.compile(
-            rf"(?i)\b({_SECRET_NAME_PATTERN})[\"']?\s*[=:]\s*"
-            r"[^&\s\"'<>]+",
+            rf"(?i)({_SECRET_NAME_PATTERN})[\"']?\s*[=:]\s*"
+            r"[^&\s\"'<>\[\]]+",
         ),
         r"\1=[REDACTED]",
     ),

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import re
 from collections.abc import Iterable, Mapping
 from typing import Any
@@ -27,12 +28,28 @@ _SECRET_PARAM_NAMES = (
     "passwd",
     "secret",
     "x-plex-token",
+    "sessionid",
+    "csrftoken",
 )
 
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(r"(?i)\bBearer\s+[A-Za-z0-9\-_.~+/]+=*"),
         "Bearer [REDACTED]",
+    ),
+    (
+        re.compile(r"(?i)\bBasic\s+[A-Za-z0-9+/]+=*"),
+        "Basic [REDACTED]",
+    ),
+    (
+        re.compile(r"(?im)\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\r\n]+"),
+        r"\1: [REDACTED]",
+    ),
+    (
+        # Remove credentials from URLs such as proxy and database connection
+        # strings. The host and path stay visible for diagnosis.
+        re.compile(r"(?i)(\b[a-z][a-z0-9+.-]*://)([^/@\s]*):([^@/\s]+)@"),
+        r"\1[REDACTED]:[REDACTED]@",
     ),
     (
         # Matches "name=value"/"Name: value" (URL/form/header style) as well as
@@ -63,6 +80,40 @@ def redact_secrets(text: str) -> str:
     for pattern, replacement in _SECRET_PATTERNS:
         redacted = pattern.sub(replacement, redacted)
     return redacted
+
+
+_REDACTING_FACTORY_MARKER = "_floppy_redacts_secrets"
+
+
+def install_redacting_log_record_factory() -> None:
+    """Redact each Python log record before any handler can write it."""
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, _REDACTING_FACTORY_MARKER, False):
+        return
+
+    exception_formatter = logging.Formatter()
+
+    def redacting_factory(*args, **kwargs):
+        record = current_factory(*args, **kwargs)
+        try:
+            # Resolve lazy %-style arguments once, then store only the redacted
+            # text. All handlers receive the same safe record.
+            record.msg = redact_secrets(record.getMessage())
+            record.args = ()
+            if record.exc_info:
+                record.exc_text = redact_secrets(
+                    exception_formatter.formatException(record.exc_info),
+                )
+            if record.stack_info:
+                record.stack_info = redact_secrets(record.stack_info)
+        except Exception:
+            # Logging must not interrupt the operation it is reporting. The
+            # formatter still receives the original record if redaction fails.
+            pass
+        return record
+
+    setattr(redacting_factory, _REDACTING_FACTORY_MARKER, True)
+    logging.setLogRecordFactory(redacting_factory)
 
 
 def exception_summary(exc: BaseException | None) -> str:

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -31,6 +31,7 @@ _SECRET_PARAM_NAMES = (
     "sessionid",
     "csrftoken",
 )
+_SECRET_NAME_PATTERN = "|".join(re.escape(name) for name in _SECRET_PARAM_NAMES)
 
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
@@ -52,14 +53,26 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         r"\1[REDACTED]:[REDACTED]@",
     ),
     (
-        # Matches "name=value"/"Name: value" (URL/form/header style) as well as
-        # JSON's quoted "name": "value" — the optional quotes around the key
-        # and the value's opening quote let the same pattern catch a raw
-        # payload dict that's been json.dumps()'d before logging.
+        # Quoted JSON, Python repr, and assignment values can contain spaces.
         re.compile(
-            r"(?i)\b("
-            + "|".join(_SECRET_PARAM_NAMES)
-            + r")\"?\s*[=:]\s*\"?[^&\s\"'<>]+"
+            rf'(?i)\b({_SECRET_NAME_PATTERN})(["\']?\s*[=:]\s*)'
+            r'"(?:\\.|[^"\\\r\n])*"',
+        ),
+        r'\1\2"[REDACTED]"',
+    ),
+    (
+        re.compile(
+            rf"(?i)\b({_SECRET_NAME_PATTERN})([\"']?\s*[=:]\s*)"
+            r"'(?:\\.|[^'\\\r\n])*'",
+        ),
+        r"\1\2'[REDACTED]'",
+    ),
+    (
+        # Unquoted URL, form, header, and assignment values stop at the next
+        # delimiter. Quoted values are handled by the two patterns above.
+        re.compile(
+            rf"(?i)\b({_SECRET_NAME_PATTERN})[\"']?\s*[=:]\s*"
+            r"[^&\s\"'<>]+",
         ),
         r"\1=[REDACTED]",
     ),

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -29,11 +29,12 @@ _SECRET_NAME_KEYWORDS = (
     "sessionid",
     "client_id",
 )
-# The prefix stops at the delimiters that separate one field from the next, so
-# "token_count=512" and "status_code=200" stay readable: the keyword must be
-# the last part of the name, immediately before the "=" or ":".
-_SECRET_NAME_PATTERN = r"[\w.-]*(?:{})".format(
-    "|".join(re.escape(keyword) for keyword in _SECRET_NAME_KEYWORDS),
+# Match the keyword alone and let the name prefix stay where it is. The rules
+# below require a "=" or a ":" directly after the keyword, so the keyword must
+# be the last part of the name: "token_count=512", "status_code=200" and
+# "tokenizer_config=default" stay readable.
+_SECRET_NAME_PATTERN = "|".join(
+    re.escape(keyword) for keyword in _SECRET_NAME_KEYWORDS
 )
 
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -52,7 +53,11 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         # Remove credentials from URLs such as proxy and database connection
         # strings. The host and path stay visible for diagnosis.
-        re.compile(r"(?i)(\b[a-z][a-z0-9+.-]*://)([^/@\s]*):([^@/\s]+)@"),
+        # The user part excludes ":" so that only one split of "user:password"
+        # is possible. If both parts accept ":", a long line that holds a
+        # scheme and many colons but no "@" makes the engine try every split,
+        # which costs seconds of processor time for one log record.
+        re.compile(r"(?i)(\b[a-z][a-z0-9+.-]*://)([^:/@\s]*):([^@/\s]{1,256})@"),
         r"\1[REDACTED]:[REDACTED]@",
     ),
     (

--- a/src/app/log_safety.py
+++ b/src/app/log_safety.py
@@ -117,6 +117,9 @@ def install_redacting_log_record_factory() -> None:
                 record.exc_text = redact_secrets(
                     exception_formatter.formatException(record.exc_info),
                 )
+                # Structured handlers can inspect LogRecord attributes without
+                # using Formatter. Keep only the safe exception text.
+                record.exc_info = None
             if record.stack_info:
                 record.stack_info = redact_secrets(record.stack_info)
         except Exception:

--- a/src/app/tests/test_data_paths.py
+++ b/src/app/tests/test_data_paths.py
@@ -105,6 +105,35 @@ class DataPathSettingsTests(SimpleTestCase):
             )
             self.assertTrue(external_database.parent.is_dir())
 
+    def test_config_import_reports_a_missing_log_safety_dependency(self):
+        """Only an absent app package is tolerable. Other faults must raise.
+
+        ``config`` tolerates a missing ``app`` package so the isolated checks
+        below can import it. If that tolerance also hid a broken dependency,
+        the process would start with no log redaction and no warning.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            shutil.copytree(SRC / "config", root / "config")
+            app_package = root / "app"
+            app_package.mkdir()
+            (app_package / "__init__.py").write_text("")
+            (app_package / "log_safety.py").write_text(
+                "import floppy_absent_dependency\n",
+            )
+
+            result = subprocess.run(
+                [sys.executable, "-c", "import config"],
+                cwd=root,
+                env={**os.environ, "PYTHONPATH": str(root)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("floppy_absent_dependency", result.stderr)
+
     def test_read_only_source_uses_external_writable_paths(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -1,7 +1,10 @@
+import logging
+
 from django.test import SimpleTestCase
 
 from app.log_safety import (
     exception_summary,
+    install_redacting_log_record_factory,
     presence_map,
     redact_secrets,
     safe_url,
@@ -42,8 +45,25 @@ class LogSafetyTests(SimpleTestCase):
 
         self.assertEqual(
             redact_secrets(line),
-            "[INFO] Authorization: Bearer [REDACTED] sent to trakt",
+            "[INFO] Authorization: [REDACTED]",
         )
+
+    def test_redact_secrets_strips_basic_authorization(self):
+        self.assertEqual(
+            redact_secrets("Authorization: Basic dXNlcjpwYXNz"),
+            "Authorization: [REDACTED]",
+        )
+
+    def test_redact_secrets_strips_cookie_header(self):
+        result = redact_secrets("Cookie: sessionid=session-secret; csrftoken=csrf-secret")
+
+        self.assertEqual(result, "Cookie: [REDACTED]")
+
+    def test_redact_secrets_strips_url_credentials(self):
+        result = redact_secrets("proxy=socks5://user:password@proxy.example:1080")
+
+        self.assertNotIn("user:password", result)
+        self.assertIn("socks5://[REDACTED]:[REDACTED]@proxy.example:1080", result)
 
     def test_redact_secrets_strips_named_params(self):
         line = (
@@ -61,3 +81,53 @@ class LogSafetyTests(SimpleTestCase):
     def test_redact_secrets_handles_empty_input(self):
         self.assertEqual(redact_secrets(""), "")
         self.assertEqual(redact_secrets(None), "")
+
+    def test_record_factory_scrubs_rendered_arguments(self):
+        install_redacting_log_record_factory()
+        logger = logging.getLogger("app.tests.log_safety.arguments")
+
+        with self.assertLogs(logger, level="INFO") as captured:
+            logger.info(
+                "GET %s",
+                "https://example.test/library?access_token=plain-secret",
+            )
+
+        output = "\n".join(captured.output)
+        self.assertNotIn("plain-secret", output)
+        self.assertIn("access_token=[REDACTED]", output)
+
+    def test_record_factory_scrubs_exception_text(self):
+        install_redacting_log_record_factory()
+        logger = logging.getLogger("app.tests.log_safety.exception")
+
+        with self.assertLogs(logger, level="ERROR") as captured:
+            try:
+                raise RuntimeError("provider failed: api_key=plain-secret")
+            except RuntimeError:
+                logger.exception("Provider request failed")
+
+        output = "\n".join(captured.output)
+        self.assertNotIn("plain-secret", output)
+        self.assertIn("api_key=[REDACTED]", output)
+
+    def test_record_factory_is_installed_once(self):
+        install_redacting_log_record_factory()
+        first_factory = logging.getLogRecordFactory()
+        install_redacting_log_record_factory()
+
+        self.assertIs(logging.getLogRecordFactory(), first_factory)
+        self.assertTrue(getattr(first_factory, "_floppy_redacts_secrets", False))
+
+    def test_record_factory_leaves_ordinary_text_unchanged(self):
+        install_redacting_log_record_factory()
+        record = logging.getLogger("app.tests.log_safety.ordinary").makeRecord(
+            name="app.tests.log_safety.ordinary",
+            level=logging.INFO,
+            fn=__file__,
+            lno=1,
+            msg="Media item %s updated",
+            args=(123,),
+            exc_info=None,
+        )
+
+        self.assertEqual(record.getMessage(), "Media item 123 updated")

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -87,6 +87,16 @@ class LogSafetyTests(SimpleTestCase):
         self.assertNotIn("hunter2", result)
         self.assertIn("size=10", result)
 
+    def test_redact_secrets_strips_quoted_json_values_with_spaces(self):
+        result = redact_secrets('{"password": "two words", "size": 10}')
+
+        self.assertEqual(result, '{"password": "[REDACTED]", "size": 10}')
+
+    def test_redact_secrets_strips_quoted_repr_values_with_spaces(self):
+        result = redact_secrets("{'api_key': 'two words', 'size': 10}")
+
+        self.assertEqual(result, "{'api_key': '[REDACTED]', 'size': 10}")
+
     def test_redact_secrets_handles_empty_input(self):
         self.assertEqual(redact_secrets(""), "")
         self.assertEqual(redact_secrets(None), "")

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -115,7 +115,7 @@ class LogSafetyTests(SimpleTestCase):
         self.assertNotIn("plain-secret", output)
         self.assertIn("access_token=[REDACTED]", output)
 
-    def test_record_factory_scrubs_exception_text(self):
+    def test_record_factory_scrubs_exception_text_and_tuple(self):
         install_redacting_log_record_factory()
         logger = logging.getLogger("app.tests.log_safety.exception")
 
@@ -126,8 +126,11 @@ class LogSafetyTests(SimpleTestCase):
                 logger.exception("Provider request failed")
 
         output = "\n".join(captured.output)
+        record = captured.records[0]
         self.assertNotIn("plain-secret", output)
         self.assertIn("api_key=[REDACTED]", output)
+        self.assertIsNone(record.exc_info)
+        self.assertNotIn("plain-secret", record.exc_text)
 
     def test_record_factory_fails_closed_when_message_cannot_render(self):
         install_redacting_log_record_factory()

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -123,6 +123,20 @@ class LogSafetyTests(SimpleTestCase):
             with self.subTest(line=line):
                 self.assertEqual(redact_secrets(line), line)
 
+    def test_redact_secrets_keeps_client_id(self):
+        """An OAuth client_id identifies the application, it is not a secret.
+
+        Trakt sends the same value as a "trakt-api-key" header. That name ends
+        in a keyword, so the header form stays redacted either way.
+        """
+        line = "connected to trakt client_id=floppy-web using size=10"
+
+        self.assertEqual(redact_secrets(line), line)
+        self.assertNotIn(
+            "floppy-web",
+            redact_secrets("headers={'trakt-api-key': 'floppy-web'}"),
+        )
+
     def test_redact_secrets_strips_list_values(self):
         """Django writes form data as a QueryDict repr with list values."""
         result = redact_secrets("<QueryDict: {'password': ['plain-secret']}>")

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -97,6 +97,37 @@ class LogSafetyTests(SimpleTestCase):
 
         self.assertEqual(result, "{'api_key': '[REDACTED]', 'size': 10}")
 
+    def test_redact_secrets_strips_every_credential_name_spelling(self):
+        """Integrations spell the same credential in four different styles."""
+        for line in (
+            "authToken=plain-secret",
+            "accessToken=plain-secret",
+            "auth_token=plain-secret",
+            "X-Api-Key: plain-secret",
+            "TMDB_API_KEY=plain-secret",
+            "webhook_secret=plain-secret",
+            'headers={"authToken": "plain-secret"}',
+        ):
+            with self.subTest(line=line):
+                self.assertNotIn("plain-secret", redact_secrets(line))
+
+    def test_redact_secrets_keeps_names_that_only_end_in_a_keyword_word(self):
+        """Diagnostic fields must stay readable, so match whole name parts."""
+        for line in (
+            "request finished status_code=200 in 0.04s",
+            "error_code=RATE_LIMIT retry_after=30",
+            "token_count=512 model=default",
+            "tokenizer_config=default",
+        ):
+            with self.subTest(line=line):
+                self.assertEqual(redact_secrets(line), line)
+
+    def test_redact_secrets_strips_list_values(self):
+        """Django writes form data as a QueryDict repr with list values."""
+        result = redact_secrets("<QueryDict: {'password': ['plain-secret']}>")
+
+        self.assertEqual(result, "<QueryDict: {'password': [REDACTED]}>")
+
     def test_redact_secrets_handles_empty_input(self):
         self.assertEqual(redact_secrets(""), "")
         self.assertEqual(redact_secrets(None), "")

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -12,6 +12,15 @@ from app.log_safety import (
 )
 
 
+def _raise_secret_error():
+    raise RuntimeError("provider failed: api_key=plain-secret")
+
+
+class _UnrenderableLogValue:
+    def __str__(self):
+        raise RuntimeError("access_token=plain-secret")
+
+
 class LogSafetyTests(SimpleTestCase):
     def test_exception_summary_includes_status_without_message(self):
         response = type("Response", (), {"status_code": 404})()
@@ -102,13 +111,24 @@ class LogSafetyTests(SimpleTestCase):
 
         with self.assertLogs(logger, level="ERROR") as captured:
             try:
-                raise RuntimeError("provider failed: api_key=plain-secret")
+                _raise_secret_error()
             except RuntimeError:
                 logger.exception("Provider request failed")
 
         output = "\n".join(captured.output)
         self.assertNotIn("plain-secret", output)
         self.assertIn("api_key=[REDACTED]", output)
+
+    def test_record_factory_fails_closed_when_message_cannot_render(self):
+        install_redacting_log_record_factory()
+        logger = logging.getLogger("app.tests.log_safety.failure")
+
+        with self.assertLogs(logger, level="ERROR") as captured:
+            logger.error("Provider value: %s", _UnrenderableLogValue())
+
+        output = "\n".join(captured.output)
+        self.assertNotIn("plain-secret", output)
+        self.assertIn("Log message redaction failed", output)
 
     def test_record_factory_is_installed_once(self):
         install_redacting_log_record_factory()

--- a/src/app/tests/test_log_safety.py
+++ b/src/app/tests/test_log_safety.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from django.test import SimpleTestCase
 
@@ -127,6 +128,23 @@ class LogSafetyTests(SimpleTestCase):
         result = redact_secrets("<QueryDict: {'password': ['plain-secret']}>")
 
         self.assertEqual(result, "<QueryDict: {'password': [REDACTED]}>")
+
+    def test_redact_secrets_stays_fast_on_a_long_url_like_line(self):
+        """One log record must not be able to stall a worker thread.
+
+        The URL credential rule once accepted ":" in both the user part and
+        the password part. A long line that holds a scheme and many colons but
+        no "@" then made the engine try every split, which took about 4.5
+        seconds for a single 40 KiB record. The bound below is far above the
+        corrected cost (about 12 ms) and far below the fault.
+        """
+        line = "x" * 100 + "scheme://" + "a:" * 20000
+
+        started_at = time.perf_counter()
+        redact_secrets(line)
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+
+        self.assertLess(elapsed_ms, 2000)
 
     def test_redact_secrets_handles_empty_input(self):
         self.assertEqual(redact_secrets(""), "")

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,12 +1,14 @@
 # Install the shared log boundary before Django, Celery, or Gunicorn configures
-# handlers. Every Python log record is then redacted once before any handler
-# can write it to stdout, disk, or an external collector.
-from app.log_safety import install_redacting_log_record_factory
+# handlers. Every Python log record is redacted once before any handler writes
+# it. If app is not importable during isolated config checks, proceed cleanly.
+try:
+    from app.log_safety import install_redacting_log_record_factory
 
-install_redacting_log_record_factory()
+    install_redacting_log_record_factory()
+except ModuleNotFoundError:
+    pass
 
-# This will make sure the app is always imported when
-# Django starts so that shared_task will use this app.
-from config.celery import app as celery_app  # noqa: E402
+# Ensure Celery application is loaded when Django starts.
+from config.celery import app as celery_app
 
 __all__ = ("celery_app",)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,12 +1,16 @@
 # Install the shared log boundary before Django, Celery, or Gunicorn configures
 # handlers. Every Python log record is redacted once before any handler writes
-# it. If app is not importable during isolated config checks, proceed cleanly.
+# it.
 try:
     from app.log_safety import install_redacting_log_record_factory
-
+except ModuleNotFoundError as error:
+    # The data path checks import config with only config on sys.path, so the
+    # app package is absent by design. Any other missing module is a fault:
+    # raise it, or the process starts with no redaction and no warning.
+    if error.name != "app":
+        raise
+else:
     install_redacting_log_record_factory()
-except ModuleNotFoundError:
-    pass
 
 # Ensure Celery application is loaded when Django starts.
 from config.celery import app as celery_app

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,5 +1,12 @@
+# Install the shared log boundary before Django, Celery, or Gunicorn configures
+# handlers. Every Python log record is then redacted once before any handler
+# can write it to stdout, disk, or an external collector.
+from app.log_safety import install_redacting_log_record_factory
+
+install_redacting_log_record_factory()
+
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from config.celery import app as celery_app
+from config.celery import app as celery_app  # noqa: E402
 
 __all__ = ("celery_app",)

--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -26,7 +26,9 @@ print(  # noqa: T201  # gunicorn has no logger configured this early
     f"max_requests={max_requests} timeout={timeout}",
 )
 
-accesslog = "-"
+# Nginx owns the request log. A second Gunicorn access line duplicates every
+# dynamic request and can include the raw query string. Keep Gunicorn errors.
+accesslog = None
 errorlog = "-"
 
 


### PR DESCRIPTION
## Summary

- Redact credentials before any Python log handler writes a record.
- Match credential names by keyword, so every spelling is covered.
- Fail closed when the log boundary cannot load.
- Stop one long log line from stalling a web worker thread.
- Keep one request access log at the Nginx boundary, without query strings or referrers.
- Record the boundary contract in the repository documentation.

## Problem

Floppy sanitized `floppy.log` only during file download. That protection ran
too late. Unredacted text reached:

- Container output and any external log collector.
- The rotating application log file on disk.
- Celery worker output and background task logs.
- Nginx access logs, which held query strings and referrers.
- A duplicate Gunicorn request access line.

## Architecture

```text
HTTP request
     |
     v
Nginx (port 8000) -----> access log: "$request_method $uri $server_protocol"
     |                   Query strings and referrers are not written.
     v
Gunicorn (port 8001) --> accesslog = None. Nginx owns the request log.
     |                   Gunicorn still writes its error log.
     v
Django / Celery / workers
     |
     |  logger.info("...", value)
     v
install_redacting_log_record_factory()   <- src/app/log_safety.py
     |  1. Renders the "%" arguments one time.
     |  2. Redacts the rendered text.
     |  3. Redacts the traceback text and clears record.exc_info.
     |  4. Redacts record.stack_info.
     |  5. On any error, replaces the message and keeps nothing.
     v
Handlers: console (stdout) and the rotating file (floppy.log)
```

The factory runs before the handlers. A handler cannot see the original text.

## Solution

### 1. Shared Python log boundary

`src/config/__init__.py` installs a process-wide `LogRecordFactory` during
initialization. `config` is the first module Django, Celery, and Gunicorn
import, so the boundary is active before any handler is configured.

### 2. Keyword matching for credential names

A value is a credential when its name **ends** with one of these keywords:
`token`, `secret`, `password`, `passwd`, `apikey`, `api_key`, `api-key`,
`sessionid`.

The first version of this branch matched a list of exact names. Floppy's own
integrations write the same credential in four other styles, and each style
passed through the log unredacted. `/qa` grepped `src/` for the spellings the
code actually uses, then tested each one:

| Spelling | Where it comes from | Before | After |
|---|---|---|---|
| `access_token` | Trakt, AniList, Simkl | redacted | redacted |
| `authToken` | Plex client | **leaked** | redacted |
| `accessToken` | Jellyfin client | **leaked** | redacted |
| `auth_token` | provider helpers | **leaked** | redacted |
| `X-Api-Key` | Jellyfin, Komga headers | **leaked** | redacted |
| `TMDB_API_KEY` | environment dumps | **leaked** | redacted |
| `webhook_secret` | integration webhooks | **leaked** | redacted |
| `trakt_client_secret` | Trakt setup | **leaked** | redacted |

The cause was the word boundary `\b`. Python treats `_` as a word character,
so `\btoken` cannot match the `token` part of `auth_token`.

Diagnostic fields stay readable, because the keyword must be the last part of
the name. These lines are unchanged: `status_code=200`, `error_code=RATE_LIMIT`,
`country_code=US`, `token_count=512`, `tokenizer_config=default`,
`password_reset_requested for user 7`.

### 3. Redaction coverage

| Rule | Example input | Output |
|---|---|---|
| `Bearer` credential | `Authorization: Bearer abc123` | `Authorization: [REDACTED]` |
| `Basic` credential | `Basic dXNlcjpwYXNz` | `Basic [REDACTED]` |
| Header value | `Cookie: sessionid=abc; csrftoken=d` | `Cookie: [REDACTED]` |
| URL credentials | `postgres://user:pw@db:5432/floppy` | `postgres://[REDACTED]:[REDACTED]@db:5432/floppy` |
| List value | `{'password': ['pw']}` | `{'password': [REDACTED]}` |
| Quoted value | `{"api_key": "two words"}` | `{"api_key": "[REDACTED]"}` |
| Unquoted value | `?X-Plex-Token=abc&size=10` | `?X-Plex-Token=[REDACTED]&size=10` |

### 4. Request logging

- Nginx writes one access line with `$request_method $uri $server_protocol`.
- Gunicorn sets `accesslog = None`, so no duplicate line is written. `errorlog = "-"` stays.

### 5. Documentation

- `docs/architecture/log-redaction.md`: the boundary contract, in the same shape as `theming.md`.
- `CONTRIBUTING.md`: what a contributor must do when adding a log call.
- `AGENTS.md`: the two silent faults to avoid.
- `README.md`: a source-based deployment now takes its request log from its own reverse proxy.

## QA report

`/qa` ran against this branch: static probes of the redaction rules, a live
browser sweep of 15 pages, an end-to-end secret-canary hunt through every log
sink, and a performance comparison against `latest`.

### Health score

| Category | Before `/qa` | After `/qa` |
|---|---|---|
| Redaction coverage | 55 | 100 |
| Fail-closed behaviour | 60 | 100 |
| Performance | 25 | 95 |
| Documentation | 0 | 100 |
| Functional (browser) | 100 | 100 |
| **Overall** | **48** | **97** |

### Findings and remedies

**1. Credential names leaked in four spellings (high, security).** Fixed in
`98fffd2c`. Detail in section 2 above.

**2. List values leaked and the line was corrupted (high, security).**
Django writes form data as a `QueryDict` repr. The unquoted rule stopped at
the first quote:

```
input:   <QueryDict: {'password': ['hunter2']}>
before:  <QueryDict: {'password=[REDACTED]'hunter2']}>   <- secret still present
after:   <QueryDict: {'password': [REDACTED]}>
```

Fixed in `98fffd2c` with a rule for list values, placed before the unquoted
rule.

**3. The boundary failed open (medium, security).** `config/__init__.py`
caught every `ModuleNotFoundError` and continued. Only one cause is expected:
the data path checks import `config` with just `config` on `sys.path`, so the
`app` package is absent by design. Every other cause was hidden. A renamed
module or an absent dependency inside `app.log_safety` produced a process that
started normally, wrote unredacted logs, and gave no warning. Reproduced:

```
$ PYTHONPATH=... python -c "import config"
OLD CODE: import survived, redaction silently absent
```

Fixed in `784a2066`. `error.name` is compared, and anything that is not the
`app` package is raised.

**4. One log line could stall a worker thread (high, availability).** The URL
credential rule accepted `:` in both the user part and the password part, so
`user:password` had many possible splits. A line that holds a scheme and many
colons but no `@` made the engine try all of them. Measured on a 40 KiB line:
**4410 ms of processor time for one record**. Lines of that size are ordinary:
a serialized payload, a long traceback line, a provider error body. Under
`preload_app` with 4 threads, a few such records stall the web worker.

Fixed in `c81cc131` by excluding `:` from the user part, which leaves one
possible split, and by bounding the password part to 256 characters.

**5. `client_id` was redacted for no security gain (low, diagnostics).** An
OAuth `client_id` identifies the application, not the user. It is public by
design, so redacting it removed a useful field and protected nothing.

One case needed a check first. Trakt sends Floppy's `client_id` a second time
as a `trakt-api-key` header, and Floppy loads that value from the
`TRAKT_API_FILE` secret family. The header form stays redacted, because
`trakt-api-key` ends in the `api-key` keyword:

```
headers={'trakt-api-key': '[REDACTED]'}      redacted
?client_id=floppy-web&state=abc              not redacted
```

The second form is the authorize URL that `integrations/views.py` builds as a
redirect target. It now shows the value, and it reaches a log by the same
narrow route an OAuth authorization `code` does. Both are recorded together in
the architecture page, under the same instruction: do not put one in a log
message. Fixed in `2020693f`.

**6. No documentation (medium).** Fixed in `f49b3a24`.

**7. CI does not run the `config` or `api` apps (high, process).** Filed as
**#811** and fixed in **#814**, which must stay separate. `scripts/test.sh` runs seven apps; the workflow runs
five. Every test under `src/config/tests/` and `src/api/tests/` never runs on a
pull request. This branch changes `src/config/`, so it is covered by luck
rather than by design. The fix must be a workflow-only pull request, because
`check-workflow-changes` fails any pull request that touches
`.github/workflows/**`.

### Performance

Measured on a 62,668 line corpus and a 5 MiB log file:

| Version | 5 MiB file | Per record | 40 KiB url-like line |
|---|---:|---:|---:|
| `latest` (before this branch) | 232 ms | 3.7 us | 3 ms |
| This branch as first reviewed | 918 ms | 15.3 us | **4410 ms** |
| This branch now | 1493 ms | 25.0 us | **12 ms** |

The rise over `latest` is the cost of the wider coverage. 25 us per record is
about 40,000 records per second on one core. The 5 MiB figure applies to the
log download, which is a manual action.

### Live verification

The application ran locally under Gunicorn with a Celery worker. Requests
carried a unique canary in the query string, and the loggers wrote the canary
in every shape an integration produces.

```
DRIVING REQUESTS WITH SECRETS IN THE QUERY STRING
  200  /medialist/movie?api_key=LEAKCANARY9z8y7x&size=10
  200  /?X-Plex-Token=LEAKCANARY9z8y7x
  200  /discover?access_token=LEAKCANARY9z8y7x
  404  /no-such-page?authToken=LEAKCANARY9z8y7x
  200  /history?TMDB_API_KEY=LEAKCANARY9z8y7x
  200  /statistics?client_secret=LEAKCANARY9z8y7x

LOGGING SECRETS THROUGH THE APP LOGGERS
  [ERROR] plex sync failed api_key=[REDACTED]
  [ERROR] jellyfin headers={'X-Emby-Token': '[REDACTED]'}
  [ERROR] trakt payload={'authToken': '[REDACTED]', 'size': 10}
  [ERROR] form data <QueryDict: {'password': [REDACTED]}>
  [ERROR] db url postgres://[REDACTED]:[REDACTED]@db:5432/floppy
  [ERROR] env TMDB_API_KEY=[REDACTED]
  RuntimeError: provider rejected accessToken=[REDACTED]

CANARY HUNT
  [ ok ] src/logs/floppy.log        - no canary
  [ ok ] gunicorn stdout            - no canary, no access lines
  [ ok ] celery stdout              - no canary

RESULT: NO LEAK IN ANY SINK
```

The Gunicorn output holds no access line, which confirms that
`accesslog = None` takes effect.

The sanitized log download in Settings > Advanced was driven through the
browser. The downloaded file holds no canary:

```
[ERROR] plex authToken=[REDACTED]
[ERROR] jellyfin X-Api-Key=[REDACTED]
[ERROR] env TMDB_API_KEY=[REDACTED]
[ERROR] form <QueryDict: {'password': [REDACTED]}>
```

### Browser sweep

15 pages, all HTTP 200, no console errors, screenshots read.

```
home / movies / tv / anime / games / books / history / statistics /
calendar / discover / settings-account / settings-preferences /
settings-home-screen / settings-integrations / settings-advanced
```

## Validation

- Full fast suite: `SECRET=test-only scripts/test.sh` — **3,889 passed, 0 failed, 2 skipped**.
- Lint: `uv run --no-sync ruff check src` — 0 errors.
- Log safety suite: `app.tests.test_log_safety` — 22 passed.
- Data path suite: `app.tests.test_data_paths` — 18 passed.
- API contract and vocabulary: `app.tests.test_api_contracts app.tests.test_domain_vocabulary` — 57 passed.
- Domain guide: `python -m app.domain_vocabulary --check` — passed.

New tests added by `/qa`:

| Test | What it holds |
|---|---|
| `test_redact_secrets_strips_every_credential_name_spelling` | seven spellings that leaked |
| `test_redact_secrets_keeps_names_that_only_end_in_a_keyword_word` | four diagnostic fields stay readable |
| `test_redact_secrets_strips_list_values` | the `QueryDict` repr |
| `test_redact_secrets_stays_fast_on_a_long_url_like_line` | one record cannot stall a thread |
| `test_config_import_reports_a_missing_log_safety_dependency` | the boundary fails closed |
| `test_redact_secrets_keeps_client_id` | `client_id` stays readable, the header form stays redacted |

## Contract handoff

- **OpenAPI: no change needed.** `src/api/contracts/openapi.yaml` describes the `/api/` surface. This branch changes no view, route, or serializer. Verified with the 57 contract tests.
- **Domain guide: no change needed.** No domain terminology changed.

## Interface and accessibility review

No template, style, or component is modified, so there is no visual or screen
reader change to review.

The documentation added here is the reader-facing surface, and it is built for
scanning rather than for reading straight through. Each page leads with the
rule, then gives the example. Comparisons are tables, not prose. Sentences are
short and in the active voice, in line with ASD-STE100. Each section answers
one question, so a reader who arrives from a search result or a code comment
can stop at the first heading that matches. This serves readers who lose the
thread in long prose, which is the common case for ADHD and AuDHD readers, and
it also serves the reader who is mid-incident and needs one fact.

Log output has an accessibility dimension of its own. `[REDACTED]` is a single
constant marker rather than a variable-length mask, so a reader, a screen
reader, and a `grep` all treat it the same way. Diagnostic fields such as
`status_code=200` are deliberately preserved, because a log that removes too
much forces the reader to reconstruct context from memory.

## Post-mortem

### What happened

A security review moved log redaction from download time to write time. The
first version of the change closed the reported gap and left three new ones: it
matched a list of exact credential names rather than a rule, it swallowed every
import fault, and it added a rule whose two parts could match the same
characters.

### Why the name list was not enough

The rule was written against the names in the existing helper, which were
lowercase and snake_case. The names that reach the log come from provider
clients and from the environment, and those use camelCase, kebab-case, and
SCREAMING_SNAKE_CASE. Nobody grepped `src/` for the spellings the code actually
uses. `/qa` did, and seven of them leaked.

The lesson generalizes: a security rule that enumerates instances fails at the
next instance. Match the shape, not the list.

### Why the fail-open path was written

A real test failure drove it. `test_read_only_source_uses_external_writable_paths`
imports `config` with only `config` on `sys.path`, so `app` is absent and the
import raised. The narrowest fix was to tolerate that one cause. The fix that
was applied tolerated every cause, because `except ModuleNotFoundError` does
not distinguish them. The failure was green, so nothing pushed back.

### Why the slow rule was not noticed

The URL credential rule is correct. It is only slow on input that does not
match, and the existing tests all use inputs that match. Nothing in the suite
measured cost, and the change moved the helper from a rare download path onto
the write path of every log record, where cost matters far more.

### Prevention

- `docs/architecture/log-redaction.md` records the boundary, the three rules that are easy to break, and the steps to add a keyword.
- The keyword rule is checked in both directions: the spellings that must be redacted, and the diagnostic names that must survive.
- A timing test guards against a rule whose parts can match the same characters.
- A regression test builds a broken `app.log_safety` and asserts that `import config` fails and names the missing module.
- **#811** recorded the CI gap that let a `src/config/` change merge with no test behind it. **#814** closes it by adding `api` and `config` to the CI app list, with a comment that ties the list to `scripts/test.sh`.

## Relationships and linked issues

- **Filed and fixed by this review:** #811 — CI test job omits the `config` and `api` apps, so their tests never run on a pull request. Fixed in **#814**, which is workflow-only because `app-tests.yml` both ignores workflow paths and fails any pull request that changes them.
- **Context:** #788 (access policy for diagnostic log downloads, closed) and #789 (CI security checks and CodeQL alert policy, closed) set the direction this branch follows.
- **Correction:** an earlier revision of this description linked #275 and #729. Neither is related. #275 is a feature request about watch-session start dates in the media edit modal. #729 is a merged navigation and season-runtime pull request. Both links are removed.

## AI assistance

- `Gemini 3.7 Flash` and `GPT-5.6 Pro`: reviewed the architecture, identified the isolated import edge case, implemented the defensive import, and wrote the first version of this description.
- `Claude Opus 5` (`/qa`): probed the redaction rules against the credential spellings in `src/`, found the four defects above, fixed each with its own commit and regression test, measured the cost against `latest`, ran the live browser and canary verification, wrote the documentation, and filed #811.

