### PR TITLE
Show watched status for episode history

### DIFF
--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -621,34 +621,33 @@ class AppTagsTests(TestCase):
         request = self.request_factory.get("/history")
         request.user = self.user
 
+        context = {
+            "entry": SimpleNamespace(
+                media_type=MediaTypes.EPISODE.value,
+                album=None,
+                item=item,
+                poster=item.image,
+                status=None,
+                runtime_display=None,
+                display_title=item.title,
+                title=item.title,
+                played_at_local=timezone.now(),
+                time_range_display="6:00 PM",
+                play_count=1,
+                progress_display=None,
+                episode_label="S1E2",
+                episode_code="S1E2",
+                show=None,
+                score=8,
+                entry_key="episode-entry-1",
+                instance_id=7,
+            ),
+            "card_class": "search-result-card",
+            "history_mode": "activity",
+            "user": self.user,
+        }
         content = render_to_string(
-            "app/components/history_card.html",
-            {
-                "entry": SimpleNamespace(
-                    media_type=MediaTypes.EPISODE.value,
-                    album=None,
-                    item=item,
-                    poster=item.image,
-                    status=None,
-                    runtime_display=None,
-                    display_title=item.title,
-                    title=item.title,
-                    played_at_local=timezone.now(),
-                    time_range_display="6:00 PM",
-                    play_count=1,
-                    progress_display=None,
-                    episode_label="S1E2",
-                    episode_code="S1E2",
-                    show=None,
-                    score=8,
-                    entry_key="episode-entry-1",
-                    instance_id=7,
-                ),
-                "card_class": "search-result-card",
-                "history_mode": "activity",
-                "user": self.user,
-            },
-            request=request,
+            "app/components/history_card.html", context, request=request
         )
 
         expected_track_url = reverse(
@@ -665,7 +664,16 @@ class AppTagsTests(TestCase):
         self.assertIn('"standard_modal": "1"', content)
         self.assertNotIn('hx-get="/history_modal/', content)
         self.assertIn("media-status-chip", content)
-        self.assertIn('d="M21.801 10A10 10 0 1 1 17 3.335"', content)
+        self.assertIn("Status: Completed", content)
+        self.assertIn('aria-hidden="true"', content)
+
+        release_content = render_to_string(
+            "app/components/history_card.html",
+            {**context, "history_mode": "release"},
+            request=request,
+        )
+        self.assertNotIn("media-status-chip", release_content)
+        self.assertNotIn("Status: Completed", release_content)
 
     def test_history_card_teleports_alt_title_tooltip(self):
         """History cards should teleport alternate-title tooltips outside the clipped shell."""

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -607,8 +607,8 @@ class AppTagsTests(TestCase):
             content,
         )
 
-    def test_history_card_episode_edit_uses_track_modal(self):
-        """Episode history cards should open the track modal so ratings can be edited."""
+    def test_history_card_episode_shows_watched_status_and_uses_track_modal(self):
+        """Episode history cards show watched status and open the track modal."""
         item = Item.objects.create(
             media_id="episode-history-1",
             source=Sources.TMDB.value,
@@ -664,6 +664,8 @@ class AppTagsTests(TestCase):
         self.assertIn('"instance_id": "7"', content)
         self.assertIn('"standard_modal": "1"', content)
         self.assertNotIn('hx-get="/history_modal/', content)
+        self.assertIn("media-status-chip", content)
+        self.assertIn('d="M21.801 10A10 10 0 1 1 17 3.335"', content)
 
     def test_history_card_teleports_alt_title_tooltip(self):
         """History cards should teleport alternate-title tooltips outside the clipped shell."""

--- a/src/templates/app/components/history_card.html
+++ b/src/templates/app/components/history_card.html
@@ -19,10 +19,11 @@
     {% endwith %}
 
     {# Status chip (top-left) #}
-    {% if entry.status %}
-      <div class="media-status-chip absolute top-2 left-2 bg-gray-900/90 text-white text-xs px-2 py-1 rounded-md flex items-center gap-1.5 shadow-md">
-        {% with status_value=entry.status %}
-          <div class="w-4 h-4 {{ status_value|status_color }}">
+    {% if entry.status or entry.media_type == MediaTypes.EPISODE.value and history_mode != "release" %}
+      {% with status_value=entry.status|default:"Completed" %}
+        <div class="media-status-chip absolute top-2 left-2 bg-gray-900/90 text-white text-xs px-2 py-1 rounded-md flex items-center gap-1.5 shadow-md">
+          <span class="sr-only">Status: {{ status_value }}</span>
+          <div class="w-4 h-4 {{ status_value|status_color }}" aria-hidden="true">
             {% if status_value == "Completed" %}
               {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
             {% elif status_value == "In progress" %}
@@ -35,16 +36,8 @@
               {% include "app/icons/states/dropped.svg" with classes="w-full h-full" %}
             {% endif %}
           </div>
-        {% endwith %}
-      </div>
-    {% elif entry.media_type == MediaTypes.EPISODE.value and history_mode != "release" %}
-      <div class="media-status-chip absolute top-2 left-2 bg-gray-900/90 text-white text-xs px-2 py-1 rounded-md flex items-center gap-1.5 shadow-md">
-        {% with status_value="Completed" %}
-          <div class="w-4 h-4 {{ status_value|status_color }}">
-            {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
-          </div>
-        {% endwith %}
-      </div>
+        </div>
+      {% endwith %}
     {% endif %}
 
     {# Runtime chip (top-right) #}

--- a/src/templates/app/components/history_card.html
+++ b/src/templates/app/components/history_card.html
@@ -37,6 +37,14 @@
           </div>
         {% endwith %}
       </div>
+    {% elif entry.media_type == MediaTypes.EPISODE.value and history_mode != "release" %}
+      <div class="media-status-chip absolute top-2 left-2 bg-gray-900/90 text-white text-xs px-2 py-1 rounded-md flex items-center gap-1.5 shadow-md">
+        {% with status_value="Completed" %}
+          <div class="w-4 h-4 {{ status_value|status_color }}">
+            {% include "app/icons/states/completed.svg" with classes="w-full h-full" %}
+          </div>
+        {% endwith %}
+      </div>
     {% endif %}
 
     {# Runtime chip (top-right) #}


### PR DESCRIPTION
## Summary
- Show the completed status tick on watched episode cards in activity history.
- Use the existing status-chip path for explicit statuses and the episode fallback.
- Expose the status to assistive technology while keeping the icon decorative.
- Add regression coverage for activity and release-history rendering.

## Problem
Episode history entries are built from completed plays but do not carry a `status` value, so their cards omitted the watched tick shown for other completed media. The initial patch also represented that state only through an icon and color.

## Solution
Render one status-chip path for either an explicit `entry.status` or an episode in non-release history, using `Completed` as the episode fallback. The chip includes `Status: Completed` screen-reader text and marks its icon wrapper `aria-hidden="true"`. Release-history cards remain unchanged.

## AI Assistance
Generated with OpenAI Codex (`gpt-5.6-sol`, Codex 5.6 SOL).

## Validation
- `scripts/test.sh app.tests.test_templatetags.AppTagsTests.test_history_card_episode_shows_watched_status_and_uses_track_modal` — passed (1 test).
- `scripts/test.sh app.tests.test_templatetags` — passed (45 tests).
- `uv run --no-sync ruff check src` — passed.
- `uv run --no-sync ruff format --check src/app/tests/test_templatetags.py` — passed.
- `npx @tailwindcss/cli -i ./src/static/css/input.css -o ./src/static/css/main.css` — passed; no generated CSS diff.
- `git diff --check` — passed.
- Browser QA with the same disposable episode/movie data at 1280×720 and 390×844 — both cards rendered correctly, the watched episode exposed `Status: Completed`, both icon wrappers were accessibility-hidden, and neither viewport had horizontal overflow.
- Negative regression coverage confirms release history does not render the episode watched-state chip.

## Contract Handoff
- Domain guide regeneration/check outcome: Not applicable; no domain vocabulary changes.
- Verified OpenAPI regeneration outcome: Not applicable; no API changes.
- Contract-test outcome: Not applicable; no contract changes.

## Screenshots

### Before
![Before: watched episode has no completed tick](https://raw.githubusercontent.com/srow90/Floppy/a050d5d3308f52385a50de71d4bca48db13d827b/issue-573-before.jpg)

### After
![After: watched episode has the completed tick](https://raw.githubusercontent.com/srow90/Floppy/a050d5d3308f52385a50de71d4bca48db13d827b/issue-573-after.jpg)

## Human Review
- [x] Pending human re-review after addressing the requested changes at `be3d9ffc`.
- [ ] Completed — reviewer/evidence:

## Gstack QA
- [x] Pending `/gstack-qa`.
- [ ] Completed — report/outcome:

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
Not applicable; this is not an upstream sync PR and contains no migrations.

## Notes
- Fixes #573.
- `djlint --check src/templates/app/components/history_card.html` also fails on untouched `latest` because it proposes a broad pre-existing reformat of this legacy template. That unrelated churn is intentionally excluded from this focused fix.
