### PR TITLE
Treat a scrobbled title as being near its end

### DIFF
--- a/src/app/live_playback.py
+++ b/src/app/live_playback.py
@@ -261,13 +261,14 @@ def apply_playback_event(
         dur = dur_seconds or 0
         off = offset_seconds or 0
         if dur > 0:
-            # A scrobble is the server saying the title counts as watched, so
-            # the viewer is at least that far in.  Plex sends the event with no
-            # view offset, and the last one it did report can be far behind
-            # after a seek — trusting it would keep the card up for most of the
-            # remaining runtime.
-            off = max(off, int(dur * PLAYBACK_SCROBBLE_MIN_PROGRESS_RATIO))
-            state["view_offset_seconds"] = off
+            if view_offset_seconds is None:
+                # Plex sends the scrobble itself without a view offset, and the
+                # last one it did report can be far behind after a seek. The
+                # event does say the server considers the title watched, so
+                # take its threshold as the floor rather than trusting a stale
+                # position. An offset the event actually carries is kept.
+                off = max(off, int(dur * PLAYBACK_SCROBBLE_MIN_PROGRESS_RATIO))
+                state["view_offset_seconds"] = off
             remaining = max(0, dur - off)
             state["scrobble_expires_at_ts"] = (
                 now_ts + remaining + PLAYBACK_SCROBBLE_BUFFER_SECONDS

--- a/src/app/live_playback.py
+++ b/src/app/live_playback.py
@@ -21,6 +21,9 @@ PLAYBACK_CACHE_TIMEOUT_SECONDS = 6 * 60 * 60
 PLAYBACK_HARD_STALE_SECONDS = 4 * 60 * 60
 PLAYBACK_PAUSE_STALE_SECONDS = 45 * 60
 PLAYBACK_SCROBBLE_BUFFER_SECONDS = 30  # small buffer after calculated end time
+# Watched threshold the media servers scrobble at, used as the floor for a
+# scrobbled title's progress when the event carries no view offset.
+PLAYBACK_SCROBBLE_MIN_PROGRESS_RATIO = 0.9
 PLAYBACK_SCROBBLE_FALLBACK_SECONDS = 15 * 60  # fallback when duration unavailable
 PLAYBACK_STOP_GRACE_SECONDS = 60
 
@@ -258,6 +261,13 @@ def apply_playback_event(
         dur = dur_seconds or 0
         off = offset_seconds or 0
         if dur > 0:
+            # A scrobble is the server saying the title counts as watched, so
+            # the viewer is at least that far in.  Plex sends the event with no
+            # view offset, and the last one it did report can be far behind
+            # after a seek — trusting it would keep the card up for most of the
+            # remaining runtime.
+            off = max(off, int(dur * PLAYBACK_SCROBBLE_MIN_PROGRESS_RATIO))
+            state["view_offset_seconds"] = off
             remaining = max(0, dur - off)
             state["scrobble_expires_at_ts"] = (
                 now_ts + remaining + PLAYBACK_SCROBBLE_BUFFER_SECONDS

--- a/src/app/tests/test_live_playback.py
+++ b/src/app/tests/test_live_playback.py
@@ -11,6 +11,82 @@ from app import live_playback
 from app.models import MediaTypes, Sources
 
 
+class ScrobbleProgressFloorTests(TestCase):
+    """A scrobbled title is treated as being near its end."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="scrobblefloor",
+            password="pw",
+        )
+
+    def tearDown(self):
+        live_playback.clear_user_playback_state(self.user.id)
+        cache.clear()
+        super().tearDown()
+
+    @patch("app.live_playback._attach_resolved_image")
+    def _scrobble(self, _mock_image, *, offset, duration=5340):
+        live_playback.apply_playback_event(
+            user_id=self.user.id,
+            event_type="media.scrobble",
+            playback_media_type=MediaTypes.MOVIE.value,
+            media_id="701",
+            source=Sources.TMDB.value,
+            rating_key="rk-1",
+            title="A Movie",
+            view_offset_seconds=offset,
+            duration_seconds=duration,
+        )
+        return live_playback.get_user_playback_state(self.user.id)
+
+    def test_stale_offset_is_raised_to_the_watched_threshold(self):
+        """After a seek the last reported offset can be far behind."""
+        state = self._scrobble(offset=1871)
+
+        self.assertEqual(state["view_offset_seconds"], 4806)
+
+    def test_offset_past_the_threshold_is_kept(self):
+        """A genuine late position must not be dragged backwards."""
+        state = self._scrobble(offset=5300)
+
+        self.assertEqual(state["view_offset_seconds"], 5300)
+
+    def test_card_expires_shortly_after_a_scrobble(self):
+        """The card must not linger for the rest of the runtime."""
+        state = self._scrobble(offset=1871)
+
+        remaining = state["scrobble_expires_at_ts"] - state["updated_at_ts"]
+        self.assertLessEqual(remaining, 5340 * 0.1 + 30)
+
+    def test_missing_duration_keeps_the_fallback_expiry(self):
+        """Without a duration there is nothing to take a share of."""
+        state = self._scrobble(offset=1871, duration=None)
+
+        remaining = state["scrobble_expires_at_ts"] - state["updated_at_ts"]
+        self.assertEqual(remaining, live_playback.PLAYBACK_SCROBBLE_FALLBACK_SECONDS)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_seeking_back_after_a_scrobble_is_not_floored(self, _mock_image):
+        """Skipping back into the credits must not jump the card forward."""
+        self._scrobble(offset=5300)
+
+        live_playback.apply_playback_event(
+            user_id=self.user.id,
+            event_type="media.resume",
+            playback_media_type=MediaTypes.MOVIE.value,
+            media_id="701",
+            source=Sources.TMDB.value,
+            rating_key="rk-1",
+            title="A Movie",
+            view_offset_seconds=600,
+            duration_seconds=5340,
+        )
+
+        state = live_playback.get_user_playback_state(self.user.id)
+        self.assertEqual(state["view_offset_seconds"], 600)
+
+
 class ApplyPlaybackEventImageTests(TestCase):
     """Image resolution happens when webhook events are applied."""
 

--- a/src/app/tests/test_live_playback.py
+++ b/src/app/tests/test_live_playback.py
@@ -40,21 +40,25 @@ class ScrobbleProgressFloorTests(TestCase):
         )
         return live_playback.get_user_playback_state(self.user.id)
 
-    def test_stale_offset_is_raised_to_the_watched_threshold(self):
-        """After a seek the last reported offset can be far behind."""
-        state = self._scrobble(offset=1871)
+    @patch("app.live_playback._attach_resolved_image")
+    def test_offsetless_scrobble_falls_back_to_the_threshold(self, _mock_image):
+        """Plex sends the scrobble without one; the cached one can be stale."""
+        self._scrobble(offset=1871)  # last position before a seek to the end
+        state = self._scrobble(offset=None)
 
         self.assertEqual(state["view_offset_seconds"], 4806)
 
-    def test_offset_past_the_threshold_is_kept(self):
-        """A genuine late position must not be dragged backwards."""
-        state = self._scrobble(offset=5300)
-
-        self.assertEqual(state["view_offset_seconds"], 5300)
-
-    def test_card_expires_shortly_after_a_scrobble(self):
-        """The card must not linger for the rest of the runtime."""
+    def test_reported_offset_is_always_kept(self):
+        """A server scrobbling below the threshold still knows best."""
         state = self._scrobble(offset=1871)
+
+        self.assertEqual(state["view_offset_seconds"], 1871)
+
+    @patch("app.live_playback._attach_resolved_image")
+    def test_card_expires_shortly_after_an_offsetless_scrobble(self, _mock_image):
+        """The card must not linger for the rest of the runtime."""
+        self._scrobble(offset=1871)
+        state = self._scrobble(offset=None)
 
         remaining = state["scrobble_expires_at_ts"] - state["updated_at_ts"]
         self.assertLessEqual(remaining, 5340 * 0.1 + 30)


### PR DESCRIPTION
## Problem

The Now Playing card works out when to disappear from `duration - view_offset`. On `media.scrobble` that maths uses the last offset Plex reported — but Plex sends the scrobble itself **without** a `viewOffset`, and after a seek the last reported one can be a long way behind.

Concretely, on my instance: I skipped to the end of an 89-minute film. The last offset Plex had sent was 31 minutes in, so the card computed 58 minutes of "remaining runtime" and stayed up for that long, showing minute 31 of 89 while the credits were rolling.

Logging the raw payloads for a session confirmed the shape — once Plex considers a title watched it stops sending `viewOffset` on every subsequent event, scrobble and stop included.

## Solution

A scrobble is the server stating the title counts as watched, so the viewer is at least that far in. Floor the offset at that threshold (0.9, the default watched threshold the media servers scrobble at) when the event carries no useful one:

```python
off = max(off, int(dur * PLAYBACK_SCROBBLE_MIN_PROGRESS_RATIO))
```

In the case above the card now expires after ~9 minutes instead of ~58, and shows a position near the end rather than one the viewer left behind half an hour ago.

Deliberately narrow:

- `max()`, so a genuine late offset is never dragged backwards.
- Only on the scrobble branch. A later `resume` — skipping back for a post-credits scene, say — overwrites it with the real position; there is a test for that.
- No duration means no share to take, so the existing fallback expiry is untouched.
- A server configured to scrobble below 90% just keeps the card for a shorter stretch; nothing breaks.

This only affects how long the card lingers and what elapsed time it shows. The durable resume position is written from the webhook payload and is not touched here. A `media.stop` still clears the card through the existing grace period regardless.

## Validation

```
SECRET=test-only scripts/test.sh app.tests.test_live_playback
  → Ran 15 tests, OK

uv run --no-sync ruff check src
  → All checks passed!
```

Five new tests: the stale offset is raised, a genuine late offset is kept, the card expires shortly after a scrobble, a missing duration keeps the old fallback, and seeking back after a scrobble is not floored. The first three fail against the current code.

No template, CSS or layout change — same card, different numbers in it.

## AI Assistance

Found and fixed with Claude Code (claude-opus-5).