### PR TITLE
Allow custom MusicBrainz instance URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ The only universally required variable is `SECRET`. For Docker installs you shou
 - `HARDCOVER_API` - Hardcover book metadata/imports
 - `COMICVINE_API` - comic metadata
 - `LASTFM_API_KEY` - Last.fm integration and scrobble polling
+- `MUSICBRAINZ_URL` - custom MusicBrainz-compatible API root, including `/ws/2` (defaults to `https://musicbrainz.org/ws/2`)
 - `TRAKT_API` / `TRAKT_API_SECRET` - Trakt private-profile OAuth imports
 - `URLS` - your public URL if using a reverse proxy, for example `https://floppy.mydomain.com`
 - `ADMIN_ENABLED` - set to `True` to enable the Django admin interface at `/admin/` (see the [Admin Guide](https://github.com/dannyvfilms/Floppy/wiki/6.-Admin-and-Operations#admin-guide))

--- a/src/app/providers/musicbrainz.py
+++ b/src/app/providers/musicbrainz.py
@@ -17,7 +17,6 @@ from app.providers import services
 
 logger = logging.getLogger(__name__)
 
-BASE_URL = "https://musicbrainz.org/ws/2"
 COVER_ART_BASE = "https://coverartarchive.org"
 WIKIPEDIA_API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary"
 MIN_REQUEST_INTERVAL = 1.0  # MusicBrainz requires 1 req/sec for unauth requests
@@ -178,7 +177,7 @@ def _rate_limit():
 def _mb_request(endpoint, params=None):
     """Make a rate-limited request to the MusicBrainz API."""
     _rate_limit()
-    url = f"{BASE_URL}/{endpoint}"
+    url = f"{settings.MUSICBRAINZ_URL.rstrip('/')}/{endpoint}"
 
     if params is None:
         params = {}

--- a/src/app/tests/providers/test_musicbrainz.py
+++ b/src/app/tests/providers/test_musicbrainz.py
@@ -2,9 +2,35 @@ from unittest.mock import patch
 
 import requests
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from app.providers import musicbrainz
+
+
+class MusicBrainzRequestTests(SimpleTestCase):
+    """Test MusicBrainz request configuration."""
+
+    @override_settings(MUSICBRAINZ_URL="http://musicbrainz:5000/ws/2/")
+    def test_mb_request_uses_custom_instance_url(self):
+        with (
+            patch("app.providers.musicbrainz._rate_limit") as mock_rate_limit,
+            patch(
+                "app.providers.musicbrainz.services.api_request",
+                return_value={"id": "artist-mbid"},
+            ) as mock_api_request,
+        ):
+            data = musicbrainz._mb_request("artist/artist-mbid", {"inc": "genres"})
+
+        self.assertEqual(data, {"id": "artist-mbid"})
+        mock_rate_limit.assert_called_once_with()
+        self.assertEqual(
+            mock_api_request.call_args.args[2],
+            "http://musicbrainz:5000/ws/2/artist/artist-mbid",
+        )
+        self.assertEqual(
+            mock_api_request.call_args.kwargs["params"],
+            {"inc": "genres", "fmt": "json"},
+        )
 
 
 class MusicBrainzReleaseTests(SimpleTestCase):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1020,6 +1020,11 @@ IMG_NONE = "https://www.themoviedb.org/assets/2/v4/glyphicons/basic/glyphicons-b
 REQUEST_TIMEOUT = 120  # seconds
 PER_PAGE = 24
 
+MUSICBRAINZ_URL = config(
+    "MUSICBRAINZ_URL",
+    default="https://musicbrainz.org/ws/2",
+)
+
 TMDB_API = config(
     "TMDB_API",
     default=secret(


### PR DESCRIPTION
## Summary

- Add a `MUSICBRAINZ_URL` environment setting for self-hosted MusicBrainz-compatible metadata servers.
- Preserve the public `https://musicbrainz.org/ws/2` endpoint as the default.
- Normalize a trailing slash before composing provider request URLs.

## Problem

Music metadata requests are hard-coded to the public MusicBrainz API, so users running a local MusicBrainz mirror cannot direct Floppy's metadata refreshes to it. Fixes #571.

## Solution

Read the full MusicBrainz `/ws/2` API root from Django settings and use it for every MusicBrainz metadata request. Document the environment variable and add a focused regression test covering a self-hosted HTTP endpoint with a trailing slash. Cover Art Archive requests and the existing MusicBrainz rate limit are unchanged.

## AI Assistance

Generated with OpenAI Codex using `gpt-5.6-sol` (Codex 5.6 SOL). The agent implemented the change, reviewed the focused diff, and ran the validation recorded below.

## Validation

- `scripts/test.sh app.tests.providers.test_musicbrainz` — 12 tests passed.
- `uv run --no-sync ruff check src` — passed.
- `PYTHONPATH=mcp_server scripts/test.sh app.tests.test_api_contracts` — 47 tests passed.
- `PYTHONPATH=mcp_server scripts/test.sh app users integrations lists events api --exclude-tag slow --exclude-tag network` — 3,755 tests ran; 3 unchanged macOS-specific entrypoint tests failed because `/var` resolves to `/private/var` and Linux ownership/symlink behavior is unavailable on this host. The other 3,750 tests passed and 2 were skipped.
- `scripts/test.sh` — attempted; the unchanged SQLite recovery tests also require Linux `/proc/self/fd`, which is unavailable on this macOS host. Linux CI remains the authoritative full application gate.
- `git diff --check` — passed.

## Contract Handoff

- Domain guide regeneration/check outcome: Not applicable — no domain vocabulary changed.
- Verified OpenAPI regeneration outcome: Not applicable — no API schema changed.
- Contract-test outcome: 47 API contract tests passed; no contract artifact changed.

## Screenshots

Not applicable — backend configuration, provider, test, and documentation changes only; no template, CSS, layout, or UI behavior changed.

## Human Review

- [x] Pending human review.
- [ ] Completed — reviewer/evidence:

## Gstack QA

- [x] Pending `/gstack-qa`.
- [ ] Completed — report/outcome:

## Migration Sync Gate

Not applicable — this is not an `upstream` to `latest` sync PR and changes no models or migrations.

## Notes

- Fixes #571.
- The configured value must be the full MusicBrainz-compatible API root, including `/ws/2`.
- Self-hosted `http://` URLs are supported for private Docker/network deployments.
