### PR TITLE
🧪 Run the config and api apps in CI

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -90,8 +90,14 @@ jobs:
           # flaky, and a pull request from a fork cannot read repository secrets,
           # so they fail there regardless of the change. Run them deliberately
           # with scripts/test.sh --network.
+          #
+          # Keep this app list the same as APPS in scripts/test.sh. The runner
+          # names apps rather than discovering them, so an app that is missing
+          # here has no test on a pull request while it still passes locally.
+          # "config" holds the settings, the startup integrity check and the
+          # recovery page; "api" holds the endpoint and contract suites.
           uv run --no-sync coverage run src/manage.py test \
-            app users integrations lists events \
+            app users integrations lists events api config \
             --parallel --exclude-tag network
 
       - name: Build Coverage Report


### PR DESCRIPTION
## Summary

- Add `api` and `config` to the CI test app list, so it matches `scripts/test.sh`.
- Record the rule in a comment, so the two lists do not drift again.

Closes #811.

## Problem

`scripts/test.sh` runs seven Django apps:

```bash
APPS=(app users integrations lists events api config)
```

`.github/workflows/app-tests.yml` ran five:

```yaml
uv run --no-sync coverage run src/manage.py test \
  app users integrations lists events \
  --parallel --exclude-tag network
```

`api` and `config` were missing. Every test under `src/api/tests/` and
`src/config/tests/` passed locally and never ran on a pull request.

## What was not covered

`src/config/tests/` holds nine modules:

| Module | What it protects |
|---|---|
| `test_gunicorn.py` | the Gunicorn configuration loads, and the fork hooks close database and Redis pools (#341, #335) |
| `test_sqlite_integrity.py` | the startup integrity check |
| `test_sqlite_recovery_server.py` | the recovery page |
| `test_settings_secrets.py` | secret loading and precedence |
| `test_settings_metadata.py` | settings metadata |
| `test_login_required.py` | the global authentication gate |
| `test_migration_hygiene.py` | migration graph hygiene |
| `test_runtime_profile.py` | host-derived worker sizing |

`src/api/tests/` holds 31 modules, including the endpoint, authentication, and
contract suites.

## Why it matters

PR #780 fixed the same gap in `scripts/test.sh`, and the comment added there
records the reason:

> "config" holds the settings, the startup integrity check and the recovery
> page. Leaving it out let a helper that nothing called, and a report that
> always raised, both ship under a green suite (PR #780).

The workflow was never updated to match. A change confined to `src/config/`
could still merge with a green tick and no test behind it.

This is live right now. PR #786 changes `src/config/__init__.py` and
`src/config/gunicorn.py`. It is covered only because its regression tests
happen to live in `src/app/tests/`, which does run. That is luck, not design.

## Validation

Ran the two added apps under the exact invocation CI uses:

```
$ SECRET=test-only python src/manage.py test api config \
    --parallel --exclude-tag network
Ran 566 tests in 45.035s
OK
```

566 tests, 45 seconds. The added cost to the job is small next to its current
23 minute run.

Note that CI excludes only the `network` tag, not `slow`, so
`test_history_benchmarks.py` (`@tag("slow", "benchmark")`) now runs on a pull
request as well. It is included in the run above and passes.

## Why this pull request holds nothing else

`app-tests.yml` guards itself twice. The workflow does not trigger on a
workflow change at all:

```yaml
on:
  pull_request:
    paths-ignore:
      - ".github/workflows/**"
```

and a job fails any pull request that reaches it with a workflow change:

```yaml
- name: Fail if workflows were modified
  if: steps.changes.outputs.workflows == 'true'
  run: |
    echo "::error::Workflow files were modified in this PR."
    exit 1
```

Either guard alone stops this change from travelling with code, so it has to be
a workflow-only pull request.

**One consequence a reviewer should know.** Because of `paths-ignore`, the App
Tests workflow does not run on this pull request, so **the new app list is not
exercised here**. It first runs on the push to `latest` after this merges. A
broken list would therefore go green here and fail on `latest`.

That risk is covered by running the exact CI invocation locally, which is the
566-test result above. Anyone re-checking this can reproduce it with:

```bash
SECRET=test-only uv run --no-sync python src/manage.py test api config \
  --parallel --exclude-tag network
```

## Prevention

The comment added above the app list states the rule directly: keep this list
the same as `APPS` in `scripts/test.sh`. The runner names apps rather than
discovering them, so any *new* Django app stays invisible to CI until someone
adds it by hand.

## Found by

`/qa` on PR #786 (branch `fix/redact-runtime-log-output`), 2026-08-16.

## AI assistance

- `Claude Opus 5` (`/qa`): found the gap while checking whether PR #786's changes to `src/config/` were covered by CI, verified the two apps under CI's invocation, and wrote this change.
