### PR TITLE
🚫 Stop publishing container images from pull requests

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -219,19 +219,13 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/latest' }}
             type=raw,value=release,enable=${{ github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/tags/v') }}
 
-      # Determine if we should push the image
-      - name: Set push flag
-        id: push-flag
-        run: |
-          if [[ "${{ github.event_name }}" != "pull_request" || "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
-            echo "PUSH=true" >> $GITHUB_OUTPUT
-          else
-            echo "PUSH=false" >> $GITHUB_OUTPUT
-          fi
-
-      # Only log in if we're going to push
+      # Pull requests build both architectures to prove the image still
+      # cross-compiles, but they must never write to the registry. A pr-N tag
+      # has no consumer and lands in the same public package users pull from,
+      # where nothing distinguishes it from a release. Publishing happens on
+      # push to latest/release and on v* tags only.
       - name: Log into registry ${{ env.REGISTRY }}
-        if: steps.push-flag.outputs.PUSH == 'true'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -246,7 +240,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: ${{ steps.push-flag.outputs.PUSH }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/dry-image-cleanup.yml
+++ b/.github/workflows/dry-image-cleanup.yml
@@ -16,3 +16,12 @@ jobs:
           delete-ghost-images: true
           delete-orphaned-images: true
           validate: true
+
+      # Mirrors the pr-* purge in image-cleanup.yml. Run this first and read
+      # the log before running the real one.
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: floppy,yamtrack
+          dry-run: true
+          delete-tags: pr-*
+          validate: true

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -15,3 +15,14 @@ jobs:
           delete-ghost-images: true
           delete-orphaned-images: true
           validate: true
+
+      # PR builds no longer publish, but pr-N tags pushed before that fix are
+      # still sitting in both packages: keep-n-untagged only prunes untagged
+      # manifests, so nothing ever collected them. Scoped to the pr-* glob, so
+      # latest/release/vX.Y.Z are untouched. Runs on the legacy package too,
+      # which the untagged rules above deliberately still skip.
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: floppy,yamtrack
+          delete-tags: pr-*
+          validate: true


### PR DESCRIPTION
## Summary

Fixes #782.

Every same-repo PR commit was pushing `pr-N` to **both** `ghcr.io/dannyvfilms/floppy` and the legacy `ghcr.io/dannyvfilms/yamtrack`. Nothing consumes those tags — they appear in no doc, compose file, or script — yet they land in the same public package users pull from, with nothing marking them as unmerged code.

**The `latest` tag was never actually moved by a PR.** Its `enable=` guard is correct: `github.ref` is `refs/pull/N/merge` on a PR event, so `type=raw,value=latest` never fired. Evidence from run [31911674099](https://github.com/dannyvfilms/Floppy/actions/runs/31911674099):

```
DOCKER_METADATA_OUTPUT_TAG_NAMES: pr-786
```

What made it *look* like `latest` was rebuilding is the package's "last published" timestamp bumping on every PR, on a `floppy` package new enough that its version list is mostly `pr-N` entries.

The actual cause was three lines conspiring — the `pull_request` trigger, `type=ref,event=pr`, and a push flag whose `|| head.repo == repository` clause made same-repo PRs publish:

```
Set push flag   if [[ "pull_request" != "pull_request" || "dannyvfilms/Floppy" == "dannyvfilms/Floppy" ]]
Log into registry   Login Succeeded!
Build and push      push: true
```

### What changed

Behavior delta is exactly one cell:

| Event | Before | After |
|---|---|---|
| push to `latest`/`release`, `v*` tag | push | push |
| `workflow_dispatch` (incl. `bootstrap_ghcr`) | push | push |
| fork PR | no push | no push |
| **same-repo PR** | **push** | **no push** |

PRs still build `linux/amd64,linux/arm64`, so a broken arm64 cross-compile is still caught before merge — they just no longer authenticate to or write to the registry. The `Set push flag` step is deleted outright; `github.event_name != 'pull_request'` says the same thing inline on the two steps that care.

`keep-n-untagged` only collects *untagged* manifests, so the `pr-N` tags already published were never going to expire and no PR-close hook exists. Both cleanup workflows gain a `pr-*` purge covering the legacy package too, scoped by glob so `latest`/`release`/`vX.Y.Z` cannot match. **Run the dry workflow first and read the log.**

Deliberately *not* included: pointing the existing `keep-n-untagged`/`delete-ghost-images` rules at `yamtrack`. That package has years of untouched history and those rules have a wide blast radius — separate decision, separate dry run.

## AI Assistance

`claude-opus-5` investigated the root cause and wrote the change.

## Validation

- `actionlint .github/workflows/docker-image.yml image-cleanup.yml dry-image-cleanup.yml` → clean
- `python3 -c "yaml.safe_load(...)"` on all three → OK
- `grep -rn "push-flag\|PUSH=" .github/workflows/` → no residual references
- `delete-tags` glob support and `packages` list syntax confirmed against the [dataaxiom/ghcr-cleanup-action](https://github.com/dataaxiom/ghcr-cleanup-action) README

**Not yet verified at runtime** — a CI change only proves itself by running. Please confirm on this PR:

1. `Build and push Docker image` logs `push: false`
2. `Log into registry` shows as skipped
3. `build` still runs both `linux/amd64` and `linux/arm64` stages
4. after merge, the push run on `latest` still logs `push: true` and tags `:latest`

## Contract Handoff
- Domain guide regeneration/check outcome: not applicable — no application code changed
- Verified OpenAPI regeneration outcome: not applicable
- Contract-test outcome: not applicable

## Human Review
- [x] Pending human review.

## Gstack QA
- [x] Completed — swept 15 pages on this branch, health 99/100, 0 issues attributable to the change (the diff touches no templates/JS/CSS). Found one pre-existing Low content bug unrelated to this PR: `/settings/preferences` renders "Unsaved changes" unconditionally at `src/templates/users/preferences.html:1200`. Filing separately.

## Notes

⚠️ **`check-workflow-changes` will go red on this PR by policy** — `app-tests.yml` fails any PR touching `.github/workflows/**`, deliberately, so CI changes cannot ride along with code. That is why this branch is workflow-only and carries no other edits. A red `check-workflow-changes` with green tests means the guard fired and nothing worse.

Refs #782.

One open question for the maintainer: if anyone has been pulling `pr-N` to test PRs locally, this removes that. The replacement is `gh pr checkout N && docker compose up --build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
