### PR TITLE
Store webhook playback positions in PlaybackProgress

### DIFF
--- a/src/api/fork_views_playback.py
+++ b/src/api/fork_views_playback.py
@@ -446,8 +446,9 @@ class PlaybackProgressView(drf_views.APIView):
 
     Complements /api/v1/scrobble/, which can push playback progress in but
     can't read saved positions back out. Positions here are written by API
-    clients and by scrobble 'stop'; Plex/Jellyfin/Emby webhook playback is
-    not mirrored into this store.
+    clients, by scrobble 'stop', and by media-server webhooks reporting a
+    position (Plex pause/resume/stop/scrobble, Jellyfin pause/stop,
+    Emby stop).
     """
 
     @extend_schema(

--- a/src/app/live_playback.py
+++ b/src/app/live_playback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
@@ -12,7 +13,7 @@ from django.utils.text import slugify
 
 from app import helpers
 from app.metadata_utils import ANIME_SUPPLEMENT_GENRE, genre_list_has_name
-from app.models import Item, MediaTypes, Sources
+from app.models import Item, MediaTypes, PlaybackProgress, Sources
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,25 @@ PLAYBACK_STOP_GRACE_SECONDS = 60
 PLAYBACK_STATUS_PLAYING = "playing"
 PLAYBACK_STATUS_PAUSED = "paused"
 PLAYBACK_STATUS_STOPPED = "stopped"
+
+# Events that carry a meaningful resume position. "media.play" is excluded:
+# it starts a title rather than reporting where the viewer is, and Plex
+# sends it with the offset still at 0, which would overwrite a good stored
+# position with a useless one.  "media.resume" is included because that is
+# how Plex reports a seek — its offset is where the viewer jumped to.
+# Not every source emits all of these (Jellyfin has no scrobble or resume,
+# Emby only start/stop).
+PLAYBACK_PROGRESS_EVENTS = (
+    "media.pause",
+    "media.resume",
+    "media.stop",
+    "media.scrobble",
+)
+# How close to the end a stop must be to keep an existing completion mark.
+# Matches the default watched threshold of the media servers (~90%); a
+# server configured to scrobble earlier than this simply keeps the mark
+# for a shorter stretch of the title.
+PLAYBACK_COMPLETION_TAIL_RATIO = 0.1
 
 IMAGE_RESOLVE_GUARD_PREFIX = "playback_img_fill"
 IMAGE_RESOLVE_GUARD_SECONDS = 60
@@ -124,6 +144,142 @@ def _state_matches(
     return False
 
 
+def _identifiers_from_state(
+    state: dict | None,
+    *,
+    rating_key: str | None,
+    media_id: str | None,
+    season_number: int | None,
+    episode_number: int | None,
+) -> tuple[str | None, int | None, int | None]:
+    """Fill in identifiers a pause/stop event does not carry itself.
+
+    Plex only resolves the show id on play/resume/scrobble, so pause and
+    stop arrive without one.  The cached state of the same playback still
+    has it — but it is only safe to reuse when the rating key proves both
+    events refer to the same item.
+    """
+    if media_id is not None or not rating_key or not state:
+        return media_id, season_number, episode_number
+
+    if str(state.get("rating_key") or "") != str(rating_key):
+        return media_id, season_number, episode_number
+
+    return (
+        state.get("media_id"),
+        season_number if season_number is not None else state.get("season_number"),
+        episode_number if episode_number is not None else state.get("episode_number"),
+    )
+
+
+def _keeps_completion(user, item, position_seconds, duration_seconds) -> bool:
+    """Return whether a stop should keep an existing completion mark.
+
+    Plex scrobbles at its own completion threshold and then sends a stop
+    when playback ends.  That trailing stop must not undo the mark, but a
+    later rewatch has to be able to clear it — so the mark is only kept
+    while the reported position is still near the end of the title.
+    """
+    if not duration_seconds or position_seconds < duration_seconds * (
+        1 - PLAYBACK_COMPLETION_TAIL_RATIO
+    ):
+        return False
+
+    return PlaybackProgress.objects.filter(
+        user=user,
+        item=item,
+        completed=True,
+    ).exists()
+
+
+def _store_playback_progress(
+    user_id: int,
+    *,
+    event_type: str,
+    playback_media_type: str | None,
+    media_id: str | None,
+    source: str,
+    season_number: int | None,
+    episode_number: int | None,
+    view_offset_seconds: int | None,
+    duration_seconds: int | None,
+) -> None:
+    """Mirror a webhook playback position into the durable progress store.
+
+    Built from the event's own fields rather than the cached card state, so
+    a position is still stored when the cache is cold, expired, or holds a
+    different title.  Identifiers a pause/stop event omits are recovered by
+    the caller via ``_identifiers_from_state``.
+
+    Failures are logged, never raised: a webhook must not fail because the
+    resume position could not be written.
+    """
+    if event_type not in PLAYBACK_PROGRESS_EVENTS:
+        return
+
+    # A scrobble is the media server's completion mark. Plex sends it
+    # without a view offset, so it must still land — as a completion,
+    # leaving whatever position is already stored untouched.
+    completion_only = event_type == "media.scrobble" and view_offset_seconds is None
+
+    # Guard before any coercion: an event without an offset carries no
+    # position, and writing 0 would destroy a good stored one.
+    if view_offset_seconds is None and not completion_only:
+        return
+
+    try:
+        item = _resolve_state_item(
+            {
+                "media_id": media_id,
+                "source": source,
+                "media_type": playback_media_type,
+                "season_number": season_number,
+                "episode_number": episode_number,
+            },
+        )
+        # _resolve_state_item falls back to the show/season row when the
+        # episode isn't known yet; a resume position belongs to the episode
+        # itself, so anything but an exact movie/episode match is dropped.
+        if item is None or item.media_type != playback_media_type:
+            return
+
+        from api.fork_views_playback import upsert_playback_progress
+
+        user = get_user_model().objects.get(pk=user_id)
+        duration = _coerce_int(duration_seconds) or None
+
+        if completion_only:
+            stored = PlaybackProgress.objects.filter(user=user, item=item).first()
+            upsert_playback_progress(
+                user,
+                item,
+                stored.position_seconds if stored else 0,
+                (stored.duration_seconds if stored else None) or duration,
+                completed=True,
+            )
+            return
+
+        position = max(0, view_offset_seconds)
+        if duration is None:
+            duration = (
+                PlaybackProgress.objects.filter(user=user, item=item)
+                .values_list("duration_seconds", flat=True)
+                .first()
+            )
+        upsert_playback_progress(
+            user,
+            item,
+            position,
+            max(0, duration) if duration else None,
+            # A completion mark is a statement about the whole title, so it
+            # must survive the media.stop Plex sends straight afterwards.
+            completed=event_type == "media.scrobble"
+            or _keeps_completion(user, item, position, duration),
+        )
+    except Exception:
+        logger.warning("Webhook playback-progress update failed", exc_info=True)
+
+
 def apply_playback_event(
     *,
     user_id: int,
@@ -139,12 +295,18 @@ def apply_playback_event(
     episode_number: int | None = None,
     view_offset_seconds: int | None = None,
     duration_seconds: int | None = None,
+    store_progress: bool = False,
 ) -> None:
     """Update live playback cache state from a webhook event.
 
     All fields are pre-extracted by the caller (Plex / Jellyfin
     processor) so this function is source-agnostic.  Event types
     use the normalised ``media.*`` naming regardless of origin.
+
+    ``store_progress`` additionally mirrors the position into
+    ``PlaybackProgress`` so it survives the cache and is readable via
+    ``/api/v1/playback/progress/``.  The media-server webhooks opt in;
+    the scrobble API does not, because it writes that store itself.
     """
     if playback_media_type not in (
         MediaTypes.MOVIE.value,
@@ -155,6 +317,9 @@ def apply_playback_event(
     if not event_type:
         return
 
+    # Kept for the progress store: the card treats resume like play, but a
+    # resume is how Plex reports a seek, so its offset is a real position.
+    source_event_type = event_type
     if event_type == "media.resume":
         event_type = "media.play"
 
@@ -187,6 +352,27 @@ def apply_playback_event(
             existing_state["status"] = PLAYBACK_STATUS_STOPPED
             existing_state["stop_expires_at_ts"] = now_ts + PLAYBACK_STOP_GRACE_SECONDS
             set_user_playback_state(user_id, existing_state)
+        # Outside the cache branch on purpose: the stop event carries its own
+        # position, so it must be stored even when no card state matched.
+        if store_progress:
+            stop_media_id, stop_season, stop_episode = _identifiers_from_state(
+                existing_state,
+                rating_key=rating_key,
+                media_id=media_id,
+                season_number=season_number,
+                episode_number=episode_number,
+            )
+            _store_playback_progress(
+                user_id,
+                event_type=event_type,
+                playback_media_type=playback_media_type,
+                media_id=stop_media_id,
+                source=source,
+                season_number=stop_season,
+                episode_number=stop_episode,
+                view_offset_seconds=view_offset_seconds,
+                duration_seconds=duration_seconds,
+            )
         return
 
     if event_type not in ("media.play", "media.pause", "media.scrobble"):
@@ -285,6 +471,28 @@ def apply_playback_event(
 
     set_user_playback_state(user_id, state)
 
+    if store_progress:
+        store_media_id, store_season, store_episode = _identifiers_from_state(
+            existing_state,
+            rating_key=rating_key,
+            media_id=media_id,
+            season_number=season_number,
+            episode_number=episode_number,
+        )
+        # The event's own offset, not the cache-backfilled one: a play that
+        # reports no position must not be stored as a position of zero.
+        _store_playback_progress(
+            user_id,
+            event_type=source_event_type,
+            playback_media_type=playback_media_type,
+            media_id=store_media_id,
+            source=source,
+            season_number=store_season,
+            episode_number=store_episode,
+            view_offset_seconds=view_offset_seconds,
+            duration_seconds=duration_seconds,
+        )
+
 
 def apply_plex_event(
     *,
@@ -326,6 +534,7 @@ def apply_plex_event(
         ),
         view_offset_seconds=_extract_offset_seconds(payload),
         duration_seconds=_extract_duration_seconds(payload),
+        store_progress=True,
     )
 
 

--- a/src/integrations/tests/test_webhook_async.py
+++ b/src/integrations/tests/test_webhook_async.py
@@ -6,16 +6,23 @@ never block a web worker.
 """
 
 import json
+from datetime import timedelta
 from unittest.mock import call, patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import Client, SimpleTestCase, TestCase
 from django.urls import reverse
+from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
+from app import live_playback
+from app.models import Item, MediaTypes, PlaybackProgress, Sources
 from integrations import tasks
 from integrations.models import JellyfinAccount, PlexAccount, PlexWebhookShare
+from integrations.webhooks.jellyfin import JellyfinWebhookProcessor
+from integrations.webhooks.plex import PlexWebhookProcessor
 
 
 class WebhookViewEnqueueTests(TestCase):
@@ -308,6 +315,388 @@ class ProcessWebhookTaskTests(TestCase):
         tasks.process_webhook("jellyfin", {"Event": "Stop"}, self.user.id)
 
         mock_push_delay.assert_not_called()
+
+
+class WebhookPlaybackProgressTests(TestCase):
+    """Webhook playback events persist a durable resume position.
+
+    Exercised through app.live_playback.apply_playback_event, which the
+    Plex, Jellyfin and Emby processors all delegate to.
+    """
+
+    def setUp(self):
+        """Create a user and the items webhook events resolve to."""
+        cache.clear()
+        self.user = get_user_model().objects.create_user(
+            username="playbackuser",
+            password="12345",
+        )
+        self.movie_item = Item.objects.create(
+            media_id="701",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="The Matrix",
+        )
+        self.episode_item = Item.objects.create(
+            media_id="103516",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Episode Four",
+            season_number=4,
+            episode_number=4,
+        )
+
+    def _apply(self, event_type, **overrides):
+        kwargs = {
+            "user_id": self.user.id,
+            "event_type": event_type,
+            "playback_media_type": MediaTypes.MOVIE.value,
+            "media_id": "701",
+            "source": Sources.TMDB.value,
+            "rating_key": "rk-1",
+            "title": "The Matrix",
+            "view_offset_seconds": 1380,
+            "duration_seconds": 8160,
+            "store_progress": True,
+        }
+        kwargs.update(overrides)
+        live_playback.apply_playback_event(**kwargs)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_pause_stores_position(self, _mock_image):
+        """A pause part-way through a movie is written to the store."""
+        self._apply("media.pause")
+
+        progress = PlaybackProgress.objects.get(
+            user=self.user,
+            item=self.movie_item,
+        )
+        self.assertEqual(progress.position_seconds, 1380)
+        self.assertEqual(progress.duration_seconds, 8160)
+        self.assertFalse(progress.completed)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_stores_episode_position(self, _mock_image):
+        """Stopping an episode records its own position, not the show's."""
+        self._apply(
+            "media.play",
+            playback_media_type=MediaTypes.EPISODE.value,
+            media_id="103516",
+            season_number=4,
+            episode_number=4,
+            view_offset_seconds=60,
+        )
+        self._apply(
+            "media.stop",
+            playback_media_type=MediaTypes.EPISODE.value,
+            media_id="103516",
+            season_number=4,
+            episode_number=4,
+            view_offset_seconds=1500,
+        )
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.item, self.episode_item)
+        self.assertEqual(progress.position_seconds, 1500)
+        self.assertFalse(progress.completed)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_scrobble_marks_completed(self, _mock_image):
+        """The media server's own completion mark sets completed."""
+        self._apply("media.scrobble", view_offset_seconds=8000)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 8000)
+        self.assertTrue(progress.completed)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_play_does_not_store_position(self, _mock_image):
+        """Play events are ignored: their offset is usually a reset to 0."""
+        self._apply("media.play", view_offset_seconds=0)
+
+        self.assertFalse(PlaybackProgress.objects.exists())
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_resume_after_seek_stores_new_position(self, _mock_image):
+        """Plex reports a seek as a resume carrying the new offset."""
+        self._apply("media.pause", view_offset_seconds=600)
+        self._apply("media.resume", view_offset_seconds=4800)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 4800)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_resume_without_offset_keeps_stored_position(self, _mock_image):
+        """A resume that reports no position must not zero the stored one."""
+        self._apply("media.pause", view_offset_seconds=600)
+        cache.clear()
+        self._apply("media.resume", view_offset_seconds=None)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 600)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_position_is_updated_not_duplicated(self, _mock_image):
+        """Repeated pauses overwrite the single row for that item."""
+        self._apply("media.pause", view_offset_seconds=600)
+        self._apply("media.pause", view_offset_seconds=1800)
+
+        self.assertEqual(PlaybackProgress.objects.count(), 1)
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 1800)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_unknown_item_is_skipped(self, _mock_image):
+        """An event for media that isn't in the library writes nothing."""
+        self._apply("media.pause", media_id="999999")
+
+        self.assertFalse(PlaybackProgress.objects.exists())
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_episode_without_episode_item_is_skipped(self, _mock_image):
+        """A show-level fallback match must not be stored as a position."""
+        Item.objects.create(
+            media_id="555",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Unwatched Show",
+        )
+
+        self._apply(
+            "media.pause",
+            playback_media_type=MediaTypes.EPISODE.value,
+            media_id="555",
+            season_number=1,
+            episode_number=1,
+        )
+
+        self.assertFalse(PlaybackProgress.objects.exists())
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_scrobble_api_path_does_not_double_write(self, _mock_image):
+        """Without store_progress the cache is updated but nothing persisted."""
+        self._apply("media.pause", store_progress=False)
+
+        self.assertFalse(PlaybackProgress.objects.exists())
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_write_failure_does_not_break_the_webhook(self, _mock_image):
+        """A failing progress write is swallowed; the cache still updates."""
+        with patch(
+            "api.fork_views_playback.upsert_playback_progress",
+            side_effect=OSError("db gone"),
+        ):
+            self._apply("media.pause")
+
+        self.assertFalse(PlaybackProgress.objects.exists())
+        self.assertIsNotNone(live_playback.get_user_playback_state(self.user.id))
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_after_scrobble_keeps_completed(self, _mock_image):
+        """Plex sends stop right after scrobble; that must not un-complete."""
+        self._apply("media.scrobble", view_offset_seconds=8100)
+        self._apply("media.stop", view_offset_seconds=8160)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertTrue(progress.completed)
+        self.assertEqual(progress.position_seconds, 8160)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_stores_position_with_cold_cache(self, _mock_image):
+        """A stop must persist even when no card state is cached."""
+        cache.clear()
+
+        self._apply("media.stop", view_offset_seconds=2400)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 2400)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_event_without_offset_keeps_stored_position(self, _mock_image):
+        """A missing offset means "no position", not position zero."""
+        self._apply("media.pause", view_offset_seconds=1200)
+        cache.clear()  # no cached offset to fall back on
+        self._apply("media.pause", view_offset_seconds=None)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 1200)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_scrobble_without_offset_marks_completed(self, _mock_image):
+        """Plex scrobbles carry no offset; they must still complete."""
+        self._apply("media.pause", view_offset_seconds=5000)
+        self._apply("media.scrobble", view_offset_seconds=None)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertTrue(progress.completed)
+        self.assertEqual(progress.position_seconds, 5000)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_rewatch_from_the_start_clears_completion(self, _mock_image):
+        """Restarting a finished title must clear its completion mark."""
+        self._apply("media.scrobble", view_offset_seconds=8100)
+
+        self._apply("media.pause", view_offset_seconds=120)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertFalse(progress.completed)
+        self.assertEqual(progress.position_seconds, 120)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_long_after_scrobble_keeps_completed(self, _mock_image):
+        """Elapsed time must not decide whether a completion survives.
+
+        Plex scrobbles at ~90%, so on a long film the trailing stop can
+        arrive far later in wall-clock terms while still being at the end
+        of the title.
+        """
+        self._apply("media.scrobble", view_offset_seconds=7300)
+        # queryset update() bypasses auto_now, so the row really ages.
+        PlaybackProgress.objects.filter(user=self.user).update(
+            updated_at=timezone.now() - timedelta(minutes=30),
+        )
+
+        self._apply("media.stop", view_offset_seconds=8160)
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertTrue(progress.completed)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_with_foreign_rating_key_writes_nothing(self, _mock_image):
+        """Identifiers are only reused when the rating key matches."""
+        self._apply("media.pause", view_offset_seconds=600)
+        self.assertEqual(PlaybackProgress.objects.count(), 1)
+
+        self._apply(
+            "media.stop",
+            media_id=None,
+            rating_key="some-other-playback",
+            view_offset_seconds=4200,
+        )
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 600)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_without_identifiers_writes_nothing(self, _mock_image):
+        """A stop that identifies nothing must not adopt a cached title."""
+        self._apply("media.pause", view_offset_seconds=600)
+        self.assertEqual(PlaybackProgress.objects.count(), 1)
+
+        self._apply(
+            "media.stop",
+            media_id=None,
+            rating_key=None,
+            view_offset_seconds=4200,
+        )
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.position_seconds, 600)
+
+
+class JellyfinWebhookProgressTests(TestCase):
+    """The Jellyfin processor stores positions end to end."""
+
+    def setUp(self):
+        """Create a user and the movie the payload resolves to."""
+        cache.clear()
+        self.user = get_user_model().objects.create_user(username="jellyfinuser")
+        self.item = Item.objects.create(
+            media_id="701",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="The Matrix",
+        )
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_stop_payload_stores_position(self, _mock_image):
+        """A Jellyfin stop payload persists the position from its ticks."""
+        processor = JellyfinWebhookProcessor()
+        processor._update_live_playback_state(
+            {
+                "Event": "Stop",
+                "Item": {
+                    "Id": "jf-1",
+                    "Name": "The Matrix",
+                    "RunTimeTicks": 81_600_000_000,  # 8160s
+                    "PlaybackPositionTicks": 13_800_000_000,  # 1380s
+                },
+            },
+            self.user,
+            {"tmdb_id": "701"},
+            MediaTypes.MOVIE.value,
+        )
+
+        progress = PlaybackProgress.objects.get(user=self.user, item=self.item)
+        self.assertEqual(progress.position_seconds, 1380)
+        self.assertEqual(progress.duration_seconds, 8160)
+
+
+class PlexWebhookProgressTests(TestCase):
+    """The Plex processor stores episode positions end to end.
+
+    Plex only resolves the show id on play/resume/scrobble, so a pause or
+    stop has to recover it from the cached state of the same playback.
+    """
+
+    def setUp(self):
+        """Create a user and the episode the payload resolves to.
+
+        Plex resolves episodes to the *show* TMDB id, so the episode Item
+        is keyed on that id rather than an episode-level one.
+        """
+        cache.clear()
+        self.user = get_user_model().objects.create_user(username="plexuser")
+        self.episode_item = Item.objects.create(
+            media_id="1416",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Episode Four",
+            season_number=4,
+            episode_number=4,
+        )
+
+    def _payload(self, event, offset_ms):
+        return {
+            "event": event,
+            "Metadata": {
+                "ratingKey": "plex-rk-1",
+                "type": "episode",
+                "title": "Episode Four",
+                "grandparentTitle": "Some Show",
+                "parentIndex": 4,
+                "index": 4,
+                "viewOffset": offset_ms,
+                "duration": 2_700_000,
+            },
+        }
+
+    @patch(
+        "integrations.webhooks.plex.PlexWebhookProcessor._find_tv_media_id",
+        return_value=("1416", None, None),
+    )
+    @patch("app.live_playback._attach_resolved_image")
+    def test_episode_pause_stores_position_after_play(self, _mock_image, _mock_find):
+        """Play resolves the show id; the following pause reuses it."""
+        processor = PlexWebhookProcessor()
+        # Play: Plex resolves the show-level id from the payload ids.
+        processor._update_live_playback_state(
+            self._payload("media.play", 30_000),
+            self.user,
+            {"tmdb_id": "1416", "tvdb_id": None, "imdb_id": None},
+            MediaTypes.EPISODE.value,
+        )
+        # Pause: the processor deliberately leaves media_id unresolved.
+        processor._update_live_playback_state(
+            self._payload("media.pause", 1_500_000),
+            self.user,
+            {"tmdb_id": None, "tvdb_id": None, "imdb_id": None},
+            MediaTypes.EPISODE.value,
+        )
+
+        progress = PlaybackProgress.objects.get(user=self.user)
+        self.assertEqual(progress.item, self.episode_item)
+        self.assertEqual(progress.position_seconds, 1500)
 
 
 class WebhookTaskRoutingTests(SimpleTestCase):

--- a/src/integrations/webhooks/emby.py
+++ b/src/integrations/webhooks/emby.py
@@ -194,4 +194,5 @@ class EmbyWebhookProcessor(BaseWebhookProcessor):
             episode_number=episode_number,
             view_offset_seconds=offset_seconds,
             duration_seconds=duration_seconds,
+            store_progress=True,
         )

--- a/src/integrations/webhooks/jellyfin.py
+++ b/src/integrations/webhooks/jellyfin.py
@@ -259,4 +259,5 @@ class JellyfinWebhookProcessor(BaseWebhookProcessor):
             episode_number=episode_number,
             view_offset_seconds=offset_seconds,
             duration_seconds=duration_seconds,
+            store_progress=True,
         )


### PR DESCRIPTION
Fixes #794
Refs #429

## Problem

Playback coming in through the Plex/Jellyfin/Emby webhooks never reaches `PlaybackProgress` — only API clients and scrobble `stop` write there. So if you stop a movie or episode part-way, no resume position is saved at all, and `/api/v1/playback/progress/` has nothing to give a syncing client.

On my own server a complete Plex session (every event accepted, item resolved fine) left `app_playbackprogress` empty, simply because the title never got watched far enough for Plex to scrobble.

## Solution

`apply_playback_event()` mirrors the reported position into `PlaybackProgress` through the existing `upsert_playback_progress()` helper. That function is source-agnostic, so Plex, Jellyfin and Emby are all covered by one change. Writing is opt-in via `store_progress`; the scrobble API path does not opt in, because it already writes that store itself.

Which events store a position:

| Event | Stored | Reason |
|---|---|---|
| `media.pause` | yes | reports where the viewer stopped |
| `media.resume` | yes | how Plex reports a seek — the offset is the new position |
| `media.stop` | yes | final position of the session |
| `media.scrobble` | completion only | the server's own watched mark |
| `media.play` | no | starts a title; Plex sends offset 0, which would clobber a good position |

Things worth flagging for review:

- **Events without an offset are ignored** rather than stored as position `0`. Plex regularly omits `viewOffset` on `pause`, `resume` and `scrobble`, and writing zero would destroy a good stored position.
- **A scrobble without an offset marks completion only**, leaving the stored position alone — that is the common Plex shape.
- **`completed` survives the trailing stop.** Plex scrobbles at ~90% and then sends a stop at the end; the mark is kept while the reported position is still inside the last 10% of the title, so a later rewatch can clear it again.
- **Plex leaves `media_id` unresolved on pause/stop** (deliberately, see #547). The identifiers are recovered from the cached state of the same playback, and only when the rating key proves it is the same item — without that, Plex episodes never store a position at all.
- **Episode positions never end up on a show or season row.** `_resolve_state_item()` falls back to those when the episode is unknown, so anything but an exact media-type match is dropped.
- Podcasts are excluded by the existing movie/episode gate; their positions stay on `Podcast.played_up_to_seconds`.
- Write failures are logged, never raised — a webhook should not fail because the resume position could not be stored. Same pattern as `fork_views_scrobble._store_playback_progress()`.

The `PlaybackProgressView` docstring said webhook playback was not mirrored into this store; corrected, along with the per-server event lists (Jellyfin has no scrobble, Emby only start/stop).

## Validation

```
SECRET=test-only scripts/test.sh integrations.tests.test_webhook_async
  → Ran 40 tests, OK

SECRET=test-only scripts/test.sh integrations.tests api.tests.test_fork_playback_progress \
    api.tests.test_fork_scrobble app.tests.test_api_contracts
  → Ran 870 tests, 1 pre-existing failure unrelated to this change
    (integrations.tests.imports.test_anilist.test_user_not_found — hits the live
     AniList API; fails the same way on a clean checkout)

uv run --no-sync ruff check src
  → All checks passed!
```

No model or migration changes, so the migration gate does not apply — `PlaybackProgress` is used as it stands. Backend only, so no screenshots.

I also ran this against my own Plex server and logged the incoming payloads for a while, which confirmed what the tests assume: a seek arrives as `resume` carrying the new offset, `pause` and `scrobble` often carry no offset at all, and for episodes `media_id` is unresolved on pause/stop. A movie and an episode both ended up with the right position stored — neither did before the change.

## AI Assistance

I used Claude Code to help write this — claude-opus-5 for the code, claude-fable-5 to review it. The review rounds turned up several bugs, all fixed here, and each fix has a test I checked actually fails without it. The problem, the approach and the testing are mine.

## Not in this PR

While testing I ran into three separate issues with the Now Playing card. They are pre-existing, live in different code, and I left them out on purpose:

- after a seek the card extrapolates from a stale position and drifts
- after an offset-less scrobble the card works out its expiry from that stale position and can stay up for the better part of an hour
- when TMDB has no backdrop, the card shows a placeholder even though the item has usable artwork

Happy to send a follow-up for the first two — they share a root cause.