### PR TITLE
Stabilize SQLite entrypoint parking test

### DIFF
--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -1042,6 +1042,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "FLOPPY_DB_PATH": db_path,
                 "PATH": f"{bin_path}:{os.environ['PATH']}",
                 "PYTHONPATH": str(ENTRYPOINT.parent / "src"),
+                "VIRTUAL_ENV": "",
             }
             output_path = tmp_path / "entrypoint-term.log"
             with output_path.open("w") as output:

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -932,14 +932,18 @@ class SqliteIntegrityTests(SimpleTestCase):
             wrappers = {
                 "python": (
                     "#!/bin/sh\n"
-                    'case "$2" in\n'
+                    'case "$*" in\n'
                     "  *check_database_integrity*)\n"
                     '    echo "[entrypoint] bounded integrity failure" >&2\n'
                     "    exit 1\n"
                     "    ;;\n"
+                    "  *config.sqlite_recovery_server*)\n"
+                    "    exit 0\n"
+                    "    ;;\n"
                     "esac\n"
                     f'exec "{sys.executable}" "$@"\n'
                 ),
+                "timeout": '#!/bin/sh\nshift\nexec "$@"\n',
                 "sleep": (
                     "#!/bin/sh\n"
                     'echo "$$" > "$PARKING_PID_FILE"\n'
@@ -959,6 +963,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "FLOPPY_DB_PATH": db_path,
                 "PATH": f"{bin_path}:{os.environ['PATH']}",
                 "PYTHONPATH": str(ENTRYPOINT.parent / "src"),
+                "VIRTUAL_ENV": "",
             }
             output_path = tmp_path / "entrypoint.log"
             with output_path.open("w") as output:


### PR DESCRIPTION
## Summary
- Make the SQLite entrypoint parking regression test deterministic.
- Keep the repair test-only and separate from PR #792.

## Problem
`test_entrypoint_parks_once_instead_of_polling_exited_checker` inherits `VIRTUAL_ENV` from the test runner. The entrypoint correctly prepends that environment to `PATH`, which bypasses the test's command wrappers. The test then starts the real recovery server and only reaches its asserted parking `sleep` when that server exits, making the result depend on platform, port state, and test order.

This was the only failure after 3,981 tests in PR #792's application suite and reproduced as a targeted failure locally on the unchanged `latest` entrypoint/test code.

## Solution
- Clear `VIRTUAL_ENV` in this test subprocess so its explicit wrapper directory stays first.
- Add a portable `timeout` wrapper.
- Match the complete Python argument list and exit the recovery-server stub cleanly before asserting the fallback parking loop.

Production entrypoint behavior is unchanged.

## AI Assistance
Generated with OpenAI Codex (`gpt-5.6-sol`, Codex 5.6 SOL).

## Validation
- Targeted test before the patch — failed locally with `parking_child_before_term == False`.
- Targeted test after the patch — passed once, then passed five consecutive repeat runs.
- `uv run --no-sync ruff check src/config/tests/test_sqlite_integrity.py` — passed.
- `git diff --check` — passed.
- Full SQLite integrity module was attempted on macOS, but its backup-path cases require Linux `/proc/self/fd`; those platform failures are unrelated to this test-only patch. The hosted Linux application suite is the authoritative module/full-suite gate.

## Contract Handoff
- Domain guide regeneration/check outcome: Not applicable; no domain vocabulary changes.
- Verified OpenAPI regeneration outcome: Not applicable; no API changes.
- Contract-test outcome: Not applicable; no contract changes.

## Human Review
- [x] Pending human review.
- [x] Completed — reviewer/evidence:

## Gstack QA
- [x] Pending `/gstack-qa`.
- [x] Completed — report/outcome:

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
Not applicable; this is not an upstream sync PR and contains no migrations.

## Notes
- Fixes #825.
- This repair is intentionally not included in PR #792.
