### PR TITLE
docs: add Discord and bug report links to README and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/uFgha7Kb6n
+    about: Ask questions, get help, or chat with the Floppy community.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@
 <p align="center">
   <a href="https://yamtrack.dannyvfilms.com">Demo</a> ·
   <a href="https://github.com/dannyvfilms/Floppy/pkgs/container/floppy">Docker Image</a> ·
+  <a href="https://discord.gg/uFgha7Kb6n">Discord</a> ·
   <a href="https://github.com/dannyvfilms/Floppy/wiki">Wiki</a> ·
-  <a href="https://github.com/dannyvfilms/Floppy/releases">Releases</a>
+  <a href="https://github.com/dannyvfilms/Floppy/releases">Releases</a> ·
+  <a href="https://github.com/dannyvfilms/Floppy/issues">Report a Bug</a>
 </p>
 
 Floppy is a self-hosted, all-in-one media tracker and personal media diary, a broader alternative to Trakt, Letterboxd, and TV Time for people who want one place for everything they watch, read, play, or listen to. It gives you a real progress view that tells you what to watch next, a unified history you can actually scan, recap-style statistics, shareable lists, owned-media collections, and integrations that sync instead of asking you to upload a file every few months.
@@ -721,6 +723,7 @@ dependency.
 ## Support the project
 
 - Star the repository if you want to help more people find Floppy.
+- Join the [Discord channel](https://discord.gg/uFgha7Kb6n) to ask questions, share feedback, and chat with the community.
 - Open an [issue](https://github.com/dannyvfilms/Floppy/issues) for bugs, or for feature requests and ideas.
 - Open a pull request if you want to contribute code, docs, or polish.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ We take the security of this project seriously.
 
 ## Urgent Inquiries
 
-For urgent but non-sensitive matters, general questions, and immediate assistance requests, please reach out to our community Discord Channel: [https://discord.gg/sqyZUU37ZY](https://discord.gg/sqyZUU37ZY).
+For urgent but non-sensitive matters, general questions, and immediate assistance requests, please reach out to our community Discord Channel: [https://discord.gg/uFgha7Kb6n](https://discord.gg/uFgha7Kb6n).
 
 ## Contributing Security Fixes
 

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -51,7 +51,7 @@ _SECRET_REPORT_KEYS = frozenset({"actions", "incident_token"})
 _HELP_LINKS = (
     ("Report a problem", "https://github.com/dannyvfilms/Floppy/issues"),
     ("Read the wiki", "https://github.com/dannyvfilms/Floppy/wiki"),
-    ("Ask on Discord", "https://discord.gg/QfNA6zJ5Ws"),
+    ("Ask on Discord", "https://discord.gg/uFgha7Kb6n"),
 )
 
 # navigator.clipboard exists only in a secure context. Floppy is usually opened

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -369,7 +369,7 @@ class RecoveryPageTests(SimpleTestCase):
                 page = recovery.render_page(candidate, interactive=True)
                 self.assertIn("github.com/dannyvfilms/Floppy/issues", page)
                 self.assertIn("github.com/dannyvfilms/Floppy/wiki", page)
-                self.assertIn("discord.gg/QfNA6zJ5Ws", page)
+                self.assertIn("discord.gg/uFgha7Kb6n", page)
 
     def test_a_cross_site_form_cannot_make_the_choice(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Problem
Users and evaluators navigating the README or looking for community support and bug reporting channels lacked quick-access links in the header navigation bar.

## Solution
- Added Discord channel (`https://discord.gg/uFgha7Kb6n`) and Report a Bug (`https://github.com/dannyvfilms/Floppy/issues`) links to the top navigation bar in `README.md`.
- Added Discord community link to the Support section in `README.md`.
- Added Discord contact link in `.github/ISSUE_TEMPLATE/config.yml` for issue chooser routing.
- Updated Discord invite URLs across `SECURITY.md`, `src/config/sqlite_recovery_server.py`, and its tests.

## Validation
- `SECRET=test-only scripts/test.sh config.tests.test_sqlite_recovery_server` (27/27 passed)
- `uv run --no-sync ruff check src` (0 issues)

## AI Assistance
Generated with Gemini (Gemini 3.7 Flash).