### PR TITLE
Prefer explicit MDBList episodes over season summaries

### DIFF
--- a/src/integrations/imports/mdblist.py
+++ b/src/integrations/imports/mdblist.py
@@ -120,6 +120,21 @@ def _parse_entry_datetime(entry, *keys):
     return None
 
 
+def _show_season_keys(show_data, season_number):
+    """Return provider identifiers that can match one show's season rows."""
+    if not isinstance(show_data, dict) or season_number is None:
+        return set()
+
+    ids = show_data.get("ids")
+    if not isinstance(ids, dict):
+        ids = {}
+    return {
+        (source, str(value), str(season_number))
+        for source in ("tmdb", "tvdb", "imdb", "mdblist")
+        if (value := ids.get(source) or show_data.get(f"{source}_id"))
+    }
+
+
 class MDBListImporter(TraktMetadataResolverMixin):
     """Import watched/watchlist/ratings/dropped/collection data from MDBList."""
 
@@ -289,10 +304,23 @@ class MDBListImporter(TraktMetadataResolverMixin):
 
         MDBList stores watched state at whatever level the user marked it:
         movie, whole show, whole season, or individual episode. Season entries
-        are expanded into their episodes via TMDB metadata; show entries are
-        recorded as a COMPLETED show without per-episode fan-out.
+        are expanded into their episodes via TMDB metadata unless explicit
+        episode rows exist for that season; show entries are recorded as a
+        COMPLETED show without per-episode fan-out.
         """
         data = self._get_grouped_sync_data("/sync/watched", "watched entries")
+        explicit_episode_seasons = set()
+        for entry in data.get("episodes", []):
+            if not isinstance(entry, dict):
+                continue
+            episode_data = entry.get("episode") or {}
+            if not isinstance(episode_data, dict):
+                continue
+            show_data = episode_data.get("show") or entry.get("show") or {}
+            explicit_episode_seasons.update(
+                _show_season_keys(show_data, episode_data.get("season")),
+            )
+
         total = sum(
             len(data.get(group, []))
             for group in ("movies", "shows", "seasons", "episodes")
@@ -323,6 +351,16 @@ class MDBListImporter(TraktMetadataResolverMixin):
             current += 1
             import_progress.report(current, total, "MDBList: watched history")
             try:
+                season_data = entry.get("season") or {}
+                show_data = season_data.get("show") or entry.get("show") or {}
+                if (
+                    _show_season_keys(
+                        show_data,
+                        season_data.get("number"),
+                    )
+                    & explicit_episode_seasons
+                ):
+                    continue
                 self.process_watched_season(entry)
             except MediaImportError:
                 raise

--- a/src/integrations/imports/mdblist.py
+++ b/src/integrations/imports/mdblist.py
@@ -120,19 +120,49 @@ def _parse_entry_datetime(entry, *keys):
     return None
 
 
-def _show_season_keys(show_data, season_number):
-    """Return provider identifiers that can match one show's season rows."""
-    if not isinstance(show_data, dict) or season_number is None:
+def _show_keys(show_data):
+    """Return provider identifiers that can match one show's rows."""
+    if not isinstance(show_data, dict):
         return set()
 
     ids = show_data.get("ids")
     if not isinstance(ids, dict):
         ids = {}
     return {
-        (source, str(value), str(season_number))
+        (source, str(value))
         for source in ("tmdb", "tvdb", "imdb", "mdblist")
         if (value := ids.get(source) or show_data.get(f"{source}_id"))
     }
+
+
+def _show_season_keys(show_data, season_number):
+    """Return provider identifiers that can match one show's season rows."""
+    if season_number is None:
+        return set()
+    return {(*show_key, str(season_number)) for show_key in _show_keys(show_data)}
+
+
+def _next_page_params(params, pagination, page_size):
+    """Return advancing cursor or offset parameters for another provider page."""
+    if page_size <= 0 or not isinstance(pagination, dict):
+        return None
+
+    next_params = dict(params)
+    cursor = pagination.get("next_cursor")
+    if cursor:
+        next_params["cursor"] = cursor
+    elif pagination.get("has_more"):
+        current_offset = params.get("offset", pagination.get("offset", 0))
+        try:
+            current_offset = int(current_offset or 0)
+        except (TypeError, ValueError):
+            current_offset = 0
+        next_params.pop("cursor", None)
+        next_params["offset"] = current_offset + page_size
+    else:
+        return None
+
+    return next_params if next_params != params else None
 
 
 class MDBListImporter(TraktMetadataResolverMixin):
@@ -148,9 +178,11 @@ class MDBListImporter(TraktMetadataResolverMixin):
         # Track existing media to handle "new" mode correctly
         self.existing_media = helpers.get_existing_media(user)
 
-        # Track previously imported episode plays so rerunning the same sync
-        # does not create duplicate episode history rows.
-        self.existing_episode_watch_keys = self._get_existing_episode_watch_keys()
+        # Track existing plays for exact dedupe and distinct-episode roll-up.
+        (
+            self.existing_episode_watch_keys,
+            self.watched_episode_numbers,
+        ) = self._get_existing_episode_state()
 
         # Track media IDs to delete in overwrite mode
         self.to_delete = defaultdict(lambda: defaultdict(set))
@@ -163,7 +195,6 @@ class MDBListImporter(TraktMetadataResolverMixin):
 
         # Track existing DB objects promoted to COMPLETED during import
         self.completed_seasons = []
-        self.completed_tvs = []
 
         # TMDB IDs of shows the user has dropped on MDBList
         self.dropped_tmdb_ids: set = set()
@@ -175,22 +206,34 @@ class MDBListImporter(TraktMetadataResolverMixin):
             mode,
         )
 
-    def _get_existing_episode_watch_keys(self):
-        """Return exact episode play keys already stored for this user."""
+    def _get_existing_episode_state(self):
+        """Return exact play keys and completed coordinates for new-mode import."""
+        watch_keys = set()
+        watched = defaultdict(set)
         if self.mode != "new":
-            return set()
+            return watch_keys, watched
 
-        return set(
-            app.models.Episode.objects.filter(
-                related_season__user=self.user,
-                end_date__isnull=False,
-            ).values_list(
-                "item__media_id",
-                "item__season_number",
-                "item__episode_number",
-                "end_date",
-            ),
+        rows = app.models.Episode.objects.filter(
+            related_season__user=self.user,
+        ).values_list(
+            "item__media_id",
+            "item__season_number",
+            "item__episode_number",
+            "end_date",
+            "status",
         )
+        for media_id, season_number, episode_number, end_date, status in rows:
+            if end_date is not None:
+                watch_keys.add(
+                    (media_id, season_number, episode_number, end_date),
+                )
+            if (
+                status == Status.COMPLETED.value
+                and season_number is not None
+                and episode_number is not None
+            ):
+                watched[(str(media_id), season_number)].add(episode_number)
+        return watch_keys, watched
 
     def import_data(self):
         """Import all user data from MDBList."""
@@ -209,12 +252,6 @@ class MDBListImporter(TraktMetadataResolverMixin):
                 app.models.Season,
                 fields=["status"],
             )
-        if self.completed_tvs:
-            bulk_update_with_history(
-                self.completed_tvs,
-                app.models.TV,
-                fields=["status"],
-            )
         if self.dropped_tvs:
             bulk_update_with_history(
                 self.dropped_tvs,
@@ -231,14 +268,20 @@ class MDBListImporter(TraktMetadataResolverMixin):
         return imported_counts, deduplicated_messages
 
     def _get_grouped_sync_data(self, path, item_type):
-        """Fetch a grouped ``/sync/*`` payload, following cursor pagination.
+        """Fetch a grouped ``/sync/*`` payload across cursor or offset pages.
 
         Returns a dict of entry lists keyed by group name (``movies``,
         ``shows``, ``seasons``, ``episodes``).
         """
         grouped = defaultdict(list)
         params = {"limit": PAGE_SIZE}
+        seen_pages = set()
         while True:
+            page_token = tuple(sorted(params.items()))
+            if page_token in seen_pages:
+                break
+            seen_pages.add(page_token)
+
             response = request(self.api_key, path, params=params)
             if not isinstance(response, dict):
                 break
@@ -253,11 +296,11 @@ class MDBListImporter(TraktMetadataResolverMixin):
                 total=None,
                 label=f"MDBList: gathering {item_type}…",
             )
-            pagination = response.get("pagination") or {}
-            cursor = pagination.get("next_cursor")
-            if not cursor or not page_size:
+            pagination = response.get("pagination") or response
+            next_params = _next_page_params(params, pagination, page_size)
+            if next_params is None:
                 break
-            params = {"limit": PAGE_SIZE, "cursor": cursor}
+            params = next_params
 
         logger.info(
             "Retrieved %s %s for user %s",
@@ -310,15 +353,32 @@ class MDBListImporter(TraktMetadataResolverMixin):
         """
         data = self._get_grouped_sync_data("/sync/watched", "watched entries")
         explicit_episode_seasons = set()
+        detailed_shows = set()
+        for entry in data.get("seasons", []):
+            if not isinstance(entry, dict):
+                continue
+            season_data = entry.get("season") or {}
+            if not isinstance(season_data, dict):
+                continue
+            season_number = season_data.get("number")
+            if season_number is None:
+                continue
+            show_data = season_data.get("show") or entry.get("show") or {}
+            detailed_shows.update(_show_keys(show_data))
+
         for entry in data.get("episodes", []):
             if not isinstance(entry, dict):
                 continue
             episode_data = entry.get("episode") or {}
             if not isinstance(episode_data, dict):
                 continue
+            season_number = episode_data.get("season")
+            if season_number is None or episode_data.get("number") is None:
+                continue
             show_data = episode_data.get("show") or entry.get("show") or {}
+            detailed_shows.update(_show_keys(show_data))
             explicit_episode_seasons.update(
-                _show_season_keys(show_data, episode_data.get("season")),
+                _show_season_keys(show_data, season_number),
             )
 
         total = sum(
@@ -341,6 +401,9 @@ class MDBListImporter(TraktMetadataResolverMixin):
             current += 1
             import_progress.report(current, total, "MDBList: watched history")
             try:
+                show_data = entry.get("show") or {}
+                if _show_keys(show_data) & detailed_shows:
+                    continue
                 self.process_watched_show(entry)
             except MediaImportError:
                 raise
@@ -560,10 +623,15 @@ class MDBListImporter(TraktMetadataResolverMixin):
         )
         season_key = f"{tmdb_id}:{season_number}"
         if season_key not in self.media_instances[MediaTypes.SEASON.value]:
-            season_obj = app.models.Season.objects.filter(
-                user=self.user,
-                item=season_item,
-            ).first()
+            replacing_tv = (
+                tmdb_id in self.to_delete[MediaTypes.TV.value][Sources.TMDB.value]
+            )
+            season_obj = None
+            if not replacing_tv:
+                season_obj = app.models.Season.objects.filter(
+                    user=self.user,
+                    item=season_item,
+                ).first()
             if season_obj is None:
                 season_obj = app.models.Season(
                     item=season_item,
@@ -603,14 +671,13 @@ class MDBListImporter(TraktMetadataResolverMixin):
         self.media_instances[MediaTypes.EPISODE.value][ep_key].append(episode_obj)
         self.bulk_media[MediaTypes.EPISODE.value].append(episode_obj)
         self.existing_episode_watch_keys.add(episode_watch_key)
+        watched_episode_numbers = self.watched_episode_numbers[(tmdb_id, season_number)]
+        watched_episode_numbers.add(episode_number)
 
         self._update_completion_status(
             season_obj,
-            tv_obj,
-            season_number,
-            episode_number,
             season_metadata,
-            tv_metadata,
+            watched_episode_numbers,
         )
 
     def _get_or_create_tv_instance(self, tmdb_id, tv_metadata, history_date, status):
@@ -621,9 +688,14 @@ class MDBListImporter(TraktMetadataResolverMixin):
         if tv_key in self.media_instances[MediaTypes.TV.value]:
             return self.media_instances[MediaTypes.TV.value][tv_key][0]
 
-        tv_obj = self.existing_media[MediaTypes.TV.value][Sources.TMDB.value].get(
-            tmdb_id,
+        replacing_tv = (
+            tmdb_id in self.to_delete[MediaTypes.TV.value][Sources.TMDB.value]
         )
+        tv_obj = None
+        if not replacing_tv:
+            tv_obj = self.existing_media[MediaTypes.TV.value][Sources.TMDB.value].get(
+                tmdb_id,
+            )
         if tv_obj is None:
             tv_obj = app.models.TV(
                 item=tv_item,
@@ -642,29 +714,37 @@ class MDBListImporter(TraktMetadataResolverMixin):
     def _update_completion_status(
         self,
         season_obj,
-        tv_obj,
-        season_number,
-        episode_number,
         season_metadata,
-        tv_metadata,
+        watched_episode_numbers,
     ):
-        """Update completion status for season and TV show if applicable."""
-        if episode_number == season_metadata["max_progress"]:
-            season_obj.status = Status.COMPLETED.value
-            if season_obj.pk:
-                self.completed_seasons.append(season_obj)
+        """Complete a season only when distinct episode evidence covers it."""
+        required_episode_numbers = {
+            episode.get("episode_number")
+            for episode in season_metadata.get("episodes", [])
+            if episode.get("episode_number") is not None
+        }
+        if not required_episode_numbers or not required_episode_numbers.issubset(
+            watched_episode_numbers,
+        ):
+            return
+        if season_obj.status in {Status.COMPLETED.value, Status.DROPPED.value}:
+            return
 
-            last_season = tv_metadata.get("last_episode_season")
-            if last_season and last_season == season_number:
-                tv_obj.status = Status.COMPLETED.value
-                if tv_obj.pk:
-                    self.completed_tvs.append(tv_obj)
+        season_obj.status = Status.COMPLETED.value
+        if season_obj.pk:
+            self.completed_seasons.append(season_obj)
 
     def _get_watchlist_entries(self):
-        """Fetch the user's MDBList watchlist, following cursor pagination."""
+        """Fetch the user's MDBList watchlist across cursor or offset pages."""
         entries = []
         params = {"limit": PAGE_SIZE}
+        seen_pages = set()
         while True:
+            page_token = tuple(sorted(params.items()))
+            if page_token in seen_pages:
+                break
+            seen_pages.add(page_token)
+
             response = request(self.api_key, "/watchlist/items", params=params)
             page = normalize_items_response(response)
             entries.extend(page)
@@ -673,17 +753,14 @@ class MDBListImporter(TraktMetadataResolverMixin):
                 total=None,
                 label="MDBList: gathering watchlist…",
             )
-            pagination = (
-                response.get("pagination") if isinstance(response, dict) else None
-            ) or {}
-            cursor = pagination.get("next_cursor")
-            if cursor:
-                params = {"limit": PAGE_SIZE, "cursor": cursor}
-                continue
-            if isinstance(response, list) and len(page) >= PAGE_SIZE:
-                params["offset"] = params.get("offset", 0) + PAGE_SIZE
-                continue
-            break
+            if isinstance(response, dict):
+                pagination = response.get("pagination") or response
+            else:
+                pagination = {"has_more": len(page) >= PAGE_SIZE}
+            next_params = _next_page_params(params, pagination, len(page))
+            if next_params is None:
+                break
+            params = next_params
         return entries
 
     def process_watchlist(self):

--- a/src/integrations/tests/imports/test_mdblist.py
+++ b/src/integrations/tests/imports/test_mdblist.py
@@ -215,6 +215,45 @@ class ImportMDBList(TestCase):
         season = Season.objects.get(item__media_id="12345", user=self.user)
         self.assertEqual(season.status, Status.COMPLETED.value)
 
+    def test_explicit_episode_prevents_season_fanout(self):
+        """Episode rows take precedence over a matching season summary."""
+        responses = {
+            "/sync/watched": {
+                "seasons": [
+                    {
+                        "watched_at": "2023-01-01T00:00:00Z",
+                        "season": {
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+                "episodes": [
+                    {
+                        "watched_at": "2023-01-01T00:00:00Z",
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        self._run_import(responses)
+
+        self.assertEqual(Episode.objects.filter(item__media_id="12345").count(), 1)
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
     def test_season_rating_backfills_episodes(self):
         """Rating a season with no watch history still creates its episodes.
 

--- a/src/integrations/tests/imports/test_mdblist.py
+++ b/src/integrations/tests/imports/test_mdblist.py
@@ -171,7 +171,7 @@ class ImportMDBList(TestCase):
         self.assertIsNotNone(collected.collected_at)
 
     def test_season_completion_rollup(self):
-        """Watching the last episode completes the season and show."""
+        """A complete episode set completes the season, but not the show."""
         responses = {
             "/sync/watched": {
                 "episodes": [
@@ -192,7 +192,35 @@ class ImportMDBList(TestCase):
         season = Season.objects.get(item__media_id="12345", user=self.user)
         tv = TV.objects.get(item__media_id="12345", user=self.user)
         self.assertEqual(season.status, Status.COMPLETED.value)
-        self.assertEqual(tv.status, Status.COMPLETED.value)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+    def test_final_episode_only_does_not_complete_season_or_show(self):
+        """The highest episode number is not proof of complete history."""
+        responses = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "watched_at": "2023-01-01T00:00:00Z",
+                        "episode": {
+                            "season": 1,
+                            "number": 2,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        self._run_import(responses)
+
+        episode = Episode.objects.get(item__media_id="12345")
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(episode.item.episode_number, 2)
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
 
     def test_watched_season_expands_to_episodes(self):
         """A season marked watched creates all of its episodes."""
@@ -253,6 +281,182 @@ class ImportMDBList(TestCase):
         tv = TV.objects.get(item__media_id="12345", user=self.user)
         self.assertEqual(season.status, Status.IN_PROGRESS.value)
         self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+    def test_episode_precedence_does_not_suppress_same_season_on_other_show(self):
+        """A matching episode does not suppress another show's season."""
+        responses = {
+            "/sync/watched": {
+                "seasons": [
+                    {
+                        "season": {
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                    {
+                        "season": {
+                            "number": 1,
+                            "show": {
+                                "title": "Other Show",
+                                "ids": {"tmdb": 54321},
+                            },
+                        },
+                    },
+                ],
+                "episodes": [
+                    {
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        self._run_import(responses)
+
+        self.assertEqual(
+            Episode.objects.filter(
+                item__media_id="12345",
+                item__season_number=1,
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            Episode.objects.filter(
+                item__media_id="54321",
+                item__season_number=1,
+            ).count(),
+            2,
+        )
+
+    def test_episode_precedence_does_not_suppress_other_season_on_same_show(self):
+        """A matching episode does not suppress another season of its show."""
+        responses = {
+            "/sync/watched": {
+                "seasons": [
+                    {
+                        "season": {
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                    {
+                        "season": {
+                            "number": 2,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+                "episodes": [
+                    {
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        self._run_import(responses)
+
+        self.assertEqual(
+            Episode.objects.filter(
+                item__media_id="12345",
+                item__season_number=1,
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            Episode.objects.filter(
+                item__media_id="12345",
+                item__season_number=2,
+            ).count(),
+            2,
+        )
+
+    def test_top_level_show_ids_match_nested_season_show_ids(self):
+        """Top-level and nested show identifier shapes share precedence."""
+        responses = {
+            "/sync/watched": {
+                "seasons": [
+                    {
+                        "season": {
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+                "episodes": [
+                    {
+                        "show": {
+                            "title": "Test Show",
+                            "tmdb_id": 12345,
+                        },
+                        "episode": {"season": 1, "number": 1},
+                    },
+                ],
+            },
+        }
+        self._run_import(responses)
+
+        self.assertEqual(Episode.objects.filter(item__media_id="12345").count(), 1)
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+    def test_show_summary_does_not_override_episode_evidence(self):
+        """Detailed episode evidence takes priority over a broad show row."""
+        responses = {
+            "/sync/watched": {
+                "shows": [
+                    {
+                        "show": {
+                            "title": "Test Show",
+                            "ids": {"tmdb": 12345},
+                        },
+                    },
+                ],
+                "episodes": [
+                    {
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        self._run_import(responses)
+
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+        self.assertEqual(Episode.objects.filter(item__media_id="12345").count(), 1)
 
     def test_season_rating_backfills_episodes(self):
         """Rating a season with no watch history still creates its episodes.
@@ -358,6 +562,97 @@ class ImportMDBList(TestCase):
             1,
         )
 
+    def test_new_mode_completion_uses_existing_episode_rows(self):
+        """Existing completed episodes contribute to the watched set."""
+        first_episode = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "watched_at": "2023-01-01T00:00:00Z",
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        final_episode = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "watched_at": "2023-01-02T00:00:00Z",
+                        "episode": {
+                            "season": 1,
+                            "number": 2,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+
+        self._run_import(first_episode)
+        self._run_import(final_episode)
+
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(season.status, Status.COMPLETED.value)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+        self.assertEqual(Episode.objects.filter(item__media_id="12345").count(), 2)
+
+    def test_completion_rollup_preserves_dropped_status(self):
+        """Completing an episode set does not replace dropped state."""
+        first_episode = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        final_episode = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "episode": {
+                            "season": 1,
+                            "number": 2,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+
+        self._run_import(first_episode)
+        Season.objects.filter(user=self.user).update(status=Status.DROPPED.value)
+        TV.objects.filter(user=self.user).update(status=Status.DROPPED.value)
+        self._run_import(final_episode)
+
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(season.status, Status.DROPPED.value)
+        self.assertEqual(tv.status, Status.DROPPED.value)
+
     def test_overwrite_mode_replaces_existing(self):
         """Overwrite mode deletes preexisting media before importing."""
         item = Item.objects.get_or_create(
@@ -386,6 +681,56 @@ class ImportMDBList(TestCase):
 
         movie = Movie.objects.get(item__media_id="67890", user=self.user)
         self.assertEqual(movie.status, Status.COMPLETED.value)
+
+    def test_overwrite_mode_replaces_episode_history_safely(self):
+        """Overwrite rebuilds TV parents before replacing episode history."""
+        first_episode = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "watched_at": "2023-01-01T00:00:00Z",
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+        replacement_episode = {
+            "/sync/watched": {
+                "episodes": [
+                    {
+                        "watched_at": "2023-01-02T00:00:00Z",
+                        "episode": {
+                            "season": 1,
+                            "number": 2,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+
+        self._run_import(first_episode)
+        original_tv_id = TV.objects.get(user=self.user).pk
+        original_season_id = Season.objects.get(user=self.user).pk
+        self._run_import(replacement_episode, mode="overwrite")
+
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        episode = Episode.objects.get(item__media_id="12345")
+        self.assertNotEqual(tv.pk, original_tv_id)
+        self.assertNotEqual(season.pk, original_season_id)
+        self.assertEqual(episode.item.episode_number, 2)
+        self.assertEqual(episode.related_season, season)
 
     def test_cursor_pagination(self):
         """Sync pagination follows next_cursor until exhausted."""
@@ -431,7 +776,146 @@ class ImportMDBList(TestCase):
 
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[1].get("cursor"), "abc")
+        self.assertEqual(calls[1].get("limit"), calls[0].get("limit"))
         self.assertEqual(Movie.objects.filter(user=self.user).count(), 2)
+
+    def test_offset_pagination_collects_episode_before_season_precedence(self):
+        """A later offset page can prevent an earlier season fan-out."""
+        pages = {
+            0: {
+                "seasons": [
+                    {
+                        "season": {
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+                "pagination": {"offset": 0, "has_more": True},
+            },
+            1: {
+                "episodes": [
+                    {
+                        "episode": {
+                            "season": 1,
+                            "number": 1,
+                            "show": {
+                                "title": "Test Show",
+                                "ids": {"tmdb": 12345},
+                            },
+                        },
+                    },
+                ],
+                "pagination": {"offset": 1, "has_more": False},
+            },
+        }
+        calls = []
+
+        def request_side_effect(_api_key, path, params=None):
+            if path == "/sync/watched":
+                calls.append(dict(params or {}))
+                return pages[params.get("offset", 0)]
+            return _empty_sync_response()
+
+        with (
+            patch(
+                "integrations.imports.mdblist.request",
+                side_effect=request_side_effect,
+            ),
+            patch(
+                "integrations.imports.mdblist.MDBListImporter._get_metadata",
+                side_effect=_metadata_side_effect,
+            ),
+        ):
+            importer("key", self.user, "new")
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1]["offset"], 1)
+        self.assertEqual(calls[1]["limit"], calls[0]["limit"])
+        self.assertEqual(Episode.objects.filter(item__media_id="12345").count(), 1)
+        season = Season.objects.get(item__media_id="12345", user=self.user)
+        tv = TV.objects.get(item__media_id="12345", user=self.user)
+        self.assertEqual(season.status, Status.IN_PROGRESS.value)
+        self.assertEqual(tv.status, Status.IN_PROGRESS.value)
+
+    def test_watchlist_uses_offset_pagination(self):
+        """Watchlist retrieval follows the same offset contract as sync."""
+        pages = {
+            0: {
+                "movies": [
+                    {"title": "Movie 1", "ids": {"tmdb": 1001}},
+                ],
+                "pagination": {"offset": 0, "has_more": True},
+            },
+            1: {
+                "movies": [
+                    {"title": "Movie 2", "ids": {"tmdb": 1002}},
+                ],
+                "pagination": {"offset": 1, "has_more": False},
+            },
+        }
+        calls = []
+
+        def request_side_effect(_api_key, path, params=None):
+            if path == "/watchlist/items":
+                calls.append(dict(params or {}))
+                return pages[params.get("offset", 0)]
+            return _empty_sync_response()
+
+        with (
+            patch(
+                "integrations.imports.mdblist.request",
+                side_effect=request_side_effect,
+            ),
+            patch(
+                "integrations.imports.mdblist.MDBListImporter._get_metadata",
+                side_effect=_metadata_side_effect,
+            ),
+        ):
+            importer("key", self.user, "new")
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1]["offset"], 1)
+        self.assertEqual(calls[1]["limit"], calls[0]["limit"])
+        self.assertEqual(Movie.objects.filter(user=self.user).count(), 2)
+
+    def test_repeated_cursor_stops_pagination(self):
+        """A non-advancing cursor cannot loop forever."""
+        calls = []
+
+        def request_side_effect(_api_key, path, params=None):
+            if path == "/sync/watched":
+                calls.append(dict(params or {}))
+                return {
+                    "movies": [
+                        {
+                            "movie": {
+                                "title": "Movie 1",
+                                "ids": {"tmdb": 1001},
+                            },
+                        },
+                    ],
+                    "pagination": {"next_cursor": "same"},
+                }
+            return _empty_sync_response()
+
+        with (
+            patch(
+                "integrations.imports.mdblist.request",
+                side_effect=request_side_effect,
+            ),
+            patch(
+                "integrations.imports.mdblist.MDBListImporter._get_metadata",
+                side_effect=_metadata_side_effect,
+            ),
+        ):
+            importer("key", self.user, "new")
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1]["cursor"], "same")
 
     def test_tmdb_fallback_via_imdb_id(self):
         """Entries without a TMDB id resolve through tmdb.find."""


### PR DESCRIPTION
## Summary

- Prefer explicit MDBList episode rows over matching broad show or season summaries.
- Collect all cursor- or offset-paginated sync data before applying evidence precedence.
- Derive season completion from the complete distinct episode set, including existing completed episodes in `new` mode.
- Rebuild TV and season parents safely when overwrite mode replaces episode history.

## Problem

MDBList can return broad show or season summaries together with more precise episode rows. Processing a broad row first could expand every episode or mark durable history completed. Offset pagination also allowed the broad row and its matching episode evidence to land on different pages, while treating the highest episode number as complete could mark a partial season and show completed.

## Solution

- Use one page-advance helper for grouped sync and watchlist retrieval.
- Follow `next_cursor` when present; otherwise advance `offset` by the received row count while `has_more` is true.
- Retain request parameters and stop on empty, repeated, or non-advancing pages.
- Normalize nested and top-level show identifiers before applying evidence precedence.
- Suppress broad show/season evidence only for the matching show and season represented by valid detailed rows.
- Track distinct watched episode coordinates, seeded from completed episode rows in `new` mode.
- Complete a season only when its metadata episode set is covered; never infer show completion from the final episode position.
- Preserve `Dropped` during roll-up and avoid overwrite references to parents scheduled for deletion.

## Test matrix requested in review

- [x] Matching season summary and explicit episode on the same page.
- [x] Matching rows split across offset pages.
- [x] Final episode only does not complete a season.
- [x] A different show with the same season number is not suppressed.
- [x] Another season of the same show is not suppressed.
- [x] Nested and top-level show identifier shapes behave the same.
- [x] A show summary cannot override more detailed evidence.
- [x] Overwrite mode replaces episode history without foreign-key references to rows scheduled for deletion.

Additional coverage confirms cursor parameter retention, repeated-cursor termination, watchlist offset pagination, existing-episode completion seeding, and preservation of `Dropped`.

## Validation

- `scripts/test.sh integrations.tests.imports.test_mdblist` — 27 tests passed.
- The same 27-test MDBList suite passed in a disposable Python 3.12 Linux container.
- `uv run --no-sync ruff check src` — passed.
- `uv run --no-sync ruff format --check src/integrations/imports/mdblist.py src/integrations/tests/imports/test_mdblist.py` — passed.
- `git diff --check` — passed.
- `docker buildx build --platform linux/amd64 ...` — passed for the production Dockerfile.
- Native arm64 production-image health, migrations, assets, API metadata, MCP package, and restart-on-persisted-volume smoke — passed.
- Hosted PR lint, all CodeQL analyses, the full Python 3.12 application workflow, production-image smoke, and downstream image build — passed for commit `f51d0a31`.
- No repository QA command or `/gstack-qa` executable is available in this contributor environment.

An additional disposable Linux fast-suite run executed 3,887 tests. The MDBList and affected application tests passed; its three failures were confined to the ad hoc container harness (missing `git` and two nested-container entrypoint signal tests). The hosted Ubuntu application workflow above is the authoritative full-suite gate.

## AI Assistance

Generated with OpenAI Codex (`gpt-5.6-sol`, Codex 5.6 SOL). The final diff was reviewed against the repository contribution guidance and every maintainer review comment before submission.

## Contract handoff

- Domain guide: not applicable; no domain vocabulary changed.
- OpenAPI artifact: not applicable; no API contract changed.
- Migrations: not applicable; no models or migrations changed.
- Screenshots: not applicable; backend importer behavior only.

## Existing data

This prevents future incorrect imports. It does not automatically rewrite already stored history. The overwrite regression now verifies safe episode-history replacement, but users should still back up their database before using overwrite as a repair action.

## Human review

- [x] Maintainer review received; requested changes implemented in `f51d0a31`.
- [ ] Re-review completed.

Fixes #661.
Fixes #662.
