### PR TITLE
fix(sqlite): reopen unresolved recovery after keep-rows startup

### DIFF
--- a/docs/architecture/sqlite-recovery-decisions.md
+++ b/docs/architecture/sqlite-recovery-decisions.md
@@ -1,0 +1,35 @@
+# SQLite recovery decision lifetime
+
+Floppy checks SQLite storage and relationships before migrations run. A recovery choice must protect data first and must also let startup make progress.
+
+## Keep rows
+
+The **keep rows** choice means: keep the affected rows unchanged and try one startup.
+
+It is not a permanent exception to the integrity check. A later migration can require valid foreign keys even when normal application reads can tolerate the existing rows. If the same relationship incident is still present on the next start, Floppy reopens recovery and asks for a new choice.
+
+When Floppy reopens a previous keep-rows decision:
+
+- it changes no database row;
+- it disables automatic orphan removal for that integrity pass;
+- it ignores a persistent recovery-action environment value for that pass;
+- it writes a new incident-scoped approval token;
+- it returns to the recovery page before migrations run.
+
+This prevents a failed startup from turning into an unapproved delete on the next restart.
+
+## Remove orphaned child rows
+
+Removal remains a separate explicit recovery action when the affected tables are safe to address. Before any row is removed, Floppy creates and verifies a SQLite backup. It checks the remaining foreign-key state before it commits the change.
+
+A relationship incident that cannot be quarantined safely stays blocked for manual repair.
+
+## Already damaged databases
+
+This recovery flow is for relationship conflicts in a readable SQLite database. It does not repair physical SQLite corruption. A file that fails `PRAGMA quick_check` stays read-only from the recovery path and must be restored or repaired from a separate copy.
+
+## Runtime and packaging
+
+The policy runs in the Python startup path and the shell entrypoint. It does not depend on Redis, provider APIs, or internet access. Container, source, offline, and packaged runtimes should use the same recovery decision semantics.
+
+The startup check is intentionally before Django migrations. This keeps a relationship problem from becoming a migration loop and keeps recovery available when the normal application cannot start.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,16 @@ if [ -z "$DB_HOST" ]; then
     # repaired; other conflicts require an incident-scoped operator choice.
     if [ -f "$DB_FILE" ]; then
         while :; do
+            previous_acceptance=0
+            if ! previous_acceptance=$(python -c 'from config.sqlite_recovery_policy import reopen_previous_acceptance; import sys; print("1" if reopen_previous_acceptance(sys.argv[1]) else "0")' "$DB_FILE"); then
+                echo "[entrypoint] Could not reopen the previous SQLite keep-rows decision. Startup stopped before migrations so the database is unchanged." >&2
+                echo "[entrypoint] ${PREFLIGHT_HINT_RUN}" >&2
+                exit 1
+            fi
+            if [ "$previous_acceptance" = "1" ]; then
+                echo "[entrypoint] The previous keep-rows choice allowed one startup attempt. The same relationship problem is still present, so Floppy will ask for a new recovery choice before another attempt." >&2
+            fi
+
             echo "[entrypoint] Checking SQLite storage and relationships for ${DB_FILE}" >&2
             integrity_status=0
             integrity_pid=
@@ -112,7 +122,15 @@ if [ -z "$DB_HOST" ]; then
             # can never drift apart.
             integrity_timeout=600
             trap 'kill "$integrity_pid" 2>/dev/null || :; wait "$integrity_pid" 2>/dev/null || :; exit 0' TERM INT
-            timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+            if [ "$previous_acceptance" = "1" ]; then
+                # A prior keep-rows choice must never turn into an automatic
+                # deletion on the next start. Re-open recovery with both
+                # automatic repair and persistent environment actions disabled.
+                FLOPPY_SQLITE_AUTO_REPAIR=false FLOPPY_SQLITE_CONFLICT_ACTION=halt \
+                    timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+            else
+                timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
+            fi
             integrity_pid=$!
             wait "$integrity_pid" || integrity_status=$?
             trap - TERM INT

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sqlite3
+from importlib import import_module
 
 from decouple import config
 
@@ -40,7 +41,8 @@ if _sqlite_policy is not None:
             _effective_synchronous,
         )
 
-# Ensure Celery application is loaded when Django starts.
-from config.celery import app as celery_app
+# Load Celery only after the SQLite policy has been published. import_module()
+# keeps this required runtime order without a late module-level import.
+celery_app = import_module("config.celery").app
 
 __all__ = ("celery_app",)

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -27,6 +27,14 @@ def reopen_previous_acceptance(db_path: str) -> bool:
         return False
 
     incident = _incident_from_report(report)
+    incident.update(
+        {
+            "affected": report.get("affected", []),
+            "other_titles": report.get("affected_other_titles", 0),
+            "other_titles_count": report.get("affected_other_titles_count", 0),
+            "unidentified": report.get("affected_unidentified", 0),
+        },
+    )
     _write_incident_report(
         db_path,
         incident,

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import os
 import secrets
 
 from config.sqlite_integrity import (
     _incident_from_report,
+    _log,
     _read_incident_report,
     _write_incident_report,
+    check_database_integrity,
 )
+
+_REOPENED_ENV = {
+    "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+    "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+}
 
 
 def reopen_previous_acceptance(db_path: str) -> bool:
@@ -43,3 +51,27 @@ def reopen_previous_acceptance(db_path: str) -> bool:
         incident_token=secrets.token_hex(16),
     )
     return True
+
+
+def check_database_for_startup(db_path: str) -> None:
+    """Run the startup integrity check with one-attempt recovery semantics."""
+    if not reopen_previous_acceptance(db_path):
+        check_database_integrity(db_path)
+        return
+
+    _log(
+        "[entrypoint] The previous keep-rows choice allowed one startup attempt. "
+        "The same relationship problem is still present, so Floppy will ask for "
+        "a new recovery choice before another attempt.",
+    )
+
+    previous = {name: os.environ.get(name) for name in _REOPENED_ENV}
+    try:
+        os.environ.update(_REOPENED_ENV)
+        check_database_integrity(db_path)
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -1,0 +1,37 @@
+"""Keep SQLite recovery choices incident-scoped across startup attempts."""
+
+from __future__ import annotations
+
+import secrets
+
+from config.sqlite_integrity import (
+    _incident_from_report,
+    _read_incident_report,
+    _write_incident_report,
+)
+
+
+def reopen_previous_acceptance(db_path: str) -> bool:
+    """Turn a prior keep-rows decision back into a blocked incident.
+
+    Keeping invalid relationship rows can be useful for one startup attempt, but
+    it cannot be a permanent bypass. A later migration can require valid foreign
+    keys and fail after the integrity check has already returned success.
+
+    Reopen the same incident before the next startup attempt. The caller can then
+    disable automatic quarantine for that check, so Floppy does not delete rows
+    only because an earlier attempt failed to start.
+    """
+    report = _read_incident_report(db_path)
+    if not report or report.get("status") != "accepted":
+        return False
+
+    incident = _incident_from_report(report)
+    _write_incident_report(
+        db_path,
+        incident,
+        status="blocked",
+        resolution="accept-expired",
+        incident_token=secrets.token_hex(16),
+    )
+    return True

--- a/src/config/tests/test_sqlite_recovery_policy.py
+++ b/src/config/tests/test_sqlite_recovery_policy.py
@@ -1,0 +1,69 @@
+import json
+import tempfile
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from config import sqlite_integrity, sqlite_recovery_policy
+
+
+class SqliteRecoveryPolicyTests(SimpleTestCase):
+    """A keep-rows decision must not become a permanent integrity bypass."""
+
+    @staticmethod
+    def _incident():
+        return {
+            "can_quarantine": True,
+            "fingerprint": "a" * 64,
+            "groups": [
+                {
+                    "count": 3,
+                    "foreign_key_id": 0,
+                    "parent": "parent",
+                    "table": "child",
+                },
+            ],
+            "samples": [],
+            "total_conflicts": 3,
+            "unsafe_reasons": [],
+        }
+
+    def test_previous_acceptance_reopens_with_new_incident_token(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            Path(db_path).touch()
+            sqlite_integrity._write_incident_report(
+                db_path,
+                self._incident(),
+                status="accepted",
+                resolution="accept",
+            )
+
+            reopened = sqlite_recovery_policy.reopen_previous_acceptance(db_path)
+
+            self.assertTrue(reopened)
+            report = json.loads(Path(f"{db_path}.integrity.json").read_text())
+            self.assertEqual(report["status"], "blocked")
+            self.assertEqual(report["resolution"], "accept-expired")
+            self.assertEqual(report["fingerprint"], "a" * 64)
+            self.assertEqual(len(report["incident_token"]), 32)
+            self.assertIn("accept", report["actions"])
+            self.assertIn("quarantine", report["actions"])
+
+    def test_nonaccepted_incident_is_left_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            Path(db_path).touch()
+            sqlite_integrity._write_incident_report(
+                db_path,
+                self._incident(),
+                status="blocked",
+                incident_token="b" * 32,
+            )
+            report_path = Path(f"{db_path}.integrity.json")
+            before = report_path.read_text()
+
+            reopened = sqlite_recovery_policy.reopen_previous_acceptance(db_path)
+
+            self.assertFalse(reopened)
+            self.assertEqual(report_path.read_text(), before)

--- a/src/config/tests/test_sqlite_recovery_policy.py
+++ b/src/config/tests/test_sqlite_recovery_policy.py
@@ -13,6 +13,7 @@ class SqliteRecoveryPolicyTests(SimpleTestCase):
     @staticmethod
     def _incident():
         return {
+            "affected": [{"count": 3, "season": None, "title": "Affected Show"}],
             "can_quarantine": True,
             "fingerprint": "a" * 64,
             "groups": [
@@ -23,8 +24,11 @@ class SqliteRecoveryPolicyTests(SimpleTestCase):
                     "table": "child",
                 },
             ],
+            "other_titles": 2,
+            "other_titles_count": 4,
             "samples": [],
             "total_conflicts": 3,
+            "unidentified": 1,
             "unsafe_reasons": [],
         }
 
@@ -49,6 +53,13 @@ class SqliteRecoveryPolicyTests(SimpleTestCase):
             self.assertEqual(len(report["incident_token"]), 32)
             self.assertIn("accept", report["actions"])
             self.assertIn("quarantine", report["actions"])
+            self.assertEqual(
+                report["affected"],
+                [{"count": 3, "season": None, "title": "Affected Show"}],
+            )
+            self.assertEqual(report["affected_other_titles"], 2)
+            self.assertEqual(report["affected_other_titles_count"], 4)
+            self.assertEqual(report["affected_unidentified"], 1)
 
     def test_nonaccepted_incident_is_left_unchanged(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Fix SQLite recovery getting stuck after an operator chooses to keep invalid relationship rows and the following migration still requires valid foreign keys.

Fixes #810

Related: #731, #780, #863, #341

Upstream context: FuzzyGrim/Yamtrack#1190 and FuzzyGrim/Yamtrack#435

## Problem

#780 added a safe recovery path for SQLite foreign-key conflicts. It can create a verified backup and remove orphaned child rows when that operation can be proven safe. It also lets an operator keep the rows unchanged and attempt startup.

#810 shows an important edge case in that second path:

1. the operator keeps the rows;
2. the recovery report is persisted as `accepted`;
3. a later start sees the same fingerprint and treats that acceptance as permanent;
4. the integrity check returns success without changing the rows;
5. Django starts a migration;
6. SQLite/Django checks foreign keys while the schema editor exits;
7. the same orphaned rows fail the migration;
8. the container retries and then restarts.

The log in #810 contains the key sequence: `Previously accepted ... unchanged foreign key conflict(s)` followed by Django rejecting the same invalid relationship during migration.

This means a valid operator choice was being used for longer than it was safe to use. “Keep rows” can permit one startup attempt, but it cannot guarantee that a future migration will tolerate those rows.

## Changes

### Recovery decision lifetime

Add `config.sqlite_recovery_policy.reopen_previous_acceptance()`.

A previous `accepted` report is changed back to a blocked incident before a new startup attempt. The incident fingerprint and relationship summary are preserved, and a new incident-scoped approval token is created.

No database row is changed by this transition.

### Startup behavior

`entrypoint.sh` checks for a previous keep-rows decision before each SQLite integrity pass.

When it finds one:

- Floppy explains that the earlier choice applied to one startup attempt;
- the incident is reopened before migrations run;
- automatic orphan removal is disabled for that integrity pass;
- a persistent recovery-action environment value is ignored for that pass;
- the normal recovery page becomes the decision point again.

This is deliberate. A failed startup must not turn into an automatic delete on the next restart.

If the operator chooses removal, the existing #780 path still creates and verifies a backup before deleting addressable orphaned child rows, checks that the foreign-key conflicts are gone, and only then commits.

If the operator chooses keep rows again, Floppy preserves the rows and makes one more startup attempt.

### Tests

Add focused tests that verify:

- an `accepted` report becomes `blocked` on the next startup decision cycle;
- the incident fingerprint is preserved;
- a new 32-character incident token is created;
- accept and quarantine actions are available only from the reopened incident;
- a report that is already blocked is not changed.

The full `config` suite remains the system-level gate for the recovery path.

### Documentation

Add `docs/architecture/sqlite-recovery-decisions.md` to define:

- keep-rows as a one-startup-attempt decision;
- why migration-time foreign-key enforcement can still block startup;
- how Floppy prevents an unapproved automatic deletion after that failure;
- the verified-backup boundary for quarantine;
- the separate boundary for physical SQLite corruption;
- source, container, offline, and packaged runtime behavior.

## Why this is separate from #866

#866 owns provider text storage, PostgreSQL migration regression coverage, API duplicate-write handling, and the current startup lint correction.

#810 changes operator recovery semantics for an already inconsistent SQLite database. Keeping this recovery work in its own PR makes the data-deletion boundary reviewable by itself.

The small `config/__init__.py` startup-import correction is also present here because merged `latest` currently fails the full Ruff check with E402. It is identical to the correction under review in #866. If #866 lands first, that shared baseline change should disappear from this PR when the branch is refreshed.

## Upstream relationship

FuzzyGrim/Yamtrack#1190 reports the same SQLite migration failure class: a child row points at a missing parent, and Django fails while checking constraints during a migration. The upstream repair was a manual backup followed by deletion of the orphaned rows.

Floppy does not copy that table-specific repair. The existing #780 recovery code already inventories all foreign-key conflicts and only offers generalized quarantine when it can address the rows safely.

FuzzyGrim/Yamtrack#435 is related migration-time constraint context, but it is a different constraint defect and is not treated as the same root cause.

## Data safety and security review

- No database constraint is disabled or weakened.
- No foreign-key check is suppressed.
- No row is deleted merely because a previous keep-rows attempt failed.
- Automatic repair is explicitly disabled when a prior acceptance is reopened.
- Persistent recovery actions are ignored for that one re-check, so an old environment value cannot silently approve deletion or another bypass.
- Existing verified-backup, trigger, row-identity, disk-space, `quick_check`, and post-delete foreign-key safeguards remain unchanged.
- Physical corruption remains outside the quarantine path.
- No database contents or approval token are exposed through a new interface.

## Performance and offline behavior

The added startup work is one bounded local report read/write when a prior accepted incident exists. Normal healthy startup does not add a database scan, provider request, Redis call, or network request beyond the integrity work that already exists.

The policy uses the local Python runtime and filesystem only. It applies to containers and can be reused by source/offline/packaged startup wrappers.

## API and UI surfaces

No HTTP API endpoint, event schema, or semantic payload changes. OpenAPI, AsyncAPI, and JSON-LD do not need a change for this PR.

The existing recovery page remains the user-facing decision surface. Its visual layout, focus behavior, contrast, and interaction controls are unchanged, so there is no new screenshot or accessibility delta to review. The behavior change reduces ambiguity by returning the operator to the same explicit decision surface instead of entering a restart loop.

## Post-mortem

The recovery implementation correctly separated “keep” from “remove,” but the lifetime of “keep” was too broad. The report fingerprint was designed to prevent an old choice from applying to a different incident; it also caused the same choice to apply forever to an unchanged incident.

That assumption fails when startup requirements change. A migration can require referential integrity even when the application could otherwise open the existing database.

The corrective rule is therefore: **a non-destructive exception can permit one attempt, but it must not become a permanent bypass of a failed startup gate.**

## QA before ready-for-review

The PR stays draft until its exact final head has:

- App Tests green, including `config`;
- Lint green;
- CodeQL green;
- Docker Image green;
- no unresolved review threads.

No tests will be skipped and no timeout will be increased to make this pass.

## AI Assistance

GPT-5.6 Sol was used for repository analysis, implementation support, test design, and documentation. The changes were reviewed against the repository behavior, issue logs, existing recovery safeguards, and CI results before submission.