### PR TITLE
Fix TMDB backdrop lookup calling base_params as an attribute

### DIFF
--- a/src/lists/models.py
+++ b/src/lists/models.py
@@ -397,7 +397,7 @@ class CustomList(models.Model):
             else:
                 url = f"{tmdb.base_url}/tv/{media_id}"
 
-            params = tmdb.base_params.copy()
+            params = dict(tmdb.base_params())
             response = services.api_request(
                 Sources.TMDB.value,
                 "GET",

--- a/src/lists/tests/test_models.py
+++ b/src/lists/tests/test_models.py
@@ -2,7 +2,9 @@ import datetime
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.db import IntegrityError, transaction
 from django.test import TestCase
 from django.utils import timezone
@@ -1111,3 +1113,35 @@ class CustomListItemDeleteRenumberTest(TestCase):
 
         with self.assertRaises(IntegrityError), transaction.atomic():
             duplicate.save(force_insert=True)
+
+
+class TmdbBackdropTest(TestCase):
+    """Backdrop lookups must actually reach TMDB."""
+
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    @patch("app.providers.services.api_request")
+    def test_backdrop_url_is_built_from_the_response(self, mock_request):
+        """A successful lookup returns the full image URL."""
+        mock_request.return_value = {"backdrop_path": "/abc.jpg"}
+
+        backdrop = CustomList()._get_tmdb_backdrop(MediaTypes.MOVIE.value, "603")
+
+        self.assertEqual(backdrop, "https://image.tmdb.org/t/p/w1280/abc.jpg")
+        params = mock_request.call_args.kwargs["params"]
+        self.assertIn("api_key", params)
+        self.assertIn("language", params)
+
+    @patch("app.providers.services.api_request")
+    def test_missing_backdrop_falls_back_to_placeholder(self, mock_request):
+        """A title without a backdrop yields the placeholder."""
+        mock_request.return_value = {}
+
+        backdrop = CustomList()._get_tmdb_backdrop(MediaTypes.MOVIE.value, "603")
+
+        self.assertEqual(backdrop, settings.IMG_NONE)


### PR DESCRIPTION
## Problem

No TMDB backdrop ever loads. `CustomList._get_tmdb_backdrop()` builds its request params with

```python
params = tmdb.base_params.copy()
```

but `tmdb.base_params` is a function (`src/app/providers/tmdb.py:47`), not a dict. That raises `AttributeError`, which the surrounding best-effort `except Exception: pass` swallows, so the lookup silently returns the placeholder — and caches it for 24 hours.

I noticed it because the Now Playing card kept showing a grey placeholder for a film that clearly has backdrops on TMDB. Checking the API directly for two of them returned 29 and 13 backdrops respectively, both with `backdrop_path` set, while Floppy returned `None` for each.

Every other call site in the codebase already calls it correctly as `base_params(language)`; this one looks like it was missed when it changed from a constant to a function.

## Solution

Call it:

```python
params = dict(tmdb.base_params())
```

Two tests cover the lookup, which had none: one asserts the URL is built from the response and that the request carries `api_key`/`language`, one asserts a title without a backdrop still yields the placeholder. The first fails against the old code.

## Validation

```
SECRET=test-only scripts/test.sh lists.tests.test_models
  → Ran 38 tests, OK

uv run --no-sync ruff check src
  → All checks passed!
```

Verified on my own instance: after the fix both films resolve to their real backdrop URLs instead of the placeholder.

No template, CSS or layout change — the card renders exactly as before, it just gets a working image URL now. Backend only, so no screenshots.

## AI Assistance

Found and fixed with Claude Code (claude-opus-5).