### PR TITLE
🧪 Stop the entrypoint tests reporting a busy CI runner as a broken entrypoint

### DIFF
--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -17,6 +17,16 @@ from config import sqlite_integrity
 from config.sqlite_integrity import check_database_integrity
 
 ENTRYPOINT = Path(__file__).resolve().parents[3] / "entrypoint.sh"
+
+# The entrypoint tests below poll for a condition and continue the moment it
+# holds, so these bounds only take effect when something is actually wrong. That
+# makes a generous value free on the passing path and a tight one expensive: CI
+# runs this suite in parallel across four thousand tests, and the parking path
+# starts the recovery server, which is a cold Django import competing for CPU
+# with everything else. Five seconds was not enough for that, so the tests
+# reported a busy runner as a broken entrypoint.
+ENTRYPOINT_STARTUP_TIMEOUT = 60
+ENTRYPOINT_SHUTDOWN_TIMEOUT = 30
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
 
 
@@ -970,7 +980,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     stderr=output,
                     text=True,
                 )
-                deadline = time.monotonic() + 5
+                deadline = time.monotonic() + ENTRYPOINT_STARTUP_TIMEOUT
                 while (
                     (
                         "SQLite startup is paused" not in output_path.read_text()
@@ -993,7 +1003,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     except ProcessLookupError:
                         pass
                 process.terminate()
-                process.wait(timeout=5)
+                process.wait(timeout=ENTRYPOINT_SHUTDOWN_TIMEOUT)
             output = output_path.read_text()
 
             self.assertTrue(parked_before_term)
@@ -1048,14 +1058,14 @@ class SqliteIntegrityTests(SimpleTestCase):
                     stderr=output,
                     text=True,
                 )
-                deadline = time.monotonic() + 5
+                deadline = time.monotonic() + ENTRYPOINT_STARTUP_TIMEOUT
                 while (
                     "checker waiting" not in output_path.read_text()
                     and time.monotonic() < deadline
                 ):
                     time.sleep(0.02)
                 process.terminate()
-                process.wait(timeout=5)
+                process.wait(timeout=ENTRYPOINT_SHUTDOWN_TIMEOUT)
             output = output_path.read_text()
 
             self.assertEqual(process.returncode, 0)


### PR DESCRIPTION
## The problem

`config.tests.test_sqlite_integrity.SqliteIntegrityTests.test_entrypoint_parks_once_instead_of_polling_exited_checker`
is the **only** failure on `latest`, and it has failed on the last six runs of
that branch:

```
failure  2026-08-16T21:29:46Z  1fda39c6
failure  2026-08-16T20:25:21Z  c264da69
failure  2026-08-16T19:39:51Z  914215be
failure  2026-08-16T19:25:43Z  4a37a8ad
failure  2026-08-16T19:20:51Z  6372457c
failure  2026-08-16T18:21:04Z  5970b012
```

The entrypoint is fine. The test runs out of patience.

## Why

Both entrypoint tests start the real `entrypoint.sh` and poll for a condition
with a five second bound. The parking path reaches its condition only after
`python -m config.sqlite_recovery_server` has started, which is a cold Django
import. CI runs this suite with `--parallel` across ~4000 tests, so that import
competes for CPU with everything else.

Measured on an idle machine, the same test completes in **1.5s** — which is
exactly why it passes locally and fails in CI.

## The fix

These loops continue the moment their condition holds, so the bound only takes
effect when something is genuinely wrong. A generous value is therefore free on
the passing path and a tight one is expensive. Both bounds are now named and
raised, with the reasoning recorded where the next person will read it.

No behaviour under test changes; no production code is touched.

## Verification

- The two affected tests pass
- Full `config` suite: 121 tests, all pass
- `ruff check src` clean

## Context

Found while working on #597 / #830, whose CI showed this same single failure.
Landing it separately so the fix is reviewable on its own and unblocks `latest`
rather than riding along with a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)