### PR TITLE
Let users pin streaming services from other regions (#519)

### DIFF
--- a/src/app/cache_utils.py
+++ b/src/app/cache_utils.py
@@ -46,6 +46,7 @@ def build_time_left_cache_key(
     provider_filter: str = "",
     watch_provider_region: str = "",
     media_status_filter: str = "",
+    pinned_providers: str = "",
 ) -> str:
     """Create the cache key used for time-left sorted TV lists."""
     normalized_status = status_filter or ""
@@ -68,13 +69,14 @@ def build_time_left_cache_key(
     normalized_provider = provider_filter or ""
     normalized_region = watch_provider_region or ""
     normalized_media_status = media_status_filter or ""
+    normalized_pinned_providers = pinned_providers or ""
     return (
         f"{TIME_LEFT_CACHE_PREFIX}_{user_id}_{media_type}_{normalized_status}_"
         f"{normalized_query}_{normalized_direction}_{normalized_rating}_{normalized_progress}_{normalized_collection}_"
         f"{normalized_genre}_{normalized_year}_{normalized_release}_{normalized_source}_"
         f"{normalized_language}_{normalized_country}_{normalized_platform}_{normalized_platform_mode}_{normalized_origin}_"
         f"{normalized_tag}_{normalized_tag_mode}_{normalized_provider}_{normalized_region}_"
-        f"{normalized_media_status}"
+        f"{normalized_media_status}_{normalized_pinned_providers}"
     )
 
 
@@ -144,6 +146,7 @@ def build_media_list_cache_key(
     provider_filter: str = "",
     watch_provider_region: str = "",
     media_status_filter: str = "",
+    pinned_providers: str = "",
 ) -> str:
     """Create the cache key for a fully-processed media list page."""
     parts = [
@@ -175,6 +178,7 @@ def build_media_list_cache_key(
         provider_filter or "",
         watch_provider_region or "",
         media_status_filter or "",
+        pinned_providers or "",
     ]
     return "_".join(parts)
 
@@ -202,6 +206,7 @@ def build_media_list_filter_cache_key(
     provider_filter: str = "",
     watch_provider_region: str = "",
     media_status_filter: str = "",
+    pinned_providers: str = "",
 ) -> str:
     """Create the cache key for media-list filter summary data."""
     parts = [
@@ -228,6 +233,7 @@ def build_media_list_filter_cache_key(
         provider_filter or "",
         watch_provider_region or "",
         media_status_filter or "",
+        pinned_providers or "",
     ]
     return "_".join(parts)
 

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -2038,6 +2038,18 @@ def media_details(
             if watch_provider_payload is not None
             else None
         )
+
+        if request.user.is_authenticated and request.user.pinned_watch_providers:
+            pinned_matches = tmdb.pinned_provider_matches(
+                detail_item, request.user.pinned_watch_providers
+            )
+            if pinned_matches:
+                merged = {p["provider_id"]: p for p in (watch_providers or [])}
+                for provider in pinned_matches:
+                    merged.setdefault(provider["provider_id"], provider)
+                watch_providers = sorted(
+                    merged.values(), key=lambda e: e.get("display_priority", 999)
+                )
     else:
         watch_providers = None
 

--- a/src/app/media_list_filters.py
+++ b/src/app/media_list_filters.py
@@ -116,6 +116,7 @@ class MediaListFilters:
     author: str = ""
     provider: str = ""
     provider_region: str = ""
+    pinned_providers: tuple[str, ...] = ()
     tags: tuple[str, ...] = ()
     tag_mode: str = "or"
     sort: str = ""
@@ -308,6 +309,10 @@ def parse_media_list_filters(request) -> MediaListFilters:
             getattr(getattr(request, "user", None), "watch_provider_region", "")
             or ""
         ).strip(),
+        pinned_providers=tuple(
+            getattr(getattr(request, "user", None), "pinned_watch_providers", None)
+            or ()
+        ),
         tags=tags,
         tag_mode=tag_mode_value,
         sort=sort,
@@ -508,11 +513,16 @@ def _matches_metadata(entry, filters, collection_platforms, collection_formats, 
     }:
         pass
     elif filters.provider:
-        providers = (
+        providers = set(
             tmdb.item_watch_provider_names(item, filters.provider_region)
             if filters.provider_region
             else []
         )
+        if filters.pinned_providers:
+            pinned_matches = tmdb.pinned_provider_matches(item, filters.pinned_providers)
+            providers |= {
+                p["provider_name"] for p in pinned_matches if p.get("provider_name")
+            }
         if not any(_normalize(filters.provider) == _normalize(value) for value in providers):
             return False
     if tag_ids[0] is not None and item.id not in tag_ids[0]:

--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -354,6 +354,7 @@ def build_filter_data_from_items(
     collection_platforms_by_item_id=None,
     region=None,
     pinned_providers=None,
+    include_providers=True,
 ):
     """Build filter menu option lists from a sequence of media/Item objects.
 
@@ -368,6 +369,10 @@ def build_filter_data_from_items(
     selectable options, even outside the user's home region, and the full
     TMDB provider catalog is returned under ``all_providers`` /
     ``pinned_providers`` for the filter dropdown's "More" panel.
+
+    ``include_providers`` should be false for media types that never show a
+    provider filter (games, books, music, ...) so the global TMDB catalog
+    fetch is skipped entirely rather than run and then discarded.
     """
     pinned_providers = list(pinned_providers or [])
     genres_set = set()
@@ -422,9 +427,10 @@ def build_filter_data_from_items(
         item_formats = _extract_item_formats(item, collection_formats_by_item_id)
         if item_formats:
             formats_set.update(item_formats)
-        if has_region:
+        if include_providers and has_region:
             providers_set.update(_extract_item_providers(item, region) or [])
-    providers_set.update(pinned_providers)
+    if include_providers:
+        providers_set.update(pinned_providers)
 
     genres = sorted(genres_set, key=lambda value: value.lower())
     implied_genres = sorted(implied_genres_set, key=lambda value: value.lower())
@@ -473,14 +479,18 @@ def build_filter_data_from_items(
         {"value": value, "label": value}
         for value in sorted(providers_set, key=lambda val: val.lower())
     ]
-    all_providers = [
-        {
-            "value": provider["provider_name"],
-            "label": provider["provider_name"],
-            "image": provider["image"],
-        }
-        for provider in tmdb.global_watch_provider_catalog()
-    ]
+    all_providers = (
+        [
+            {
+                "value": provider["provider_name"],
+                "label": provider["provider_name"],
+                "image": provider["image"],
+            }
+            for provider in tmdb.global_watch_provider_catalog()
+        ]
+        if include_providers
+        else []
+    )
     media_statuses = [
         {"value": value, "label": value}
         for value in sorted(media_statuses_set, key=lambda val: val.lower())
@@ -1670,6 +1680,7 @@ def media_list(request, media_type):
                 collection_platforms_by_item_id=collection_platforms_by_item_id,
                 region=watch_provider_region,
                 pinned_providers=request.user.pinned_watch_providers,
+                include_providers=media_type in provider_media_types,
             )
             filter_data["show_languages"] = media_type in (
                 MediaTypes.TV.value,
@@ -1912,6 +1923,7 @@ def media_list(request, media_type):
             collection_platforms_by_item_id=collection_platforms_by_item_id,
             region=watch_provider_region,
             pinned_providers=request.user.pinned_watch_providers,
+            include_providers=media_type in provider_media_types,
         )
         filter_data["show_languages"] = media_type in (
             MediaTypes.TV.value,

--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -256,11 +256,26 @@ PROVIDER_MEDIA_TYPES = (
 )
 
 
-def _extract_item_providers(item, region):
-    """Extract watch-provider names for an item, or None if region is unset."""
+def _extract_item_providers(item, region, pinned_providers=None):
+    """Extract watch-provider names for an item, or None if region is unset.
+
+    When ``pinned_providers`` is given, also matches those provider names
+    against the item's availability in *any* region, so a pinned provider
+    from outside the user's home region still filters correctly.
+    """
     if not item:
         return None
-    return tmdb.item_watch_provider_names(item, region)
+    names = tmdb.item_watch_provider_names(item, region)
+    if pinned_providers:
+        pinned_matches = tmdb.pinned_provider_matches(item, pinned_providers)
+        pinned_names = {
+            provider["provider_name"]
+            for provider in pinned_matches
+            if provider.get("provider_name")
+        }
+        if pinned_names:
+            return sorted((set(names) if names else set()) | pinned_names)
+    return names
 
 
 def _extract_item_authors(item):
@@ -338,6 +353,7 @@ def build_filter_data_from_items(
     collection_formats_by_item_id=None,
     collection_platforms_by_item_id=None,
     region=None,
+    pinned_providers=None,
 ):
     """Build filter menu option lists from a sequence of media/Item objects.
 
@@ -346,7 +362,14 @@ def build_filter_data_from_items(
     ``collection_platforms_by_item_id`` from the media-list view to include
     collection-enriched format/platform data; omit them (or pass None) for
     contexts that don't have collection data (e.g. person detail pages).
+
+    ``pinned_providers`` is the user's pinned/favorited watch-provider names
+    (see ``User.pinned_watch_providers``). They're always included as
+    selectable options, even outside the user's home region, and the full
+    TMDB provider catalog is returned under ``all_providers`` /
+    ``pinned_providers`` for the filter dropdown's "More" panel.
     """
+    pinned_providers = list(pinned_providers or [])
     genres_set = set()
     implied_genres_set = set()
     years_set = set()
@@ -401,6 +424,7 @@ def build_filter_data_from_items(
             formats_set.update(item_formats)
         if has_region:
             providers_set.update(_extract_item_providers(item, region) or [])
+    providers_set.update(pinned_providers)
 
     genres = sorted(genres_set, key=lambda value: value.lower())
     implied_genres = sorted(implied_genres_set, key=lambda value: value.lower())
@@ -449,6 +473,14 @@ def build_filter_data_from_items(
         {"value": value, "label": value}
         for value in sorted(providers_set, key=lambda val: val.lower())
     ]
+    all_providers = [
+        {
+            "value": provider["provider_name"],
+            "label": provider["provider_name"],
+            "image": provider["image"],
+        }
+        for provider in tmdb.global_watch_provider_catalog()
+    ]
     media_statuses = [
         {"value": value, "label": value}
         for value in sorted(media_statuses_set, key=lambda val: val.lower())
@@ -465,6 +497,8 @@ def build_filter_data_from_items(
         "formats": formats,
         "authors": authors,
         "providers": providers,
+        "all_providers": all_providers,
+        "pinned_providers": sorted(pinned_providers, key=lambda val: val.lower()),
         "media_statuses": media_statuses,
         "show_languages": False,
         "show_countries": False,
@@ -837,7 +871,7 @@ def media_list(request, media_type):
                 filtered_items.append(media)
         return filtered_items
 
-    def apply_provider_filter(media_items, filter_value, region):
+    def apply_provider_filter(media_items, filter_value, region, pinned_providers=None):
         if not filter_value:
             return media_items
         target = _normalize_filter_value(filter_value)
@@ -846,7 +880,7 @@ def media_list(request, media_type):
             item = getattr(media, "item", None)
             if not item:
                 continue
-            providers = _extract_item_providers(item, region)
+            providers = _extract_item_providers(item, region, pinned_providers)
             if providers and any(
                 _normalize_filter_value(provider) == target for provider in providers
             ):
@@ -1385,6 +1419,9 @@ def media_list(request, media_type):
             provider_filter=provider_filter,
             watch_provider_region=watch_provider_region,
             media_status_filter=media_status_filter,
+            pinned_providers=",".join(
+                sorted(request.user.pinned_watch_providers or [])
+            ),
         )
         if _use_media_list_cache
         else None
@@ -1413,6 +1450,9 @@ def media_list(request, media_type):
             provider_filter=provider_filter,
             watch_provider_region=watch_provider_region,
             media_status_filter=media_status_filter,
+            pinned_providers=",".join(
+                sorted(request.user.pinned_watch_providers or [])
+            ),
         )
         if (_use_media_list_cache or _time_left_active)
         else None
@@ -1456,6 +1496,9 @@ def media_list(request, media_type):
             provider_filter=provider_filter,
             watch_provider_region=watch_provider_region,
             media_status_filter=media_status_filter,
+            pinned_providers=",".join(
+                sorted(request.user.pinned_watch_providers or [])
+            ),
         )
         _time_left_cached_order = cache.get(_time_left_cache_key)
         if _time_left_cached_order is not None and filter_data is not None:
@@ -1626,6 +1669,7 @@ def media_list(request, media_type):
                 collection_formats_by_item_id=collection_formats_by_item_id,
                 collection_platforms_by_item_id=collection_platforms_by_item_id,
                 region=watch_provider_region,
+                pinned_providers=request.user.pinned_watch_providers,
             )
             filter_data["show_languages"] = media_type in (
                 MediaTypes.TV.value,
@@ -1644,7 +1688,8 @@ def media_list(request, media_type):
             filter_data["show_formats"] = media_type in author_media_types
             filter_data["show_authors"] = media_type in author_media_types
             filter_data["show_providers"] = media_type in provider_media_types and bool(
-                watch_provider_region and watch_provider_region != "UNSET"
+                (watch_provider_region and watch_provider_region != "UNSET")
+                or request.user.pinned_watch_providers
             )
             filter_data["show_progress"] = media_type in progress_media_types
             filter_data.update(
@@ -1673,7 +1718,10 @@ def media_list(request, media_type):
             media_list = apply_format_filter(media_list, format_filter)
         if media_type in provider_media_types:
             media_list = apply_provider_filter(
-                media_list, provider_filter, watch_provider_region
+                media_list,
+                provider_filter,
+                watch_provider_region,
+                request.user.pinned_watch_providers,
             )
         if sort_filter == "author" and media_type in author_media_types:
             media_list = sort_media_items_by_author(media_list, direction)
@@ -1863,6 +1911,7 @@ def media_list(request, media_type):
             collection_formats_by_item_id=collection_formats_by_item_id,
             collection_platforms_by_item_id=collection_platforms_by_item_id,
             region=watch_provider_region,
+            pinned_providers=request.user.pinned_watch_providers,
         )
         filter_data["show_languages"] = media_type in (
             MediaTypes.TV.value,
@@ -1881,7 +1930,8 @@ def media_list(request, media_type):
         filter_data["show_formats"] = media_type in author_media_types
         filter_data["show_authors"] = media_type in author_media_types
         filter_data["show_providers"] = media_type in provider_media_types and bool(
-            watch_provider_region and watch_provider_region != "UNSET"
+            (watch_provider_region and watch_provider_region != "UNSET")
+            or request.user.pinned_watch_providers
         )
         filter_data["show_progress"] = media_type in progress_media_types
         filter_data.update(
@@ -2933,3 +2983,17 @@ def update_table_columns(request, media_type):
     response = HttpResponse(status=204)
     response["HX-Trigger"] = json.dumps({"refreshTableColumns": True})
     return response
+
+
+def toggle_pinned_provider(request):
+    """Pin or unpin a watch-provider name, promoting/demoting it in filter menus."""
+    if not request.user.is_authenticated:
+        return HttpResponseBadRequest("Authentication required")
+
+    provider_name = request.POST.get("provider_name", "").strip()
+    if not provider_name:
+        return HttpResponseBadRequest("provider_name is required")
+
+    request.user.toggle_pinned_provider(provider_name)
+
+    return HttpResponse(status=204)

--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -32,6 +32,11 @@ SEARCH_CACHE_TIMEOUT = 60 * 60
 # Season blobs are the largest single thing Floppy caches (full episode lists),
 # so they expire sooner than the show payload they hang off.
 SEASON_CACHE_TIMEOUT = 60 * 60 * 12
+# build_filter_data_from_items() requests this catalog on every media-list
+# render. A cold cache during a TMDB outage must not repeat both provider
+# requests (each carrying the full request timeout) on every single render,
+# so a failed fetch is still cached, just for a much shorter window.
+WATCH_PROVIDER_CATALOG_FAILURE_CACHE_TIMEOUT = 60 * 5
 TMDB_APPEND_TO_RESPONSE_MAX_REMOTE_CALLS = 20
 TV_DETAIL_APPEND_RESPONSES = (
     "recommendations,external_ids,aggregate_credits,alternative_titles,watch/providers"
@@ -2314,6 +2319,7 @@ def global_watch_provider_catalog():
 
     if data is None:
         providers = {}
+        any_fetch_failed = False
         for media_type in ("movie", "tv"):
             url = f"{base_url}/watch/providers/{media_type}"
             params = {**base_params()}
@@ -2330,6 +2336,7 @@ def global_watch_provider_catalog():
                     "Skipping %s watch-provider catalog fetch due to TMDB API error",
                     media_type,
                 )
+                any_fetch_failed = True
                 continue
 
             for provider in response.get("results", []):
@@ -2346,6 +2353,10 @@ def global_watch_provider_catalog():
         data = sorted(providers.values(), key=lambda p: p["provider_name"].lower())
         if data:
             cache.set(cache_key, data)
+        elif any_fetch_failed:
+            # Cache the empty result too, just briefly: an outage must not
+            # repeat two full-timeout requests on every media-list render.
+            cache.set(cache_key, data, WATCH_PROVIDER_CATALOG_FAILURE_CACHE_TIMEOUT)
 
     return data
 

--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -2300,6 +2300,86 @@ def watch_provider_regions():
     return data
 
 
+def global_watch_provider_catalog():
+    """Return the full TMDB watch-provider catalog (movie + tv), deduped by id.
+
+    Unlike ``filter_providers``, this isn't scoped to a single item or region —
+    it's the source list for browsing/pinning providers outside the user's
+    home region. This is called on every media-list render (to populate the
+    "More" filter panel), so a TMDB outage must degrade to an empty list
+    rather than take the page down.
+    """
+    cache_key = f"{Sources.TMDB.value}_watch_provider_catalog"
+    data = cache.get(cache_key)
+
+    if data is None:
+        providers = {}
+        for media_type in ("movie", "tv"):
+            url = f"{base_url}/watch/providers/{media_type}"
+            params = {**base_params()}
+
+            try:
+                response = services.api_request(
+                    Sources.TMDB.value,
+                    "GET",
+                    url,
+                    params=params,
+                )
+            except (requests.exceptions.RequestException, services.ProviderAPIError):
+                logger.warning(
+                    "Skipping %s watch-provider catalog fetch due to TMDB API error",
+                    media_type,
+                )
+                continue
+
+            for provider in response.get("results", []):
+                provider_id = provider.get("provider_id")
+                provider_name = provider.get("provider_name")
+                if provider_id is None or not provider_name:
+                    continue
+                providers[provider_id] = {
+                    "provider_id": provider_id,
+                    "provider_name": provider_name,
+                    "image": get_image_url(provider.get("logo_path")),
+                }
+
+        data = sorted(providers.values(), key=lambda p: p["provider_name"].lower())
+        if data:
+            cache.set(cache_key, data)
+
+    return data
+
+
+def pinned_provider_matches(item, pinned_names):
+    """Return providers on ``item`` (any region) whose name is in ``pinned_names``.
+
+    Lets a pinned provider surface on the detail page even when the item is
+    only available on it outside the user's home region.
+    """
+    if not item or not pinned_names or not item.watch_providers:
+        return []
+
+    pinned_set = set(pinned_names)
+    providers = {}
+    for region_data in item.watch_providers.values():
+        if not isinstance(region_data, dict):
+            continue
+        for provider in [
+            *region_data.get("flatrate", []),
+            *region_data.get("free", []),
+        ]:
+            if provider.get("provider_name") not in pinned_set:
+                continue
+            providers[provider.get("provider_id")] = provider
+
+    matches = list(providers.values())
+    for provider in matches:
+        provider["image"] = get_image_url(provider.get("logo_path"))
+
+    matches.sort(key=lambda e: e.get("display_priority", 999))
+    return matches
+
+
 def metadata_languages():
     """Return the available metadata languages from The Movie Database."""
     cache_key = f"{Sources.TMDB.value}_metadata_languages"

--- a/src/app/tests/views/test_media_list.py
+++ b/src/app/tests/views/test_media_list.py
@@ -2819,6 +2819,81 @@ class MediaListViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["filter_data"]["show_providers"])
 
+    def test_pinned_provider_shown_and_filters_outside_home_region(self):
+        """A pinned provider from a non-home region still filters the library (#519)."""
+        uk_only_movie = Item.objects.create(
+            media_id="provider-filter-pinned-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Provider Filter Pinned Movie",
+            image="http://example.com/pfp1.jpg",
+            watch_providers={
+                "GB": {"flatrate": [{"provider_id": 39, "provider_name": "Now TV"}]},
+            },
+        )
+        other_movie = Item.objects.create(
+            media_id="provider-filter-pinned-2",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Provider Filter Other Movie",
+            image="http://example.com/pfp2.jpg",
+            watch_providers={
+                "US": {"flatrate": [{"provider_id": 8, "provider_name": "Netflix"}]},
+            },
+        )
+        Movie.objects.create(
+            item=uk_only_movie,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=0,
+        )
+        Movie.objects.create(
+            item=other_movie,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=0,
+        )
+        # No home region configured, but "Now TV" (GB-only) is pinned.
+        self.user.pinned_watch_providers = ["Now TV"]
+        self.user.save(update_fields=["pinned_watch_providers"])
+
+        url = reverse("medialist", args=[MediaTypes.MOVIE.value])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["filter_data"]["show_providers"])
+        self.assertTrue(
+            any(
+                option["value"] == "Now TV"
+                for option in response.context["filter_data"]["providers"]
+            ),
+        )
+
+        filtered_response = self.client.get(f"{url}?provider=Now TV")
+        self.assertEqual(filtered_response.status_code, 200)
+        self.assertContains(filtered_response, "Provider Filter Pinned Movie")
+        self.assertNotContains(filtered_response, "Provider Filter Other Movie")
+
+    def test_toggle_pinned_provider_requires_authentication(self):
+        self.client.logout()
+        response = self.client.post(
+            reverse("toggle_pinned_provider"), {"provider_name": "Netflix"}
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_toggle_pinned_provider_pins_and_unpins(self):
+        url = reverse("toggle_pinned_provider")
+
+        response = self.client.post(url, {"provider_name": "Netflix"})
+        self.assertEqual(response.status_code, 204)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.pinned_watch_providers, ["Netflix"])
+
+        response = self.client.post(url, {"provider_name": "Netflix"})
+        self.assertEqual(response.status_code, 204)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.pinned_watch_providers, [])
+
     def test_movie_filter_data_hides_author_filter(self):
         response = self.client.get(reverse("medialist", args=[MediaTypes.MOVIE.value]))
         self.assertEqual(response.status_code, 200)

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         views.update_table_columns,
         name="medialist_columns",
     ),
+    path(
+        "providers/pin/",
+        views.toggle_pinned_provider,
+        name="toggle_pinned_provider",
+    ),
     path("tags", views.tag_index, name="tag_index"),
     path("search", views.media_search, name="search"),
     path(

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -168,6 +168,7 @@ from app.media_list_views import (
     _collect_reading_activity_day_keys,
     _tracked_media_entries,
     media_list,
+    toggle_pinned_provider,
     update_table_columns,
 )
 from app.metadata_sync_views import (
@@ -2219,6 +2220,7 @@ __all__ = [
     "tag_item_toggle",
     "tags_modal",
     "time",
+    "toggle_pinned_provider",
     "track_modal",
     "trakt_popularity_service",
     "update_album_score",

--- a/src/templates/app/components/filter_toolbar.html
+++ b/src/templates/app/components/filter_toolbar.html
@@ -1039,7 +1039,11 @@
           <div class="max-h-64 overflow-y-auto">
             <template x-for="option in filteredAllProviders()" :key="option.value">
               <div class="flex items-center w-full px-4 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]">
-                <button class="flex items-center flex-1 min-w-0 gap-2 cursor-pointer"
+                <button hx-get="{{ filter_hx_endpoint }}"
+                        hx-target="{{ filter_hx_target }}"
+                        hx-include="#filter-form"
+                        hx-indicator="#loading-indicator"
+                        class="flex items-center flex-1 min-w-0 gap-2 cursor-pointer"
                         @click="provider = option.value; open = false; view = 'root'"
                         type="button">
                   <span class="block min-w-0 truncate max-w-[10rem]" x-text="option.label"></span>

--- a/src/templates/app/components/filter_toolbar.html
+++ b/src/templates/app/components/filter_toolbar.html
@@ -1015,6 +1015,45 @@
                 </span>
               </button>
             </template>
+            <button class="flex items-center w-full px-4 py-2 text-left text-sm transition-colors cursor-pointer text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                    @click="view = 'providerMore'; moreProviderSearch = ''"
+                    type="button">
+              <span>More…</span>
+            </button>
+          </div>
+        </div>
+
+        <div x-show="view === 'providerMore'" x-cloak class="p-2">
+          <div class="flex items-center gap-2 px-2 py-1">
+            <button class="p-1 rounded hover:bg-[var(--color-surface-hover)] transition-colors cursor-pointer"
+                    @click="view = 'provider'"
+                    type="button">{% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}</button>
+            <div class="text-xs uppercase tracking-wide text-[var(--color-text-secondary)]">All Streaming Services</div>
+          </div>
+          <div class="px-2 py-2">
+            <input type="text"
+                   x-model="moreProviderSearch"
+                   placeholder="Search all streaming services"
+                   class="w-full px-3 py-2 rounded-md bg-[var(--color-surface)] text-sm text-[var(--color-text-secondary)] placeholder-[var(--color-text-muted)] border border-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+          </div>
+          <div class="max-h-64 overflow-y-auto">
+            <template x-for="option in filteredAllProviders()" :key="option.value">
+              <div class="flex items-center w-full px-4 py-2 text-left text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]">
+                <button class="flex items-center flex-1 min-w-0 gap-2 cursor-pointer"
+                        @click="provider = option.value; open = false; view = 'root'"
+                        type="button">
+                  <span class="block min-w-0 truncate max-w-[10rem]" x-text="option.label"></span>
+                </button>
+                <button class="p-1 ml-auto rounded hover:bg-[var(--color-surface-hover)] transition-colors cursor-pointer"
+                        :title="isProviderPinned(option.value) ? 'Unpin' : 'Pin to promote out of More'"
+                        @click.stop="togglePinnedProvider(option.value)"
+                        type="button">
+                  <span :class="isProviderPinned(option.value) ? 'text-yellow-400 fill-current' : 'text-[var(--color-text-muted)]'">
+                    {% include "app/icons/star.svg" with classes="w-4 h-4" %}
+                  </span>
+                </button>
+              </div>
+            </template>
           </div>
         </div>
 

--- a/src/templates/app/components/filter_toolbar_scripts.html
+++ b/src/templates/app/components/filter_toolbar_scripts.html
@@ -66,6 +66,7 @@
       formatSearch: '',
       authorSearch: '',
       providerSearch: '',
+      moreProviderSearch: '',
       tagSearch: '',
       departmentSearch: '',
       genres: data.genres || [],
@@ -80,6 +81,9 @@
       formats: data.formats || [],
       authors: data.authors || [],
       providers: data.providers || [],
+      allProviders: data.all_providers || [],
+      pinnedProviderNames: data.pinned_providers || [],
+      pinTogglePending: false,
       tags: data.tags || [],
       tagCounts: data.tag_counts || {},
       departments: data.departments || [],
@@ -96,6 +100,7 @@
         this.formatSearch = '';
         this.authorSearch = '';
         this.providerSearch = '';
+        this.moreProviderSearch = '';
         this.tagSearch = '';
         this.departmentSearch = '';
       },
@@ -182,6 +187,35 @@
           return this.providers;
         }
         return this.providers.filter(option => option.label.toLowerCase().includes(term));
+      },
+      filteredAllProviders() {
+        const term = this.moreProviderSearch.toLowerCase();
+        if (!term) {
+          return this.allProviders;
+        }
+        return this.allProviders.filter(option => option.label.toLowerCase().includes(term));
+      },
+      isProviderPinned(name) {
+        return this.pinnedProviderNames.includes(name);
+      },
+      togglePinnedProvider(name) {
+        if (this.pinTogglePending) {
+          return;
+        }
+        this.pinTogglePending = true;
+        fetch('{% url "toggle_pinned_provider" %}', {
+          method: 'POST',
+          headers: { 'X-CSRFToken': '{{ csrf_token }}' },
+          body: new URLSearchParams({ provider_name: name }),
+        })
+          .then((response) => {
+            if (response.ok) {
+              window.location.reload();
+            }
+          })
+          .finally(() => {
+            this.pinTogglePending = false;
+          });
       },
       filteredTags() {
         const term = this.tagSearch.toLowerCase();

--- a/src/users/migrations/0126_user_pinned_watch_providers.py
+++ b/src/users/migrations/0126_user_pinned_watch_providers.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0125_mark_additional_plex_qa_accounts'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='pinned_watch_providers',
+            field=models.JSONField(blank=True, default=list, help_text="Watch-provider names pinned/favorited by the user, promoted out of 'More'"),
+        ),
+    ]

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1169,6 +1169,11 @@ class User(AbstractUser):
         blank=True,
         help_text="Per-library table column order and hidden keys",
     )
+    pinned_watch_providers = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Watch-provider names pinned/favorited by the user, promoted out of 'More'",
+    )
     book_comic_manga_progress_percentage = models.BooleanField(
         default=False,
         help_text="Track book, comic, and manga progress as percentage instead of pages/issues/chapters",
@@ -1527,6 +1532,19 @@ class User(AbstractUser):
             self.save(update_fields=["table_column_prefs"])
 
         return prefs[media_type]
+
+    def toggle_pinned_provider(self, provider_name):
+        """Pin or unpin a watch-provider name, returning the updated pinned list."""
+        pinned = list(self.pinned_watch_providers or [])
+        if provider_name in pinned:
+            pinned.remove(provider_name)
+        else:
+            pinned.append(provider_name)
+
+        self.pinned_watch_providers = pinned
+        self.save(update_fields=["pinned_watch_providers"])
+
+        return pinned
 
     @property
     def rating_scale_max(self):

--- a/src/users/tests/test_models.py
+++ b/src/users/tests/test_models.py
@@ -308,6 +308,33 @@ class UserColumnPrefsTests(TestCase):
         )
 
 
+class UserPinnedProvidersTests(TestCase):
+    """Tests for pinning/favoriting watch providers (issue #519)."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="pinnedproviders",
+            password="12345",
+        )
+
+    def test_toggle_pinned_provider_adds_new_provider(self):
+        result = self.user.toggle_pinned_provider("Netflix")
+
+        self.assertEqual(result, ["Netflix"])
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.pinned_watch_providers, ["Netflix"])
+
+    def test_toggle_pinned_provider_removes_existing_provider(self):
+        self.user.pinned_watch_providers = ["Netflix", "Hulu"]
+        self.user.save(update_fields=["pinned_watch_providers"])
+
+        result = self.user.toggle_pinned_provider("Netflix")
+
+        self.assertEqual(result, ["Hulu"])
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.pinned_watch_providers, ["Hulu"])
+
+
 class UserGetImportTasksTests(TestCase):
     """Tests for the User.get_import_tasks method."""
 


### PR DESCRIPTION
## Summary
- Resolves the library-filtering half of #519 (the RICE triage comment on that issue split it into two products; browsing a provider's full external catalogue is a separate, much larger future epic and is intentionally out of scope here).
- Adds `User.pinned_watch_providers`, so a user can pin/favorite a streaming-service name regardless of region.
- Surfaces this **in context** rather than in Settings, per explicit direction: the existing library filter dropdown's "Streaming Service" submenu gains a "More…" panel (reusing the app's established search/submenu Alpine.js conventions in `filter_toolbar.html`/`filter_toolbar_scripts.html`) listing the full TMDB provider catalog; starring an entry pins it and promotes it into the always-visible primary list.
- Filtering (`media_list_views.py`, `media_list_filters.py` for the REST API) and the item detail page's STREAMING block now match a pinned provider against an item's availability in *any* region, not just the user's home region — this was the core correctness gap: without it, pinning a provider from another region wouldn't actually filter anything.
- New `POST /providers/pin/` endpoint toggles a pin.
- Cache keys in `cache_utils.py` were extended so pinning changes invalidate the relevant cached filter/list data.
- Known follow-up (not in this PR): `lists/smart_rules.py`'s provider filter for Smart Lists still only matches the home region; threading pinned providers through it needs its own pass.

## AI Assistance
- This change was generated and substantially shaped by `claude-sonnet-5`.

## Validation
- `python manage.py check` — no issues.
- `python manage.py makemigrations users --check --dry-run` — no drift (migration matches model).
- `python manage.py test users.tests.test_models.UserPinnedProvidersTests` — pass.
- `python manage.py test app.tests.views.test_media_list app.tests.views.test_media_details` — 215/215 pass (run twice, including a fresh isolated run after fixing an early regression).
- `python manage.py test api.tests.test_media_list_filters` — pass.
- Live browser walkthrough via Playwright against a local server: opened the filter dropdown, confirmed the pinned cross-region provider ("Now TV", GB-only) appears alongside the home-region provider ("Netflix", US) in the primary list, and confirmed filtering by the pinned provider correctly isolates only the item available on it — verifying the cross-region matching fix end-to-end, not just via unit tests.

## Contract Handoff
- Domain guide regeneration/check outcome: not applicable (no OpenAPI/domain-contract surface touched beyond existing `media_list_filters.py` fields).
- Verified OpenAPI regeneration outcome: not applicable.
- Contract-test outcome: not applicable.

## Human Review
- [x] Pending human review.

## Gstack QA
- [x] Pending `/gstack-qa`.

## Migration Sync Gate (Required for `upstream` -> `latest` sync PRs)
- Not applicable — this is a regular feature PR, not an `upstream` → `latest` sync PR.

## Notes
- Refs #519


---
_Generated by [Claude Code](https://claude.ai/code/session_018EZs6TNA6acZLSRQPqUvAD)_