### PR TITLE
Handle malformed Cinemeta video entries

### DIFF
--- a/src/integrations/imports/stremio.py
+++ b/src/integrations/imports/stremio.py
@@ -384,11 +384,50 @@ class StremioImporter:
                 logger.warning("Cinemeta video-ids request failed: %s", error)
                 continue
 
+            malformed_meta_count = 0
             for meta in response.get("metasDetailed") or []:
-                if meta and meta.get("id"):
-                    videos_by_id[meta["id"]] = [
-                        video["id"] for video in meta.get("videos") or []
-                    ]
+                if not isinstance(meta, dict):
+                    malformed_meta_count += 1
+                    continue
+
+                meta_id = meta.get("id")
+                if not isinstance(meta_id, str) or not meta_id:
+                    malformed_meta_count += 1
+                    continue
+
+                raw_videos = meta.get("videos")
+                if raw_videos is None:
+                    raw_videos = []
+                elif not isinstance(raw_videos, list):
+                    self.warnings.append(
+                        f"{meta_id}: Cinemeta returned a malformed video list; skipped.",
+                    )
+                    videos_by_id[meta_id] = []
+                    continue
+
+                video_ids = []
+                malformed_video_count = 0
+                for video in raw_videos:
+                    video_id = video if isinstance(video, str) else None
+                    if isinstance(video, dict):
+                        video_id = video.get("id")
+
+                    if isinstance(video_id, str) and video_id:
+                        video_ids.append(video_id)
+                    else:
+                        malformed_video_count += 1
+
+                videos_by_id[meta_id] = video_ids
+                if malformed_video_count:
+                    self.warnings.append(
+                        f"{meta_id}: Cinemeta skipped "
+                        f"{malformed_video_count} malformed video entries.",
+                    )
+
+            if malformed_meta_count:
+                self.warnings.append(
+                    f"Cinemeta skipped {malformed_meta_count} malformed series entries.",
+                )
 
         return videos_by_id
 

--- a/src/integrations/tests/imports/test_stremio.py
+++ b/src/integrations/tests/imports/test_stremio.py
@@ -239,6 +239,82 @@ class ImportStremioTests(TestCase):
         ):
             return stremio.importer(None, self.user, mode)
 
+    def test_cinemeta_skips_malformed_series_entries(self):
+        """Malformed series metadata is summarized without blocking valid data."""
+        importer = stremio.StremioImporter(self.user, "new")
+        response = {
+            "metasDetailed": [
+                None,
+                "private-provider-payload",
+                {"videos": []},
+                {
+                    "id": "tt0903747",
+                    "videos": [{"id": "tt0903747:1:1"}],
+                },
+            ],
+        }
+
+        with patch(
+            "app.providers.services.api_request",
+            return_value=response,
+        ):
+            videos = importer._fetch_cinemeta_videos(["tt0903747"])
+
+        self.assertEqual(videos, {"tt0903747": ["tt0903747:1:1"]})
+        self.assertEqual(
+            importer.warnings,
+            ["Cinemeta skipped 3 malformed series entries."],
+        )
+        self.assertNotIn("private-provider-payload", importer.warnings[0])
+
+    def test_cinemeta_accepts_string_ids_and_skips_malformed_videos(self):
+        """Valid video IDs survive malformed siblings in the same response."""
+        importer = stremio.StremioImporter(self.user, "new")
+        response = {
+            "metasDetailed": [
+                {
+                    "id": "tt0903747",
+                    "videos": [
+                        "tt0903747:1:1",
+                        {"id": "tt0903747:1:2"},
+                        None,
+                        7,
+                        {},
+                        {"id": ""},
+                    ],
+                },
+                {
+                    "id": "tt7366338",
+                    "videos": [{"id": "tt7366338:1:1"}],
+                },
+                {"id": "tt1234567", "videos": "not-a-list"},
+            ],
+        }
+
+        with patch(
+            "app.providers.services.api_request",
+            return_value=response,
+        ):
+            videos = importer._fetch_cinemeta_videos(
+                ["tt0903747", "tt7366338"],
+            )
+
+        self.assertEqual(
+            videos,
+            {
+                "tt0903747": ["tt0903747:1:1", "tt0903747:1:2"],
+                "tt7366338": ["tt7366338:1:1"],
+                "tt1234567": [],
+            },
+        )
+        self.assertEqual(
+            importer.warnings,
+            [
+                "tt0903747: Cinemeta skipped 4 malformed video entries.",
+                "tt1234567: Cinemeta returned a malformed video list; skipped.",
+            ],
+        )
+
     def test_movie_statuses(self):
         """Movies map to completed/in-progress/planning from watch state."""
         library_items = [


### PR DESCRIPTION
## Summary

- Make the Stremio Cinemeta parser tolerate malformed series and video entries.
- Accept both provider-observed string video IDs and the existing object form.
- Preserve valid entries from mixed responses.
- Emit bounded warnings that do not contain raw provider payloads.

## Problem

`_fetch_cinemeta_videos()` assumed that every `metasDetailed` value and every nested video value was an object. Cinemeta can return video IDs as strings. Malformed scalar or null entries can also occur. One unexpected value raised `AttributeError` or `TypeError` and stopped the full Stremio import.

## Solution

Validate the Cinemeta response at the existing parser boundary.

- Skip series entries that are not objects or do not have a usable ID.
- Accept non-empty string video IDs.
- Accept object video entries with a non-empty `id`.
- Skip malformed siblings without discarding valid siblings.
- Report aggregate counts and, when available, the affected IMDb series ID.
- Do not put the raw response value or account data in warnings.

## Security and failure-boundary review

The reviewed boundary is untrusted Cinemeta JSON entering the importer. The required behavior is:

1. One malformed entry must not stop the batch.
2. Valid sibling entries must continue.
3. Warning text must not expose the provider payload.
4. The importer must keep the existing return contract.

Reviewer result: no blocking security, privacy, or data-integrity finding in this change. The parser now handles both reported valid shapes and isolates malformed children. Top-level response-container hardening can remain a separate small follow-up because it is not needed for the reported failures.

## AI Assistance

Generated with OpenAI Codex (`gpt-5.6-sol`, Codex 5.6 SOL). Reviewed against the repository contribution rules and validated with the checks below.

## Validation

Author-reported checks:

- `scripts/test.sh integrations.tests.imports.test_stremio.ImportStremioTests.test_cinemeta_skips_malformed_series_entries integrations.tests.imports.test_stremio.ImportStremioTests.test_cinemeta_accepts_string_ids_and_skips_malformed_videos` — 2 tests passed
- `scripts/test.sh integrations.tests.imports.test_stremio` — 38 tests passed
- `PYTHONPATH=mcp_server scripts/test.sh app.tests.test_api_contracts --parallel 1` — 47 tests passed
- `uv run --no-sync ruff check src` — passed
- `git diff --check upstream/latest...HEAD` — passed

Reviewer verification:

- Inspected every changed line in the importer and its tests.
- Checked malformed series, mixed child values, valid-sibling preservation, warning content, and partial-progress behavior.
- Compared the branch with the current `latest` target on 2026-08-16. The branch is behind by unrelated commits; the current target has not replaced this two-file fix.
- GitHub Actions currently reports `action_required` for App Tests, Lint, Docker Image, and CodeQL. These jobs have not executed and still need maintainer approval or a branch update.

The standard fast suite was also attempted by the author. Its reported `config.tests.test_sqlite_integrity` failures depend on Linux `/proc/self/fd`, and three reported `app.tests.test_data_paths` entrypoint assertions depend on Linux path or ownership behavior. The author reproduced representative failures on untouched `upstream/latest` commit `7c7ff5f3`. No reported failure involved the Stremio importer.

## Contract handoff

- Domain guide regeneration: Not applicable. No domain vocabulary changed.
- OpenAPI regeneration: Not applicable. No API contract changed.
- Contract tests: 47 API contract tests passed in the author-reported run. No contract artifact changed.

## Screenshots and interaction QA

Not applicable. This PR changes backend importer parsing only. It does not change templates, CSS, layout, focus behavior, keyboard behavior, screen-reader output, visual grouping, or cognitive load.

## Human review

- [x] Completed on 2026-08-16.
- [x] No blocking finding.
- [ ] Reconfirm after the branch is updated with current `latest` and GitHub Actions execute.

## `/qa`

- [x] Static boundary and regression-test review completed.
- [x] Warning privacy and failure-isolation review completed.
- [x] Current-target compatibility reviewed.
- [ ] GitHub Actions execution pending maintainer approval or branch update.

## Post-mortem

**Trigger:** Cinemeta returned valid video IDs as strings and could include malformed scalar or null entries.

**Failure:** The importer treated each entry as an object. A single unexpected value stopped the full import.

**Impact:** A user could not finish a Stremio import even when the remaining provider data was valid.

**Why the defect escaped:** Existing parsing and tests represented only the object form of the provider response.

**Prevention in this PR:** Validate at the provider boundary, keep valid siblings, use bounded warnings, and add mixed-shape regression tests.

## Relationships

- Fixes #599.
- Fixes #802.
- Fixes #680 for the Cinemeta parser failure described by that issue.
- Refs #813 for the separate first-run `related_tv` bulk-create failure reported later in #680.
