### PR TITLE
test(config): stop the parking test depending on whether port 8000 is free

### DIFF
--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -18,6 +18,12 @@ from config.sqlite_integrity import check_database_integrity
 
 ENTRYPOINT = Path(__file__).resolve().parents[3] / "entrypoint.sh"
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
+# How long to wait for the entrypoint shell script to reach the state under
+# test. This budget covers process startup on a shared runner, not the timing of
+# the behaviour itself, so it is generous on purpose: five seconds was enough on
+# an idle machine and ran out on CI, which failed the assertion that followed as
+# if the entrypoint had misbehaved.
+_STARTUP_WAIT_SECONDS = 60
 
 
 class SqliteIntegrityTests(SimpleTestCase):
@@ -970,7 +976,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     stderr=output,
                     text=True,
                 )
-                deadline = time.monotonic() + 5
+                deadline = time.monotonic() + _STARTUP_WAIT_SECONDS
                 while (
                     (
                         "SQLite startup is paused" not in output_path.read_text()
@@ -996,8 +1002,17 @@ class SqliteIntegrityTests(SimpleTestCase):
                 process.wait(timeout=5)
             output = output_path.read_text()
 
-            self.assertTrue(parked_before_term)
-            self.assertTrue(parking_child_before_term)
+            # Report the entrypoint log on failure. Without it these read as
+            # "False is not true", which does not say whether the entrypoint
+            # behaved wrongly or simply had not started yet.
+            self.assertTrue(
+                parked_before_term,
+                f"entrypoint exited instead of parking. Log:\n{output}",
+            )
+            self.assertTrue(
+                parking_child_before_term,
+                f"no live parking child was found. Log:\n{output}",
+            )
             self.assertEqual(process.returncode, 0)
             self.assertEqual(output.count("bounded integrity failure"), 1)
             self.assertNotIn("Still checking SQLite integrity", output)
@@ -1048,7 +1063,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     stderr=output,
                     text=True,
                 )
-                deadline = time.monotonic() + 5
+                deadline = time.monotonic() + _STARTUP_WAIT_SECONDS
                 while (
                     "checker waiting" not in output_path.read_text()
                     and time.monotonic() < deadline

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -18,16 +18,11 @@ from config.sqlite_integrity import check_database_integrity
 
 ENTRYPOINT = Path(__file__).resolve().parents[3] / "entrypoint.sh"
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
-# How long to wait for the entrypoint shell script to reach the state under
-# test. This budget covers process startup on a shared runner, not the timing of
-# the behaviour itself, so it is generous on purpose: five seconds was enough on
-# an idle machine and ran out on CI, which failed the assertion that followed as
-# if the entrypoint had misbehaved.
-_STARTUP_WAIT_SECONDS = 60
-# Same reasoning for the wait after terminate(). Handling SIGTERM should be
-# quick, so this is a smaller risk than the startup poll, but it is the same
-# tight bound on the same loaded runner.
-_SHUTDOWN_WAIT_SECONDS = 30
+# The entrypoint reaches the state under test in well under a second once it is
+# not waiting on a live recovery server, so a short bound is correct here and
+# reports a deadlock quickly instead of hiding one.
+_STARTUP_WAIT_SECONDS = 5
+_SHUTDOWN_WAIT_SECONDS = 5
 
 
 class SqliteIntegrityTests(SimpleTestCase):
@@ -947,13 +942,27 @@ class SqliteIntegrityTests(SimpleTestCase):
                     '    echo "[entrypoint] bounded integrity failure" >&2\n'
                     "    exit 1\n"
                     "    ;;\n"
+                    # The real recovery page binds port 8000 and serves until it
+                    # is stopped. The entrypoint waits on it, and only parks in
+                    # the sleep loop this test measures once it exits. Whether
+                    # that happens depended on whether port 8000 was already
+                    # taken on the machine running the suite: taken, and the
+                    # server gave up and the test passed; free, and it served
+                    # forever and the test timed out. Exit here so the path under
+                    # test is reached either way.
+                    "  *sqlite_recovery_server*)\n"
+                    "    exit 0\n"
+                    "    ;;\n"
                     "esac\n"
                     f'exec "{sys.executable}" "$@"\n'
                 ),
                 "sleep": (
                     "#!/bin/sh\n"
                     'echo "$$" > "$PARKING_PID_FILE"\n'
-                    "exec /bin/sleep 30\n"
+                    # Sleep for what the entrypoint asked for. A fixed shorter
+                    # sleep ends, the parking loop starts another one, and the
+                    # pid file is overwritten while the test is reading it.
+                    'exec /bin/sleep "$@"\n'
                 ),
             }
             for name, script in wrappers.items():
@@ -1031,6 +1040,9 @@ class SqliteIntegrityTests(SimpleTestCase):
             )
             self.assertEqual(process.returncode, 0)
             self.assertEqual(output.count("bounded integrity failure"), 1)
+            # The point of the test: park once. Running the check again means
+            # the outer loop spun instead of parking.
+            self.assertEqual(output.count("Checking SQLite storage"), 1, output)
             self.assertNotIn("Still checking SQLite integrity", output)
             self.assertIn("SQLite startup is paused", output)
             self.assertNotIn("exceeded its 600s timeout", output)

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -24,6 +24,10 @@ _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
 # an idle machine and ran out on CI, which failed the assertion that followed as
 # if the entrypoint had misbehaved.
 _STARTUP_WAIT_SECONDS = 60
+# Same reasoning for the wait after terminate(). Handling SIGTERM should be
+# quick, so this is a smaller risk than the startup poll, but it is the same
+# tight bound on the same loaded runner.
+_SHUTDOWN_WAIT_SECONDS = 30
 
 
 class SqliteIntegrityTests(SimpleTestCase):
@@ -999,7 +1003,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     except ProcessLookupError:
                         pass
                 process.terminate()
-                process.wait(timeout=5)
+                process.wait(timeout=_SHUTDOWN_WAIT_SECONDS)
             output = output_path.read_text()
 
             # Report the entrypoint log on failure. Without it these read as
@@ -1070,7 +1074,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 ):
                     time.sleep(0.02)
                 process.terminate()
-                process.wait(timeout=5)
+                process.wait(timeout=_SHUTDOWN_WAIT_SECONDS)
             output = output_path.read_text()
 
             self.assertEqual(process.returncode, 0)

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -980,7 +980,8 @@ class SqliteIntegrityTests(SimpleTestCase):
                     stderr=output,
                     text=True,
                 )
-                deadline = time.monotonic() + _STARTUP_WAIT_SECONDS
+                started_waiting = time.monotonic()
+                deadline = started_waiting + _STARTUP_WAIT_SECONDS
                 while (
                     (
                         "SQLite startup is paused" not in output_path.read_text()
@@ -989,6 +990,12 @@ class SqliteIntegrityTests(SimpleTestCase):
                     and time.monotonic() < deadline
                 ):
                     time.sleep(0.02)
+                # Two different faults leave parking_child_before_term False: the
+                # wait ran out before the pid file appeared, or the pid file
+                # appeared and the process it names had already exited. They need
+                # opposite fixes, so record which one happened.
+                waited_seconds = time.monotonic() - started_waiting
+                pid_file_appeared = (tmp_path / "parking.pid").is_file()
                 parked_before_term = process.poll() is None
                 parking_pid = (
                     int((tmp_path / "parking.pid").read_text())
@@ -1015,7 +1022,12 @@ class SqliteIntegrityTests(SimpleTestCase):
             )
             self.assertTrue(
                 parking_child_before_term,
-                f"no live parking child was found. Log:\n{output}",
+                "no live parking child was found after "
+                f"{waited_seconds:.2f}s of {_STARTUP_WAIT_SECONDS}s. "
+                f"parking.pid present: {pid_file_appeared}. "
+                "A pid file that never appeared means startup was too slow. "
+                "A pid file naming a dead process means the parking child "
+                f"exited, which no wait can fix. Log:\n{output}",
             )
             self.assertEqual(process.returncode, 0)
             self.assertEqual(output.count("bounded integrity failure"), 1)


### PR DESCRIPTION
## Summary

`config.tests.test_sqlite_integrity.test_entrypoint_parks_once_instead_of_polling_exited_checker` fails on every CI run and passes on every developer machine. The cause is not timing. The test depends on whether TCP port 8000 happens to be free.

- Stub the recovery page so the entrypoint reaches the path under test either way.
- Sleep for the interval the entrypoint asked for, not a shorter fixed one.
- Assert the storage check ran exactly once, which is what "parks once" means.
- Report which fault occurred when no parking child is found.

## Root cause

`config/sqlite_recovery_server.py` hard codes `_PORT = 8000`. It has two outcomes:

```
bind succeeds -> server.serve_forever()          # runs until stopped
bind fails    -> "Could not use port 8000" ; return
```

`entrypoint.sh` starts it in the background and waits on it. Only after it exits does the entrypoint reach the `sleep 86400` parking loop, and that loop is what the test measures, through a stubbed `sleep` that writes its pid to `PARKING_PID_FILE`.

So the outcome is decided by the machine:

| Port 8000 | Recovery page | Entrypoint | Test |
|---|---|---|---|
| taken | gives up, exits | reaches the sleep loop, writes `parking.pid` | passes |
| free | serves forever | waits on it, never parks in the loop | times out |

Developer machines commonly have something on 8000. On this one it is a rootless port forwarder. CI has nothing there.

That explains the shape of the evidence, which no timing theory does: **4 failures out of 4 CI runs across two unrelated PRs**, one changing only a template and a test, and consistent passes locally.

## Reproduced, both directions

Same machine, same commit, the only variable being port 8000. Freed by running the suite in a private network namespace:

| Condition | Before this PR | After |
|---|---|---|
| 8000 taken | pass, 0.35s | pass, 0.51s |
| 8000 free | **fail, 60.02s**, `parking.pid present: False` | **pass, 0.49s** |

Full suite, both states: 43 tests, all pass.

## A wrong turn, recorded

The first commits on this branch raised the waits from 5s to 60s and 30s, on the theory that a shared runner was too slow to start the process in time. That theory was wrong. No wait can fix a script that is waiting on a server which never exits; the longer bound only made the failure take a minute.

Two things caught it. An outside review pointed out that the failing assertion has two possible causes, a wait that ran out or a pid file naming a process that had already exited, and that I had assumed the first. Adding that diagnostic is what made the real cause visible: the reproduction reported `parking.pid present: False` after the full wait, which pointed at the entrypoint never reaching the loop rather than at slow startup.

The waits are restored to 5s. The test reaches its state in under a second, so a short bound is right and reports a deadlock quickly instead of hiding one.

## Second defect in the stub

The `sleep` stub ran `exec /bin/sleep 30` while the entrypoint asks for `sleep 86400`. After 30 seconds the stub exits, the parking loop starts another one, and `parking.pid` is overwritten while the test is reading it. It now passes the requested interval through.

## What this test no longer covers

Stubbing the recovery page means this test no longer executes the page itself, its socket bind, or `serve_forever`. That is the right trade for this test, whose subject is the shell script's parking behaviour, but it leaves a real gap: when port 8000 is free the entrypoint parks by waiting on the live server, and nothing covers that path. Worth its own test rather than conflating the two.

## Product defect worth a separate issue

The recovery page port is hard coded to 8000, the port the app publishes on. A self-hoster who already uses 8000 and whose database then needs recovery gets a parked container and no page, and has to find the HTML file written beside the database. Reading the port from the environment would fix it. Not changed here, because this is a test-only PR.

## Validation

- `manage.py test config.tests.test_sqlite_integrity` — 43 tests, pass with port 8000 taken and with it free.
- `ruff check src` — clean.

## Risk

Test-only. No application code changes.

## Relationships

- Found while landing #832, whose CI showed this as its only failure. Blocks #829, #832, and #836, which all fail on it.
- Duplicate #835 was opened independently and closed in favour of this PR; the diagnostic assertion suggested there is included.
- The affected suite belongs to the SQLite startup guard, #593.
