### PR TITLE
Add TVDB person profiles and filmography support

### DIFF
--- a/src/app/credits.py
+++ b/src/app/credits.py
@@ -122,7 +122,7 @@ def usable_credits_backfill_item_ids(item_ids):
 
 
 def missing_credits_backfill_item_ids(item_ids):
-    """Return TMDB item IDs that still need credits backfill."""
+    """Return item IDs that still need credits backfill."""
     normalized_ids = []
     for item_id in item_ids or []:
         try:
@@ -138,20 +138,21 @@ def missing_credits_backfill_item_ids(item_ids):
     candidate_items = list(
         Item.objects.filter(
             id__in=normalized_ids,
-            source=Sources.TMDB.value,
+            source__in=(Sources.TMDB.value, Sources.TVDB.value),
             media_type__in=[
                 MediaTypes.MOVIE.value,
                 MediaTypes.TV.value,
                 MediaTypes.SEASON.value,
                 MediaTypes.EPISODE.value,
             ],
-        ).values("id", "media_type"),
+        ).values("id", "media_type", "source"),
     )
     if not candidate_items:
         return []
 
     candidate_ids = {row["id"] for row in candidate_items}
     media_type_by_id = {row["id"]: row["media_type"] for row in candidate_items}
+    source_by_id = {row["id"]: row["source"] for row in candidate_items}
     current_credit_ids = current_credits_backfill_item_ids(candidate_ids)
 
     person_credit_ids = set(
@@ -177,12 +178,19 @@ def missing_credits_backfill_item_ids(item_ids):
         has_people = item_id in person_credit_ids
         has_cast = item_id in cast_credit_ids
         has_studios = item_id in studio_credit_ids
+        # TVDB never returns studio data (see providers.tvdb._build_series_metadata),
+        # so only TMDB items are held to the "has studios" bar.
+        studios_required = source_by_id.get(item_id) == Sources.TMDB.value
         if media_type == MediaTypes.SEASON.value:
             if not has_cast or item_id not in current_credit_ids:
                 missing_ids.append(item_id)
             continue
         if media_type == MediaTypes.TV.value:
-            if not has_cast or not has_studios or item_id not in current_credit_ids:
+            if (
+                not has_cast
+                or (studios_required and not has_studios)
+                or item_id not in current_credit_ids
+            ):
                 missing_ids.append(item_id)
             continue
         if media_type == MediaTypes.EPISODE.value:

--- a/src/app/credits.py
+++ b/src/app/credits.py
@@ -145,7 +145,15 @@ def missing_credits_backfill_item_ids(item_ids):
                 MediaTypes.SEASON.value,
                 MediaTypes.EPISODE.value,
             ],
-        ).values("id", "media_type", "source"),
+        )
+        # TVDB seasons/episodes never carry a credits payload (see
+        # providers.tvdb._normalize_season_metadata / episode()), so they
+        # would otherwise always look "missing" and be requeued forever.
+        .exclude(
+            source=Sources.TVDB.value,
+            media_type__in=[MediaTypes.SEASON.value, MediaTypes.EPISODE.value],
+        )
+        .values("id", "media_type", "source"),
     )
     if not candidate_items:
         return []

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -1205,7 +1205,7 @@ def media_details(
 
     if (
         render_secondary_only
-        and source == Sources.TMDB.value
+        and source in (Sources.TMDB.value, Sources.TVDB.value)
         and tracking_media_type
         in (
             MediaTypes.MOVIE.value,
@@ -1216,14 +1216,18 @@ def media_details(
         and detail_item
     ):
         missing_people = not detail_item.person_credits.exists()
-        missing_studios = not detail_item.studio_credits.exists()
+        # TVDB never returns studio data, so it would otherwise always look
+        # "missing" and re-trigger this sync on every page view.
+        missing_studios = (
+            source == Sources.TMDB.value and not detail_item.studio_credits.exists()
+        )
         if missing_people or missing_studios:
             _best_effort_detail_db_work(
                 lambda: credits.sync_item_credits_from_metadata(
                     detail_item,
                     media_metadata,
                 ),
-                operation_name="TMDB detail credits sync",
+                operation_name="detail credits sync",
             )
 
     should_refresh_igdb_game_studios = (

--- a/src/app/people_views.py
+++ b/src/app/people_views.py
@@ -22,7 +22,15 @@ from app.models import (
     Sources,
     Studio,
 )
-from app.providers import comicvine, hardcover, igdb, mangaupdates, openlibrary, tmdb
+from app.providers import (
+    comicvine,
+    hardcover,
+    igdb,
+    mangaupdates,
+    openlibrary,
+    tmdb,
+    tvdb,
+)
 from users.models import MediaSortChoices
 
 logger = __import__("logging").getLogger(__name__)
@@ -42,6 +50,15 @@ def person_detail(request, source, person_id, name):
             ),
             "source_url": lambda person_id_value: (
                 f"https://www.themoviedb.org/person/{person_id_value}"
+            ),
+            "is_author": False,
+        },
+        Sources.TVDB.value: {
+            "fetcher": tvdb.person,
+            "entries_key": "filmography",
+            "tracked_media_types": (MediaTypes.TV.value,),
+            "source_url": lambda person_id_value: (
+                f"https://www.thetvdb.com/dereferrer/person/{person_id_value}"
             ),
             "is_author": False,
         },

--- a/src/app/providers/tvdb.py
+++ b/src/app/providers/tvdb.py
@@ -995,6 +995,44 @@ def _person_filmography_entries(characters, language: str | None = None):
     return list(deduped.values())
 
 
+def _person_biography(response: dict | None, language: str | None = None) -> str:
+    """Return the preferred-language biography from a TVDB people/extended payload.
+
+    TVDB v4 exposes localized biographies as a `biographies` array (each row
+    keyed by `language`), not under `translations.overview` or a singular
+    `biography` field - those are only checked as a defensive fallback.
+    """
+    response = response or {}
+    biographies = [
+        row for row in _coerce_list(response.get("biographies")) if isinstance(row, dict)
+    ]
+
+    def _text(row: dict) -> str | None:
+        return _normalize_text_value(
+            row.get("biography") or row.get("overview") or row.get("text"),
+        )
+
+    preferred = _preferred_language_code(language)
+    lang_keys = dict.fromkeys((preferred, preferred[:2], "eng", "en"))
+    for lang_key in lang_keys:
+        for row in biographies:
+            if _normalize_language_code(row.get("language")) == lang_key:
+                text = _text(row)
+                if text:
+                    return text
+
+    for row in biographies:
+        text = _text(row)
+        if text:
+            return text
+
+    return (
+        _find_translation(response, "overview", language=language)
+        or _normalize_text_value(response.get("biography"))
+        or ""
+    )
+
+
 def person(person_id, language=None):
     """Return metadata for a TVDB person profile."""
     cache_key = _person_cache_key(person_id, language)
@@ -1011,9 +1049,7 @@ def person(person_id, language=None):
         "source": Sources.TVDB.value,
         "name": _get_name(response),
         "image": response.get("image") or settings.IMG_NONE,
-        "biography": _find_translation(response, "overview", language=language)
-        or _normalize_text_value(response.get("biography"))
-        or "",
+        "biography": _person_biography(response, language),
         "known_for_department": _normalize_text_value(response.get("peopleType")) or "",
         "gender": "unknown",
         "birth_date": _normalize_text_value(response.get("birth")),

--- a/src/app/providers/tvdb.py
+++ b/src/app/providers/tvdb.py
@@ -940,6 +940,95 @@ def _build_series_metadata(series_data: dict, *, media_type: str, language: str 
     }
 
 
+def _person_cache_key(person_id, language: str | None = None):
+    """Return the cache key for a person profile payload."""
+    return _cache_key("person", person_id, _preferred_language_code(language))
+
+
+def _person_filmography_entries(characters, language: str | None = None):
+    """Return normalized filmography entries from a TVDB person's characters."""
+    entries = []
+    for character in _coerce_list(characters):
+        if not isinstance(character, dict):
+            continue
+        series_id = character.get("seriesId") or character.get("series_id")
+        if not series_id:
+            continue
+        series_row = character.get("series")
+        series_row = series_row if isinstance(series_row, dict) else {}
+        title = (
+            _find_translation(series_row, "name", language=language)
+            or _get_name(series_row)
+            or _normalize_text_value(character.get("seriesName"))
+            or "Unknown Title"
+        )
+        year = None
+        first_aired = _parse_date(
+            series_row.get("firstAired") or character.get("year"),
+        )
+        if first_aired:
+            year = first_aired.year
+        is_cast = str(character.get("type") or "").lower() in {
+            "actor",
+            "guest star",
+            "voice",
+        }
+        entries.append(
+            {
+                "media_id": str(series_id),
+                "source": Sources.TVDB.value,
+                "media_type": MediaTypes.TV.value,
+                "title": title,
+                "image": _get_image(series_row, language),
+                "year": year,
+                "credit_type": "cast" if is_cast else "crew",
+                "role": character.get("name") or character.get("character") or "",
+                "department": "Acting" if is_cast else (character.get("type") or "Crew"),
+            },
+        )
+
+    # Deduplicate by media + credit + role in case TVDB returns duplicates.
+    deduped = {}
+    for entry in entries:
+        key = (entry["media_id"], entry["credit_type"], entry["role"])
+        deduped.setdefault(key, entry)
+    return list(deduped.values())
+
+
+def person(person_id, language=None):
+    """Return metadata for a TVDB person profile."""
+    cache_key = _person_cache_key(person_id, language)
+    data = cache.get(cache_key)
+    if data is not None:
+        return data
+
+    response = _unwrap_data(_request(f"people/{person_id}/extended")) or {}
+    if not response:
+        return None
+
+    data = {
+        "person_id": str(response.get("id") or person_id),
+        "source": Sources.TVDB.value,
+        "name": _get_name(response),
+        "image": response.get("image") or settings.IMG_NONE,
+        "biography": _find_translation(response, "overview", language=language)
+        or _normalize_text_value(response.get("biography"))
+        or "",
+        "known_for_department": _normalize_text_value(response.get("peopleType")) or "",
+        "gender": "unknown",
+        "birth_date": _normalize_text_value(response.get("birth")),
+        "death_date": _normalize_text_value(response.get("death")),
+        "place_of_birth": _normalize_text_value(response.get("birthPlace")) or "",
+        "filmography": _person_filmography_entries(
+            response.get("characters"), language,
+        ),
+    }
+
+    cache.set(cache_key, data, timeout=TVDB_METADATA_CACHE_TIMEOUT)
+
+    return data
+
+
 def _normalize_episode_rows(
     season_data: dict | None, language: str | None = None, *, series_id: Any = None
 ):

--- a/src/app/tasks_credits.py
+++ b/src/app/tasks_credits.py
@@ -11,7 +11,13 @@ from celery import shared_task
 from app import backfill_queue
 from app import credits as credit_helpers
 from app.log_safety import exception_summary
-from app.models import CREDITS_BACKFILL_VERSION, Item, MediaTypes, MetadataBackfillField
+from app.models import (
+    CREDITS_BACKFILL_VERSION,
+    Item,
+    MediaTypes,
+    MetadataBackfillField,
+    Sources,
+)
 from app.providers import services
 from app.task_cooperation import CooperativeRun
 from app.tasks_backfill_state import (
@@ -48,6 +54,15 @@ def _next_credits_backfill_item_ids(batch_size: int, scan_multiplier: int):
                 MediaTypes.SEASON.value,
                 MediaTypes.EPISODE.value,
             ],
+        )
+        # TVDB only exposes cast/crew on the series-level payload: seasons get
+        # no credits payload at all, and tvdb.episode() hardcodes empty
+        # cast/crew, so both would otherwise be reprocessed every cycle for
+        # nothing (a season eventually gives up; an episode never fails, so
+        # it never stops being requeued).
+        .exclude(
+            source=Sources.TVDB.value,
+            media_type__in=[MediaTypes.SEASON.value, MediaTypes.EPISODE.value],
         )
         .order_by("id")
         .values_list("id", flat=True)[:candidate_limit]

--- a/src/app/tasks_credits.py
+++ b/src/app/tasks_credits.py
@@ -25,7 +25,7 @@ from app.tasks_metadata_cache import _clear_item_metadata_cache, _fetch_item_met
 
 logger = logging.getLogger(__name__)
 
-CREDITS_BACKFILL_SOURCES = ("tmdb",)
+CREDITS_BACKFILL_SOURCES = ("tmdb", "tvdb")
 CREDITS_BACKFILL_QUEUE_TTL = 60 * 60  # 1 hour
 CREDITS_BACKFILL_ITEMS_QUEUE_KEY = "credits_backfill_items_queue"
 CREDITS_BACKFILL_ITEMS_SCHEDULED_KEY = "credits_backfill_items_scheduled"

--- a/src/app/tests/providers/test_tvdb.py
+++ b/src/app/tests/providers/test_tvdb.py
@@ -696,7 +696,9 @@ class TVDBProviderTests(TestCase):
                 "id": 291115,
                 "name": "Bryan Cranston",
                 "image": "https://artworks.thetvdb.com/banners/person/291115.jpg",
-                "biography": "American actor.",
+                "biographies": [
+                    {"language": "eng", "biography": "American actor."},
+                ],
                 "peopleType": "Actor",
                 "birth": "1956-03-07",
                 "death": None,
@@ -763,3 +765,35 @@ class TVDBProviderTests(TestCase):
         result = tvdb.person("291115")
 
         self.assertEqual(result["filmography"], [])
+
+    @patch("app.providers.tvdb._request")
+    def test_person_prefers_english_biography_among_multiple_languages(
+        self, mock_request
+    ):
+        """Biography should be picked from the `biographies` array by language."""
+        mock_request.return_value = {
+            "data": {
+                "id": 291115,
+                "name": "Bryan Cranston",
+                "biographies": [
+                    {"language": "spa", "biography": "Actor estadounidense."},
+                    {"language": "eng", "biography": "American actor."},
+                ],
+                "characters": [],
+            },
+        }
+
+        result = tvdb.person("291115")
+
+        self.assertEqual(result["biography"], "American actor.")
+
+    @patch("app.providers.tvdb._request")
+    def test_person_falls_back_when_no_biographies_present(self, mock_request):
+        """Missing `biographies` shouldn't crash and should return an empty bio."""
+        mock_request.return_value = {
+            "data": {"id": 291115, "name": "Bryan Cranston", "characters": []},
+        }
+
+        result = tvdb.person("291115")
+
+        self.assertEqual(result["biography"], "")

--- a/src/app/tests/providers/test_tvdb.py
+++ b/src/app/tests/providers/test_tvdb.py
@@ -687,3 +687,79 @@ class TVDBProviderTests(TestCase):
         self.assertEqual(first["1_1"], "2008-01-20T22:00:00+00:00")
         self.assertEqual(second, first)
         mock_request.assert_called_once()
+
+    @patch("app.providers.tvdb._request")
+    def test_person_normalizes_profile_and_filmography(self, mock_request):
+        """Person profiles should normalize bio fields and character credits."""
+        mock_request.return_value = {
+            "data": {
+                "id": 291115,
+                "name": "Bryan Cranston",
+                "image": "https://artworks.thetvdb.com/banners/person/291115.jpg",
+                "biography": "American actor.",
+                "peopleType": "Actor",
+                "birth": "1956-03-07",
+                "death": None,
+                "birthPlace": "Hollywood, California, USA",
+                "characters": [
+                    {
+                        "seriesId": 81189,
+                        "type": "Actor",
+                        "name": "Walter White",
+                        "series": {
+                            "id": 81189,
+                            "name": "Breaking Bad",
+                            "image": "https://artworks.thetvdb.com/banners/series/81189.jpg",
+                            "firstAired": "2008-01-20",
+                        },
+                    },
+                ],
+            },
+        }
+
+        result = tvdb.person("291115")
+
+        self.assertEqual(result["person_id"], "291115")
+        self.assertEqual(result["source"], Sources.TVDB.value)
+        self.assertEqual(result["name"], "Bryan Cranston")
+        self.assertEqual(result["biography"], "American actor.")
+        self.assertEqual(result["birth_date"], "1956-03-07")
+        self.assertIsNone(result["death_date"])
+        self.assertEqual(result["place_of_birth"], "Hollywood, California, USA")
+
+        self.assertEqual(len(result["filmography"]), 1)
+        entry = result["filmography"][0]
+        self.assertEqual(entry["media_id"], "81189")
+        self.assertEqual(entry["media_type"], MediaTypes.TV.value)
+        self.assertEqual(entry["title"], "Breaking Bad")
+        self.assertEqual(entry["year"], 2008)
+        self.assertEqual(entry["credit_type"], "cast")
+        self.assertEqual(entry["role"], "Walter White")
+
+    @patch("app.providers.tvdb._request")
+    def test_person_caches_response(self, mock_request):
+        """Person profiles should be cached between calls."""
+        mock_request.return_value = {
+            "data": {"id": 291115, "name": "Bryan Cranston", "characters": []},
+        }
+
+        first = tvdb.person("291115")
+        second = tvdb.person("291115")
+
+        self.assertEqual(first, second)
+        mock_request.assert_called_once()
+
+    @patch("app.providers.tvdb._request")
+    def test_person_skips_characters_without_series_id(self, mock_request):
+        """Characters missing a seriesId shouldn't produce filmography entries."""
+        mock_request.return_value = {
+            "data": {
+                "id": 291115,
+                "name": "Bryan Cranston",
+                "characters": [{"type": "Actor", "name": "Unknown Role"}],
+            },
+        }
+
+        result = tvdb.person("291115")
+
+        self.assertEqual(result["filmography"], [])

--- a/src/app/tests/test_tasks_credits.py
+++ b/src/app/tests/test_tasks_credits.py
@@ -527,6 +527,62 @@ class CreditsBackfillTaskTests(TestCase):
 
         self.assertEqual(missing_ids, [])
 
+    def test_missing_credits_item_ids_excludes_tvdb_seasons_and_episodes(self):
+        """TVDB seasons/episodes never carry a credits payload; skip them entirely.
+
+        Otherwise a season would record a permanent backfill failure and an
+        episode (whose provider payload hardcodes empty cast/crew) would be
+        reprocessed forever since it "succeeds" with zero credits every time.
+        """
+        tvdb_season = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="TVDB Season",
+        )
+        tvdb_episode = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="TVDB Episode",
+        )
+
+        missing_ids = tasks._missing_credits_item_ids(
+            [tvdb_season.id, tvdb_episode.id]
+        )
+
+        self.assertEqual(missing_ids, [])
+
+    @patch("app.tasks.populate_credits_backfill_queue.apply_async")
+    def test_enqueue_credits_backfill_excludes_tvdb_seasons_and_episodes(
+        self, mock_apply_async
+    ):
+        tvdb_season = Item.objects.create(
+            media_id="81190",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="TVDB Season Needing Credits",
+        )
+        tvdb_episode = Item.objects.create(
+            media_id="81190",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="TVDB Episode Needing Credits",
+        )
+
+        queued = tasks.enqueue_credits_backfill_items(
+            [tvdb_season.id, tvdb_episode.id], countdown=1
+        )
+
+        self.assertEqual(queued, 0)
+        mock_apply_async.assert_not_called()
+
     @patch("app.tasks.populate_credits_backfill_queue.apply_async")
     def test_enqueue_credits_backfill_requeues_tv_and_season_with_old_strategy_version(
         self,

--- a/src/app/tests/test_tasks_credits.py
+++ b/src/app/tests/test_tasks_credits.py
@@ -494,6 +494,39 @@ class CreditsBackfillTaskTests(TestCase):
 
         self.assertCountEqual(missing_ids, [tv_item.id, season_item.id])
 
+    def test_missing_credits_item_ids_does_not_require_studios_for_tvdb_tv(self):
+        """TVDB never returns studio data, so cast alone should satisfy TV items."""
+        tvdb_item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="TVDB Show",
+        )
+        person = Person.objects.create(
+            source=Sources.TVDB.value,
+            source_person_id="291115",
+            name="TVDB Cast Member",
+            gender=PersonGender.UNKNOWN.value,
+        )
+        ItemPersonCredit.objects.create(
+            item=tvdb_item,
+            person=person,
+            role_type=CreditRoleType.CAST.value,
+            role="Lead",
+        )
+        MetadataBackfillState.objects.update_or_create(
+            item=tvdb_item,
+            field=MetadataBackfillField.CREDITS,
+            defaults={
+                "last_success_at": timezone.now(),
+                "strategy_version": CREDITS_BACKFILL_VERSION,
+            },
+        )
+
+        missing_ids = tasks._missing_credits_item_ids([tvdb_item.id])
+
+        self.assertEqual(missing_ids, [])
+
     @patch("app.tasks.populate_credits_backfill_queue.apply_async")
     def test_enqueue_credits_backfill_requeues_tv_and_season_with_old_strategy_version(
         self,

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -5082,6 +5082,64 @@ class MediaDetailsViewTests(TestCase):
         self.assertTrue(response.context["detail_persistence_deferred"])
         _mock_sleep.assert_not_called()
 
+    @patch("integrations.tasks.fetch_collection_metadata_for_item.delay")
+    @patch("app.views.credits.sync_item_credits_from_metadata")
+    @patch("app.views.metadata_utils.apply_item_metadata", return_value=[])
+    @patch("app.providers.services.get_media_metadata")
+    def test_tvdb_tv_media_details_syncs_credits(
+        self,
+        mock_get_metadata,
+        _mock_apply_item_metadata,
+        mock_sync_credits,
+        _mock_fetch_delay,
+    ):
+        """A TVDB-sourced TV item should also get its cast/crew persisted (#868)."""
+        item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Breaking Bad",
+            image="https://example.com/breaking-bad.jpg",
+        )
+        base_metadata = {
+            "media_id": item.media_id,
+            "title": "Breaking Bad",
+            "media_type": MediaTypes.TV.value,
+            "source": Sources.TVDB.value,
+            "source_url": "https://www.thetvdb.com/dereferrer/series/81189",
+            "image": "https://example.com/breaking-bad.jpg",
+            "synopsis": "Chemistry teacher cooks meth.",
+            "details": {"episodes": 62},
+            "related": {},
+            "cast": [
+                {
+                    "person_id": "291115",
+                    "name": "Bryan Cranston",
+                    "image": "https://example.com/bryan.jpg",
+                    "role": "Walter White",
+                },
+            ],
+            "crew": [],
+            "studios_full": [],
+        }
+        mock_get_metadata.return_value = base_metadata
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.TVDB.value,
+                    "media_type": MediaTypes.TV.value,
+                    "media_id": item.media_id,
+                    "title": "breaking-bad",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_sync_credits.assert_called_once_with(item, base_metadata)
+
     @patch(
         "app.media_details_views._queue_game_lengths_refresh",
         side_effect=RuntimeError("queue unavailable"),

--- a/src/app/tests/views/test_person_detail.py
+++ b/src/app/tests/views/test_person_detail.py
@@ -1010,6 +1010,75 @@ class PersonDetailViewTests(TestCase):
         )
         self.assertContains(response, "Manga Title")
 
+    @patch("app.providers.tvdb.person")
+    def test_person_detail_shows_tvdb_filmography(self, mock_person):
+        item = Item.objects.create(
+            media_id="81189",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Tracked Show",
+            image="http://example.com/tracked.jpg",
+        )
+        person = Person.objects.create(
+            source=Sources.TVDB.value,
+            source_person_id="291115",
+            name="Bryan Cranston",
+        )
+        ItemPersonCredit.objects.create(
+            item=item,
+            person=person,
+            role_type=CreditRoleType.CAST.value,
+            role="Walter White",
+        )
+        TV.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.PLANNING.value,
+        )
+
+        mock_person.return_value = {
+            "person_id": "291115",
+            "source": Sources.TVDB.value,
+            "name": "Bryan Cranston",
+            "image": "http://example.com/bryan.jpg",
+            "biography": "American actor.",
+            "known_for_department": "Actor",
+            "gender": "male",
+            "birth_date": "1956-03-07",
+            "death_date": None,
+            "place_of_birth": "Hollywood, California, USA",
+            "filmography": [
+                {
+                    "media_id": "81189",
+                    "source": Sources.TVDB.value,
+                    "media_type": MediaTypes.TV.value,
+                    "title": "Tracked Show",
+                    "image": "http://example.com/tracked.jpg",
+                    "year": 2008,
+                    "credit_type": "cast",
+                    "role": "Walter White",
+                    "department": "Acting",
+                },
+            ],
+        }
+
+        response = self.client.get(
+            reverse(
+                "person_detail",
+                kwargs={
+                    "source": Sources.TVDB.value,
+                    "person_id": "291115",
+                    "name": "bryan-cranston",
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "app/person_detail.html")
+        self.assertEqual(len(response.context["filmography"]), 1)
+        self.assertContains(response, "Tracked Show")
+        self.assertContains(response, "?person_source=tvdb&amp;person_id=291115")
+
     def test_person_detail_rejects_unsupported_source(self):
         response = self.client.get(
             reverse(


### PR DESCRIPTION
## Summary

This PR adds support for fetching and displaying TVDB person profiles with filmography data, bringing feature parity with existing TMDB and other provider integrations.

**Key changes:**
- Added `tvdb.person()` function to fetch TVDB person profiles with normalized metadata (biography, birth/death dates, place of birth)
- Added `_person_filmography_entries()` helper to extract and normalize character credits from TVDB person data, with deduplication logic
- Extended person detail view to support TVDB source with filmography display
- Updated credits backfill system to include TVDB TV items (previously TMDB-only)
- Modified credits validation to not require studio data for TVDB items (TVDB API doesn't provide this)
- Updated media detail views to sync credits for TVDB TV items on secondary fragment renders

**Why:** TVDB is a primary source for TV metadata in the application. Supporting person profiles enables users to explore cast/crew information and discover related shows, improving the browsing experience for TV content.

## How It Was Tested

- Added unit tests for `tvdb.person()` covering profile normalization, caching, and filmography extraction
- Added unit tests for person detail view rendering with TVDB filmography
- Added unit tests for media detail view credit syncing with TVDB TV items
- Added unit tests for credits backfill validation excluding studio requirements for TVDB
- Existing test suite passes with new TVDB source handling in credits system

## Public API & Documentation Handoff

- [x] Not applicable (no API or vocabulary changes)

## Database & Migration Safety

- [x] Not applicable (no database changes)

## Related Issues

- Fixes #868 (TVDB TV items should have cast/crew persisted)

https://claude.ai/code/session_01CrStoLf4uYJvNkLRFSr1F5