### PR TITLE
fix: keep Discover missing artwork provider-neutral

### DIFF
--- a/src/app/discover/artwork.py
+++ b/src/app/discover/artwork.py
@@ -19,11 +19,18 @@ logger = logging.getLogger(__name__)
 ROW_CACHE_TTL_SECONDS = 60 * 60
 ROW_CACHE_TTL_LOCAL_SECONDS = 60 * 30
 
-PROVIDER_ARTWORK_HYDRATION_ROW_KEYS = {
+RANKED_ARTWORK_ROW_KEYS = {
     "trending_right_now",
     "all_time_greats_unseen",
     "coming_soon",
 }
+VIDEO_ARTWORK_MEDIA_TYPES = frozenset(
+    {
+        MediaTypes.MOVIE.value,
+        MediaTypes.TV.value,
+        MediaTypes.ANIME.value,
+    },
+)
 PROVIDER_ARTWORK_HYDRATION_PROVIDERS = frozenset(
     {
         (MediaTypes.BOARDGAME.value, Sources.BGG.value),
@@ -43,7 +50,7 @@ LEGACY_IMG_NONE_VALUES = frozenset(
         ),
         (
             "data:image/svg+xml;base64,"
-            "PHN2ZyBpZD0iZ2x5cGhpY29ucy1iYXNpYyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMzIgMzIiPgogIDxwYXRoIGZpbGw9IiNiNWI1YjUiIGlkPSJwaWN0dXJlIiBkPSJNMjcuNSw1SDQuNUExLjUwMDA4LDEuNTAwMDgsMCwwLDAsMyw2LjV2MTlBMS41MDAwOCwxLjUwMDA4LDAsMCwwLDQuNSwyN2gyM0ExLjUwMDA4LDEuNTAwMDgsMCwwLDAsMjksMjUuNVY2LjVBMS41MDAwOCwxLjUwMDA4LDAsMCwwLDI3LjUsNVpNMjYsMTguNWwtNC43OTQyNS01LjIzMDFhLjk5MzgzLjk5MzgzLDAsMCAwLTEuNDQ0MjgtLjAzMTM3bC01LjM0NzQxLDUuMzQ3NDFMMTkuODI4MTIsMjRIMTdsLTQuNzkyOTEtNC43OTNhMS4wMDAyMiwxLjAwMDIyLDAsMCAwLTEuNDE0MTgsMEw2LDI0VjhIMjZabS0xNy45LTZhMi40LDIuNCwwLDEsMSwyLjQsMi40QTIuNDAwMDUsMi40MDAwNSwwLDAsMSw4LjEsMTIuNVoiLz4KPC9zdmc+Cg=="
+            "PHN2ZyBpZD0iZ2x5cGhpY29ucy1iYXNpYyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMzIgMzIiPgogIDxwYXRoIGZpbGw9IiNiNWI1YjUiIGlkPSJwaWN0dXJlIiBkPSJNMjcuNSw1SDQuNUExLjUwMDA4LDEuNTAwMDgsMCwwLDAsMyw2LjV2MTlBMS41MDAwOCwxLjUwMDA4LDAsMCwwLDQuNSwyN2gyM0ExLjUwMDAwOCwxLjUwMDA4LDAsMCwwLDAsMjksMjUuNVY2LjVBMS41MDAwOCwxLjUwMDA4LDAsMCwwLDI3LjUsNVpNMjYsMTguNWwtNC43OTQyNS01LjIzMDFhLjk5MzgzLjk5MzgzLDAsMCAwLTEuNDQ0MjgtLjAzMTM3bC01LjM0NzQxLDUuMzQ3NDFMMTkuODI4MTIsMjRIMTdsLTQuNzkyOTEtNC43OTNhMS4wMDAyMiwxLjAwMDIyLDAsMCAwLTEuNDE0MTgsMEw2LDI0VjhIMjZabS0xNy45LTZhMi40LDIuNCwwLDEsMSwyLjQsMi40QTIuNDAwMDUsMi40MDAwNSwwLDAsMSw4LjEsMTIuNVoiLz4KPC9zdmc+Cg=="
         ),
     },
 )
@@ -161,24 +168,19 @@ def _hydrate_provider_ranked_artwork(
     _hydrate_missing_artwork(display_candidates, allow_remote=allow_remote)
 
 
-def _hydrate_trakt_ranked_artwork(
+def _hydrate_ranked_video_artwork(
     media_type: str,
     candidates: list[CandidateItem],
     *,
     allow_remote: bool = True,
     hydrate_limit: int = MAX_ITEMS_PER_ROW,
 ) -> None:
-    """Hydrate missing artwork for displayed Trakt-ranked candidates."""
-    if media_type not in {
-        MediaTypes.MOVIE.value,
-        MediaTypes.TV.value,
-        MediaTypes.ANIME.value,
-    }:
+    """Hydrate missing artwork for displayed ranked video candidates."""
+    if media_type not in VIDEO_ARTWORK_MEDIA_TYPES:
         return
 
-    # Trakt ranks the row. CandidateItem.source owns the metadata identity used
-    # for local and remote artwork, so a different mapping/provider can be
-    # introduced without changing this hydration path.
+    # The row source owns ranking. CandidateItem.source owns metadata identity,
+    # so ranking and metadata providers can change independently.
     display_candidates = [
         candidate
         for candidate in candidates[:hydrate_limit]
@@ -218,23 +220,18 @@ def hydrate_visible_row_artwork(
     if not effective_media_type:
         return
 
-    if effective_media_type in {
-        MediaTypes.MOVIE.value,
-        MediaTypes.TV.value,
-        MediaTypes.ANIME.value,
-    } and row.key in {
-        "trending_right_now",
-        "all_time_greats_unseen",
-        "coming_soon",
-    }:
-        _hydrate_trakt_ranked_artwork(
+    if (
+        effective_media_type in VIDEO_ARTWORK_MEDIA_TYPES
+        and row.key in RANKED_ARTWORK_ROW_KEYS
+    ):
+        _hydrate_ranked_video_artwork(
             effective_media_type,
             row.items,
             allow_remote=allow_remote,
         )
         return
 
-    if row.source == "provider" and row.key in PROVIDER_ARTWORK_HYDRATION_ROW_KEYS:
+    if row.source == "provider" and row.key in RANKED_ARTWORK_ROW_KEYS:
         _hydrate_provider_ranked_artwork(
             row.items,
             allow_remote=allow_remote,

--- a/src/app/discover/artwork.py
+++ b/src/app/discover/artwork.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 
-from app.discover.adapters import TMDB_ADAPTER
 from app.discover.service_helpers import MAX_ITEMS_PER_ROW
 from app.models import Item, MediaTypes, Sources
 from app.providers import services
@@ -25,6 +24,29 @@ PROVIDER_ARTWORK_HYDRATION_ROW_KEYS = {
     "all_time_greats_unseen",
     "coming_soon",
 }
+PROVIDER_ARTWORK_HYDRATION_PROVIDERS = frozenset(
+    {
+        (MediaTypes.BOARDGAME.value, Sources.BGG.value),
+        (MediaTypes.MUSIC.value, Sources.MUSICBRAINZ.value),
+    },
+)
+
+# These values can remain in persisted rows or cached Discover payloads after
+# the configured placeholder changes. Keep exact historical values here instead
+# of importing a migration at runtime; migrations must remain deterministic.
+LEGACY_IMG_NONE_VALUES = frozenset(
+    {
+        (
+            "https://www.themoviedb.org/assets/2/v4/glyphicons/basic/"
+            "glyphicons-basic-38-picture-grey-"
+            "c2ebdbb057f2a7614185931650f8cee23fa137b93812ccb132b9df511df1cfac.svg"
+        ),
+        (
+            "data:image/svg+xml;base64,"
+            "PHN2ZyBpZD0iZ2x5cGhpY29ucy1iYXNpYyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMzIgMzIiPgogIDxwYXRoIGZpbGw9IiNiNWI1YjUiIGlkPSJwaWN0dXJlIiBkPSJNMjcuNSw1SDQuNUExLjUwMDA4LDEuNTAwMDgsMCwwLDAsMyw2LjV2MTlBMS41MDAwOCwxLjUwMDA4LDAsMCwwLDQuNSwyN2gyM0ExLjUwMDA4LDEuNTAwMDgsMCwwLDAsMjksMjUuNVY2LjVBMS41MDAwOCwxLjUwMDA4LDAsMCwwLDI3LjUsNVpNMjYsMTguNWwtNC43OTQyNS01LjIzMDFhLjk5MzgzLjk5MzgzLDAsMCAwLTEuNDQ0MjgtLjAzMTM3bC01LjM0NzQxLDUuMzQ3NDFMMTkuODI4MTIsMjRIMTdsLTQuNzkyOTEtNC43OTNhMS4wMDAyMiwxLjAwMDIyLDAsMCAwLTEuNDE0MTgsMEw2LDI0VjhIMjZabS0xNy45LTZhMi40LDIuNCwwLDEsMSwyLjQsMi40QTIuNDAwMDUsMi40MDAwNSwwLDAsMSw4LjEsMTIuNVoiLz4KPC9zdmc+Cg=="
+        ),
+    },
+)
 
 
 def _row_ttl_seconds(row_definition: RowDefinition) -> int:
@@ -35,26 +57,47 @@ def _row_ttl_seconds(row_definition: RowDefinition) -> int:
     )
 
 
+def _is_missing_image_value(image: str | None) -> bool:
+    """Return whether an image value represents missing artwork."""
+    return (
+        not image
+        or image == settings.IMG_NONE
+        or image in LEGACY_IMG_NONE_VALUES
+    )
+
+
 def _is_missing_image(candidate: CandidateItem) -> bool:
-    return not candidate.image or candidate.image == settings.IMG_NONE
+    return _is_missing_image_value(candidate.image)
 
 
-def _provider_media_type_for_artwork(candidate_media_type: str) -> str | None:
-    if candidate_media_type == MediaTypes.MOVIE.value:
-        return MediaTypes.MOVIE.value
-    if candidate_media_type in {MediaTypes.TV.value, MediaTypes.ANIME.value}:
-        return MediaTypes.TV.value
-    return None
+def _local_images_for_candidates(
+    candidates: list[CandidateItem],
+) -> dict[tuple[str, str, str], str]:
+    """Return usable local artwork keyed by normalized candidate identity."""
+    identities = {candidate.identity() for candidate in candidates}
+    if not identities:
+        return {}
+
+    items = Item.objects.filter(
+        media_id__in={candidate.media_id for candidate in candidates},
+        media_type__in={candidate.media_type for candidate in candidates},
+        source__in={candidate.source for candidate in candidates},
+    ).only("media_type", "source", "media_id", "image")
+
+    local_images = {}
+    for item in items:
+        identity = (item.media_type, item.source, str(item.media_id))
+        if identity not in identities or _is_missing_image_value(item.image):
+            continue
+        local_images[identity] = item.image
+    return local_images
 
 
 def _supports_provider_artwork_hydration(candidate: CandidateItem) -> bool:
     return (
-        candidate.media_type == MediaTypes.BOARDGAME.value
-        and candidate.source == Sources.BGG.value
-    ) or (
-        candidate.media_type == MediaTypes.MUSIC.value
-        and candidate.source == Sources.MUSICBRAINZ.value
-    )
+        candidate.media_type,
+        candidate.source,
+    ) in PROVIDER_ARTWORK_HYDRATION_PROVIDERS
 
 
 def _hydrate_provider_ranked_artwork(
@@ -78,16 +121,7 @@ def _hydrate_provider_ranked_artwork(
     if not missing:
         return
 
-    local_images = {
-        (item.media_type, item.source, str(item.media_id)): item.image
-        for item in Item.objects.filter(
-            media_id__in=[candidate.media_id for candidate in missing],
-            media_type__in=[MediaTypes.BOARDGAME.value, MediaTypes.MUSIC.value],
-            source__in=[Sources.BGG.value, Sources.MUSICBRAINZ.value],
-        ).only("media_type", "source", "media_id", "image")
-        if item.image and item.image != settings.IMG_NONE
-    }
-
+    local_images = _local_images_for_candidates(missing)
     for candidate in missing:
         local_image = local_images.get(candidate.identity())
         if local_image:
@@ -116,7 +150,7 @@ def _hydrate_provider_ranked_artwork(
             continue
 
         image = (metadata or {}).get("image")
-        if image and image != settings.IMG_NONE:
+        if not _is_missing_image_value(image):
             candidate.image = image
 
 
@@ -127,16 +161,21 @@ def _hydrate_trakt_ranked_artwork(
     allow_remote: bool = True,
     hydrate_limit: int = MAX_ITEMS_PER_ROW,
 ) -> None:
-    """Hydrate missing artwork for displayed Trakt-ranked TMDB candidates."""
-    provider_media_type = _provider_media_type_for_artwork(media_type)
-    if provider_media_type is None:
+    """Hydrate missing artwork for displayed Trakt-ranked candidates."""
+    if media_type not in {
+        MediaTypes.MOVIE.value,
+        MediaTypes.TV.value,
+        MediaTypes.ANIME.value,
+    }:
         return
 
+    # Trakt ranks the row. CandidateItem.source owns the metadata identity used
+    # for local and remote artwork, so a different mapping/provider can be
+    # introduced without changing this hydration path.
     display_candidates = [
         candidate
         for candidate in candidates[:hydrate_limit]
         if candidate.media_type == media_type
-        and candidate.source == TMDB_ADAPTER.provider
     ]
     if not display_candidates:
         return
@@ -147,18 +186,9 @@ def _hydrate_trakt_ranked_artwork(
     if not missing:
         return
 
-    local_images = {
-        str(item.media_id): item.image
-        for item in Item.objects.filter(
-            media_type=media_type,
-            source=TMDB_ADAPTER.provider,
-            media_id__in=[candidate.media_id for candidate in missing],
-        ).only("media_id", "image")
-        if item.image and item.image != settings.IMG_NONE
-    }
-
+    local_images = _local_images_for_candidates(missing)
     for candidate in missing:
-        local_image = local_images.get(str(candidate.media_id))
+        local_image = local_images.get(candidate.identity())
         if local_image:
             candidate.image = local_image
 
@@ -170,20 +200,22 @@ def _hydrate_trakt_ranked_artwork(
             continue
         try:
             metadata = services.get_media_metadata(
-                provider_media_type,
+                candidate.media_type,
                 candidate.media_id,
-                TMDB_ADAPTER.provider,
+                candidate.source,
             )
         except Exception as error:
             logger.warning(
-                "discover_tmdb_artwork_lookup_failed media_id=%s error=%s",
+                "discover_artwork_lookup_failed media_type=%s source=%s media_id=%s error=%s",
+                candidate.media_type,
+                candidate.source,
                 candidate.media_id,
                 error,
             )
             continue
 
         image = (metadata or {}).get("image")
-        if image:
+        if not _is_missing_image_value(image):
             candidate.image = image
 
 

--- a/src/app/discover/artwork.py
+++ b/src/app/discover/artwork.py
@@ -93,96 +93,13 @@ def _local_images_for_candidates(
     return local_images
 
 
-def _supports_provider_artwork_hydration(candidate: CandidateItem) -> bool:
-    return (
-        candidate.media_type,
-        candidate.source,
-    ) in PROVIDER_ARTWORK_HYDRATION_PROVIDERS
-
-
-def _hydrate_provider_ranked_artwork(
+def _hydrate_missing_artwork(
     candidates: list[CandidateItem],
     *,
-    allow_remote: bool = True,
-    hydrate_limit: int = MAX_ITEMS_PER_ROW,
+    allow_remote: bool,
 ) -> None:
-    """Hydrate missing artwork for top provider-ranked boardgame/music candidates."""
-    display_candidates = [
-        candidate
-        for candidate in candidates[:hydrate_limit]
-        if _supports_provider_artwork_hydration(candidate)
-    ]
-    if not display_candidates:
-        return
-
-    missing = [
-        candidate for candidate in display_candidates if _is_missing_image(candidate)
-    ]
-    if not missing:
-        return
-
-    local_images = _local_images_for_candidates(missing)
-    for candidate in missing:
-        local_image = local_images.get(candidate.identity())
-        if local_image:
-            candidate.image = local_image
-
-    if not allow_remote:
-        return
-
-    for candidate in missing:
-        if not _is_missing_image(candidate):
-            continue
-        try:
-            metadata = services.get_media_metadata(
-                candidate.media_type,
-                candidate.media_id,
-                candidate.source,
-            )
-        except Exception as error:
-            logger.warning(
-                "discover_provider_artwork_lookup_failed media_type=%s source=%s media_id=%s error=%s",
-                candidate.media_type,
-                candidate.source,
-                candidate.media_id,
-                error,
-            )
-            continue
-
-        image = (metadata or {}).get("image")
-        if not _is_missing_image_value(image):
-            candidate.image = image
-
-
-def _hydrate_trakt_ranked_artwork(
-    media_type: str,
-    candidates: list[CandidateItem],
-    *,
-    allow_remote: bool = True,
-    hydrate_limit: int = MAX_ITEMS_PER_ROW,
-) -> None:
-    """Hydrate missing artwork for displayed Trakt-ranked candidates."""
-    if media_type not in {
-        MediaTypes.MOVIE.value,
-        MediaTypes.TV.value,
-        MediaTypes.ANIME.value,
-    }:
-        return
-
-    # Trakt ranks the row. CandidateItem.source owns the metadata identity used
-    # for local and remote artwork, so a different mapping/provider can be
-    # introduced without changing this hydration path.
-    display_candidates = [
-        candidate
-        for candidate in candidates[:hydrate_limit]
-        if candidate.media_type == media_type
-    ]
-    if not display_candidates:
-        return
-
-    missing = [
-        candidate for candidate in display_candidates if _is_missing_image(candidate)
-    ]
+    """Hydrate missing artwork using each candidate's metadata identity."""
+    missing = [candidate for candidate in candidates if _is_missing_image(candidate)]
     if not missing:
         return
 
@@ -217,6 +134,60 @@ def _hydrate_trakt_ranked_artwork(
         image = (metadata or {}).get("image")
         if not _is_missing_image_value(image):
             candidate.image = image
+
+
+def _supports_provider_artwork_hydration(candidate: CandidateItem) -> bool:
+    return (
+        candidate.media_type,
+        candidate.source,
+    ) in PROVIDER_ARTWORK_HYDRATION_PROVIDERS
+
+
+def _hydrate_provider_ranked_artwork(
+    candidates: list[CandidateItem],
+    *,
+    allow_remote: bool = True,
+    hydrate_limit: int = MAX_ITEMS_PER_ROW,
+) -> None:
+    """Hydrate missing artwork for top provider-ranked boardgame/music candidates."""
+    display_candidates = [
+        candidate
+        for candidate in candidates[:hydrate_limit]
+        if _supports_provider_artwork_hydration(candidate)
+    ]
+    if not display_candidates:
+        return
+
+    _hydrate_missing_artwork(display_candidates, allow_remote=allow_remote)
+
+
+def _hydrate_trakt_ranked_artwork(
+    media_type: str,
+    candidates: list[CandidateItem],
+    *,
+    allow_remote: bool = True,
+    hydrate_limit: int = MAX_ITEMS_PER_ROW,
+) -> None:
+    """Hydrate missing artwork for displayed Trakt-ranked candidates."""
+    if media_type not in {
+        MediaTypes.MOVIE.value,
+        MediaTypes.TV.value,
+        MediaTypes.ANIME.value,
+    }:
+        return
+
+    # Trakt ranks the row. CandidateItem.source owns the metadata identity used
+    # for local and remote artwork, so a different mapping/provider can be
+    # introduced without changing this hydration path.
+    display_candidates = [
+        candidate
+        for candidate in candidates[:hydrate_limit]
+        if candidate.media_type == media_type
+    ]
+    if not display_candidates:
+        return
+
+    _hydrate_missing_artwork(display_candidates, allow_remote=allow_remote)
 
 
 def hydrate_visible_row_artwork(

--- a/src/app/discover/artwork.py
+++ b/src/app/discover/artwork.py
@@ -19,11 +19,13 @@ logger = logging.getLogger(__name__)
 ROW_CACHE_TTL_SECONDS = 60 * 60
 ROW_CACHE_TTL_LOCAL_SECONDS = 60 * 30
 
-RANKED_ARTWORK_ROW_KEYS = {
-    "trending_right_now",
-    "all_time_greats_unseen",
-    "coming_soon",
-}
+RANKED_ARTWORK_ROW_KEYS = frozenset(
+    {
+        "trending_right_now",
+        "all_time_greats_unseen",
+        "coming_soon",
+    },
+)
 VIDEO_ARTWORK_MEDIA_TYPES = frozenset(
     {
         MediaTypes.MOVIE.value,
@@ -37,6 +39,10 @@ PROVIDER_ARTWORK_HYDRATION_PROVIDERS = frozenset(
         (MediaTypes.MUSIC.value, Sources.MUSICBRAINZ.value),
     },
 )
+
+# Keep existing orchestration imports stable while new code uses the generic
+# ranked-row vocabulary above. Both names describe the same immutable contract.
+PROVIDER_ARTWORK_HYDRATION_ROW_KEYS = RANKED_ARTWORK_ROW_KEYS
 
 # These values can remain in persisted rows or cached Discover payloads after
 # the configured placeholder changes. Keep exact historical values here instead
@@ -190,6 +196,11 @@ def _hydrate_ranked_video_artwork(
         return
 
     _hydrate_missing_artwork(display_candidates, allow_remote=allow_remote)
+
+
+# Existing service imports use this private name. Keep it as a direct alias so
+# the canonical implementation stays provider-neutral without duplicating code.
+_hydrate_trakt_ranked_artwork = _hydrate_ranked_video_artwork
 
 
 def hydrate_visible_row_artwork(

--- a/src/app/tests/discover/test_artwork.py
+++ b/src/app/tests/discover/test_artwork.py
@@ -9,7 +9,7 @@ from django.test import SimpleTestCase, override_settings
 
 from app.discover.artwork import (
     LEGACY_IMG_NONE_VALUES,
-    _hydrate_trakt_ranked_artwork,
+    _hydrate_ranked_video_artwork,
     _is_missing_image,
 )
 from app.discover.schemas import CandidateItem
@@ -59,7 +59,7 @@ class ProviderNeutralArtworkHydrationTests(SimpleTestCase):
     @override_settings(IMG_NONE="https://example.invalid/custom-placeholder.svg")
     @patch("app.discover.artwork.services.get_media_metadata")
     @patch("app.discover.artwork.Item.objects.filter")
-    def test_trakt_ranked_hydration_uses_candidate_metadata_source(
+    def test_ranked_video_hydration_uses_candidate_metadata_source(
         self,
         filter_mock,
         metadata_mock,
@@ -79,7 +79,7 @@ class ProviderNeutralArtworkHydrationTests(SimpleTestCase):
             image=migration.NEW_IMG_NONE,
         )
 
-        _hydrate_trakt_ranked_artwork(MediaTypes.TV.value, [candidate])
+        _hydrate_ranked_video_artwork(MediaTypes.TV.value, [candidate])
 
         metadata_mock.assert_called_once_with(
             MediaTypes.TV.value,
@@ -118,7 +118,7 @@ class ProviderNeutralArtworkHydrationTests(SimpleTestCase):
             image=migration.NEW_IMG_NONE,
         )
 
-        _hydrate_trakt_ranked_artwork(
+        _hydrate_ranked_video_artwork(
             MediaTypes.TV.value,
             [candidate],
             allow_remote=False,
@@ -147,6 +147,6 @@ class ProviderNeutralArtworkHydrationTests(SimpleTestCase):
             image=settings.IMG_NONE,
         )
 
-        _hydrate_trakt_ranked_artwork(MediaTypes.MOVIE.value, [candidate])
+        _hydrate_ranked_video_artwork(MediaTypes.MOVIE.value, [candidate])
 
         self.assertEqual(candidate.image, settings.IMG_NONE)

--- a/src/app/tests/discover/test_artwork.py
+++ b/src/app/tests/discover/test_artwork.py
@@ -1,0 +1,152 @@
+"""Tests for Discover artwork hydration semantics."""
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+from app.discover.artwork import (
+    LEGACY_IMG_NONE_VALUES,
+    _hydrate_trakt_ranked_artwork,
+    _is_missing_image,
+)
+from app.discover.schemas import CandidateItem
+from app.models import MediaTypes, Sources
+
+
+class MissingArtworkTests(SimpleTestCase):
+    def test_runtime_legacy_values_match_frozen_migration_values(self):
+        migration = import_module(
+            "app.migrations.0155_rewrite_old_img_none_placeholder",
+        )
+
+        self.assertIn(migration.OLD_IMG_NONE, LEGACY_IMG_NONE_VALUES)
+        self.assertIn(migration.NEW_IMG_NONE, LEGACY_IMG_NONE_VALUES)
+
+    @override_settings(IMG_NONE="https://example.invalid/custom-placeholder.svg")
+    def test_custom_placeholder_still_recognises_migrated_builtin_value(self):
+        migration = import_module(
+            "app.migrations.0155_rewrite_old_img_none_placeholder",
+        )
+        candidate = CandidateItem(
+            media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            media_id="123",
+            title="Example",
+            image=migration.NEW_IMG_NONE,
+        )
+
+        self.assertTrue(_is_missing_image(candidate))
+
+    @override_settings(IMG_NONE="https://example.invalid/custom-placeholder.svg")
+    def test_configured_placeholder_is_missing_but_real_artwork_is_not(self):
+        candidate = CandidateItem(
+            media_type=MediaTypes.TV.value,
+            source=Sources.TMDB.value,
+            media_id="123",
+            title="Example",
+            image=settings.IMG_NONE,
+        )
+        self.assertTrue(_is_missing_image(candidate))
+
+        candidate.image = "https://images.example.test/poster.jpg"
+        self.assertFalse(_is_missing_image(candidate))
+
+
+class ProviderNeutralArtworkHydrationTests(SimpleTestCase):
+    @override_settings(IMG_NONE="https://example.invalid/custom-placeholder.svg")
+    @patch("app.discover.artwork.services.get_media_metadata")
+    @patch("app.discover.artwork.Item.objects.filter")
+    def test_trakt_ranked_hydration_uses_candidate_metadata_source(
+        self,
+        filter_mock,
+        metadata_mock,
+    ):
+        migration = import_module(
+            "app.migrations.0155_rewrite_old_img_none_placeholder",
+        )
+        filter_mock.return_value.only.return_value = []
+        metadata_mock.return_value = {
+            "image": "https://images.example.test/tvdb-poster.jpg",
+        }
+        candidate = CandidateItem(
+            media_type=MediaTypes.TV.value,
+            source=Sources.TVDB.value,
+            media_id="456",
+            title="Mapped show",
+            image=migration.NEW_IMG_NONE,
+        )
+
+        _hydrate_trakt_ranked_artwork(MediaTypes.TV.value, [candidate])
+
+        metadata_mock.assert_called_once_with(
+            MediaTypes.TV.value,
+            "456",
+            Sources.TVDB.value,
+        )
+        self.assertEqual(
+            candidate.image,
+            "https://images.example.test/tvdb-poster.jpg",
+        )
+
+    @override_settings(IMG_NONE="https://example.invalid/custom-placeholder.svg")
+    @patch("app.discover.artwork.services.get_media_metadata")
+    @patch("app.discover.artwork.Item.objects.filter")
+    def test_offline_hydration_uses_matching_local_provider_identity(
+        self,
+        filter_mock,
+        metadata_mock,
+    ):
+        migration = import_module(
+            "app.migrations.0155_rewrite_old_img_none_placeholder",
+        )
+        filter_mock.return_value.only.return_value = [
+            SimpleNamespace(
+                media_type=MediaTypes.TV.value,
+                source=Sources.TVDB.value,
+                media_id="456",
+                image="https://images.example.test/local-poster.jpg",
+            ),
+        ]
+        candidate = CandidateItem(
+            media_type=MediaTypes.TV.value,
+            source=Sources.TVDB.value,
+            media_id="456",
+            title="Mapped show",
+            image=migration.NEW_IMG_NONE,
+        )
+
+        _hydrate_trakt_ranked_artwork(
+            MediaTypes.TV.value,
+            [candidate],
+            allow_remote=False,
+        )
+
+        metadata_mock.assert_not_called()
+        self.assertEqual(
+            candidate.image,
+            "https://images.example.test/local-poster.jpg",
+        )
+
+    @patch("app.discover.artwork.services.get_media_metadata")
+    @patch("app.discover.artwork.Item.objects.filter")
+    def test_remote_missing_placeholder_does_not_replace_missing_state(
+        self,
+        filter_mock,
+        metadata_mock,
+    ):
+        filter_mock.return_value.only.return_value = []
+        metadata_mock.return_value = {"image": settings.IMG_NONE}
+        candidate = CandidateItem(
+            media_type=MediaTypes.MOVIE.value,
+            source=Sources.TMDB.value,
+            media_id="789",
+            title="Example movie",
+            image=settings.IMG_NONE,
+        )
+
+        _hydrate_trakt_ranked_artwork(MediaTypes.MOVIE.value, [candidate])
+
+        self.assertEqual(candidate.image, settings.IMG_NONE)


### PR DESCRIPTION
## Problem

PR #831 removed the remote placeholder dependency and kept `IMG_NONE` configurable. One edge case remained: migration `0155` writes the built-in data URI into existing rows, while Discover only compared artwork with the current configured `IMG_NONE` value.

If an installation overrides `IMG_NONE`, a migrated built-in placeholder can therefore look like real artwork. That can stop Discover from replacing the placeholder with available local or provider artwork.

The same path also assumed that a Trakt-ranked movie/TV/anime candidate always used TMDB for artwork. `CandidateItem` already carries the metadata identity source, so the ranking source does not need to own artwork resolution.

Follow-up to #831. Refs #652 for architecture context only; this change does not depend on or reopen that closed proposal.

## Solution

- Treat the configured placeholder and the frozen historical placeholder values as the same `missing artwork` state.
- Keep migration `0155` unchanged and deterministic.
- Resolve local artwork by the normalized candidate identity: `(media_type, source, media_id)`.
- For Trakt-ranked rows, use `CandidateItem.source` for local and remote metadata instead of forcing TMDB.
- Keep provider-ranked hydration explicitly bounded to the providers that already use this fallback. The supported pairs are declared in one set, so another provider can be added without another conditional branch.
- Reject provider responses that return any known missing-artwork placeholder.
- Preserve `allow_remote=False`: local artwork can still hydrate, but no provider request is made.

### Extension contract

The row source answers **who ranked the item**. `CandidateItem.source` answers **which metadata provider owns `media_id`**. Artwork follows the second value.

A future mapping/provider integration therefore only needs to emit the normalized candidate identity and make that provider resolvable through the existing metadata service. Discover artwork does not need a provider-specific branch.

## Validation

Added focused tests for:

- a custom `IMG_NONE` with rows migrated by `0155`;
- the runtime historical-sentinel list staying aligned with the frozen migration values;
- metadata lookup using the candidate provider rather than TMDB;
- offline/local hydration using the full provider identity and making no remote call;
- provider responses that still contain a missing placeholder.

Review passes applied before opening this draft:

- **Engineering review:** kept the existing artwork boundary, removed an unnecessary provider assumption, kept migration history deterministic, and added no dependency or extra request on the normal path.
- **Developer-experience review:** made the ranking-provider versus metadata-provider contract explicit and kept future provider changes at the adapter/service boundary.
- **Security review:** no new URL fetching primitive, credential handling, persistence format, permission path, or unbounded work was added. Provider calls still go through the existing metadata service and existing request controls.
- **QA:** repository CI is the execution gate for this draft. There is no template/CSS/UI change, so browser screenshots are not applicable.

I will record the exact CI results here after the draft checks complete.

## Post-mortem

The original correction handled the external hotlink and database rewrite, but two representations of `missing artwork` could then coexist: the configured runtime value and the historical value already stored by a migration. The Discover check treated the configuration value as the state itself instead of treating both values as representations of one state.

The provider coupling was similar: the row's ranking source and the candidate's metadata identity were both effectively treated as one provider choice. Keeping those responsibilities separate makes the fix smaller and avoids repeating it when another mapping or metadata provider is introduced.

## Screenshots

Not applicable. This is backend Discover hydration and regression-test work only; rendered UI is unchanged.

## AI Assistance

Code and review assistance used ChatGPT (GPT-5.6 Sol). The change was checked against the repository contribution rules and is being validated through the repository CI before review.