### PR TITLE
🔍 Scan GitHub Actions and simplify CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,79 +1,54 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "release", "latest" ]
+    branches:
+      - latest
+      - release
   pull_request:
-    branches: [ "latest" ]
+    branches:
+      - latest
   schedule:
-    - cron: '22 5 * * 5'
+    - cron: "22 5 * * 5"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
-    name: Analyze
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
-      # required for all workflows
-      security-events: write
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
-
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript', 'python' ]
-        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-        # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language:
+          - actions
+          - javascript-typescript
+          - python
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        config-file: .github/codeql/codeql-config.yml
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
-
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      # These languages do not need a compiled build. CodeQL extracts them
+      # during initialization, so an autobuild step adds no coverage.
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow analysis to the CodeQL matrix.
- Remove unused Swift-specific runner and timeout logic.
- Remove the autobuild step for the interpreted languages in this repository.
- Cancel superseded runs for the same branch or pull request.
- Add manual dispatch and one explicit job timeout.
- Keep the current query filters unchanged so coverage and alert-policy changes remain separate reviews.

## Problem
The CodeQL workflow successfully analyzes Python and JavaScript/TypeScript, but its configuration has several gaps and unnecessary branches:

- workflow files are not analyzed as GitHub Actions code;
- the runner and timeout expressions contain Swift handling, although Swift is not in the matrix;
- `autobuild` adds a step but no extraction coverage for the configured interpreted languages;
- a newer push does not cancel an older run for the same branch;
- maintainers cannot start the workflow manually;
- a green workflow does not show whether the alert inventory is empty or actionable.

The result is more workflow text and runner use than the current language set needs, while an important repository code surface is not scanned.

## Change
### Coverage
The matrix now analyzes:

- `actions`;
- `javascript-typescript`;
- `python`.

This lets CodeQL review workflow triggers, permissions, expressions, and shell steps beside the application code.

### Simpler execution
All matrix jobs now use one Ubuntu runner and one 45-minute timeout. The unused Swift branches are removed.

The workflow runs initialization and analysis directly. These languages do not require a compiled autobuild step.

### Run control
The workflow now supports:

- scheduled scans;
- pushes to `latest` and `release`;
- pull requests to `latest`;
- manual dispatch;
- cancellation of a superseded run for the same ref.

`fail-fast` remains disabled, so one analyzer failure does not hide the result of the other analyzers.

### Alert policy
This PR does not change `.github/codeql/codeql-config.yml`. In particular, it does not broaden or remove the current logging-related query filters. Analyzer coverage and alert-noise policy have different failure modes and need separate evidence.

## Security review scope
The review covered:

- CodeQL triggers, matrix entries, permissions, queries, and recent job behavior;
- workflow source coverage;
- action version maintenance through Dependabot;
- pre-commit secret and dependency checks;
- dependency audit scripts;
- image build and smoke-test workflows;
- the runtime logging paths changed in the companion PR.

The current GitHub connection could not read the private code-scanning alert inventory. This PR therefore does not state a current alert count or dismiss any alert.

## Validation
- [x] The workflow parses as YAML.
- [x] The branch changes only `.github/workflows/codeql.yml`.
- [x] The existing CodeQL configuration file and query filters are preserved.
- [x] CodeQL `actions` analysis passed.
- [x] CodeQL JavaScript/TypeScript analysis passed.
- [x] CodeQL Python analysis passed.
- [x] The existing container build and smoke test passed.

Evidence:

- [CodeQL run 534](https://github.com/dannyvfilms/Floppy/actions/runs/31910728567)
- [Docker Image run 989](https://github.com/dannyvfilms/Floppy/actions/runs/31910728543)

The repository application-test and lint workflows intentionally ignore workflow-only pull requests. The CodeQL matrix is the relevant `/qa` gate for this change.

## Contract Handoff
- Domain guide regeneration/check outcome: Not applicable. No public contract changed.
- Verified OpenAPI regeneration outcome: Not applicable. No API schema changed.
- Contract-test outcome: Not applicable. No API contract changed.

## Accessibility and interface review
There is no visible interface change. Focus order, keyboard behavior, labels, motion, color use, and screen-reader output are unchanged.

### Screenshots
Not applicable. This PR changes a GitHub Actions workflow only.

## Human Review
- [ ] Pending human review.
- [ ] Completed — reviewer/evidence: <!-- link or concise evidence -->

## Gstack QA
- [x] Not applicable to this workflow-only change. The executed workflow runs are the QA evidence.

## Migration Sync Gate
Not applicable. This is not an upstream synchronization PR and it does not change the database schema.

## Post-mortem
### Detection
The review compared the repository code surfaces with the language matrix and then read the workflow for branches that cannot execute with the current matrix.

### Cause
The workflow retained generic multi-language example logic while the repository settled on Python and JavaScript/TypeScript. Workflow analysis and run cancellation were not added when the CI surface grew.

### Why existing checks did not prevent it
The existing analyzers do not inspect GitHub Actions as a language. Dead Swift branches are valid YAML, so they do not fail the workflow. A successful scan therefore confirms that the selected analyzers ran, not that every relevant repository language was selected.

### Prevention
The matrix now names every supported repository language directly. The runner and timeout are fixed because all selected analyzers use the same environment. Superseded work is cancelled automatically.

## Residual risk and follow-up
- CodeQL is not a dependency, secret, or container-image scanner. Existing local checks should be promoted into one small CI security gate rather than adding overlapping scanners.
- The broad logging-query exclusion can hide a future real regression. It needs a separate review with sampled alerts and narrow modeling after the runtime redaction boundary is merged.
- Branch protection must require the useful security checks. Workflow files alone cannot enforce that repository setting.

## AI Assistance
- Model: `GPT-5.6 Pro`.
- The model reviewed the workflow and repository security controls, prepared the change, and wrote the handoff text.

## Notes
- Refs #275 — this security review was requested from that issue context. This PR does not change the media activity/session model and does not close the issue.
- Related #729 — prior CodeQL query-filter correction and alert-policy context.
- Companion implementation: #786.
- Follow-up security gate and alert-policy work: #789.
