### PR TITLE
fix(sqlite): preserve tracking data during relationship recovery

### DIFF
--- a/docs/architecture/sqlite-recovery-decisions.md
+++ b/docs/architecture/sqlite-recovery-decisions.md
@@ -1,35 +1,75 @@
-# SQLite recovery decision lifetime
+# SQLite relationship recovery
 
-Floppy checks SQLite storage and relationships before migrations run. A recovery choice must protect data first and must also let startup make progress.
+Floppy checks SQLite storage and relationships before Django migrations run. Recovery must protect user data first and must leave the database in a state that SQLite can validate during migrations.
 
-## Keep rows
+## Why keep-and-start was retired
 
-The **keep rows** choice means: keep the affected rows unchanged and try one startup.
+A broken foreign key can be tolerated by some normal reads, but Django checks SQLite constraints when a schema migration finishes. Starting with the same invalid relationship can therefore pass Floppy's preflight and then fail inside `migrate`.
 
-It is not a permanent exception to the integrity check. A later migration can require valid foreign keys even when normal application reads can tolerate the existing rows. If the same relationship incident is still present on the next start, Floppy reopens recovery and asks for a new choice.
+For that reason, a blocked relationship incident no longer offers **keep everything and start Floppy**. A legacy `accept` choice is treated as retired. Floppy changes no row and returns to recovery instead of entering another migration loop.
 
-When Floppy reopens a previous keep-rows decision:
+## Repair the relationship, not every child row
 
-- it changes no database row;
-- it disables automatic orphan removal for that integrity pass;
-- it ignores a persistent recovery-action environment value for that pass;
-- it writes a new incident-scoped approval token;
-- it returns to the recovery page before migrations run.
+Foreign-key failures do not all have the same ownership meaning. Recovery uses the table schema and a small allowlist of derived relationship tables to choose the least destructive valid repair.
 
-This prevents a failed startup from turning into an unapproved delete on the next restart.
+### Nullable references
 
-## Remove orphaned child rows
+When the broken foreign key column is nullable, Floppy clears only that reference. It preserves the child row and its user-owned state.
 
-Removal remains a separate explicit recovery action when the affected tables are safe to address. Before any row is removed, Floppy creates and verifies a SQLite backup. It checks the remaining foreign-key state before it commits the change.
+For example, `Music.album` and `Music.track` are optional catalog references. If an album or track row is missing, recovery sets the invalid `album_id` or `track_id` to `NULL` instead of deleting the Music tracking row.
 
-A relationship incident that cannot be quarantined safely stays blocked for manual repair.
+### Derived relationship rows
 
-## Already damaged databases
+Some rows exist only to connect two catalog records. `AlbumArtist` is one example. If its required album parent is gone, the relationship row has no independent user state. Floppy may remove that derived row automatically after it creates and verifies a backup.
 
-This recovery flow is for relationship conflicts in a readable SQLite database. It does not repair physical SQLite corruption. A file that fails `PRAGMA quick_check` stays read-only from the recovery path and must be restored or repaired from a separate copy.
+### Required-parent user-state rows
+
+A row such as `AlbumTracker` carries user state and cannot remain valid when its required album parent is missing. Floppy does not remove that row automatically. It pauses and asks for an incident-scoped repair choice.
+
+If the operator chooses repair:
+
+1. Floppy acquires a SQLite write lock.
+2. It verifies that the incident fingerprint still matches the live database.
+3. It creates a consistent backup and runs `PRAGMA quick_check` on that backup.
+4. It applies the least destructive repairs.
+5. It runs `PRAGMA foreign_key_check` again.
+6. It commits only when the required repair has converged to a clean foreign-key state.
+
+The removed live row remains available in the verified recovery backup.
+
+## Partial safe repair
+
+A single database can contain several relationship classes at once. Floppy may first clear nullable references and remove known derived rows while preserving required-parent user-state rows.
+
+If conflicts remain, Floppy writes a new bounded incident report with a new fingerprint and approval token. A choice made for the pre-repair incident cannot apply to the new database state.
+
+This also matters for counts: `PRAGMA foreign_key_check` counts broken relationships, not unique rows. One Music row with both a missing album and a missing track contributes two relationship failures. The recovery page therefore describes **broken relationships** and does not claim that the displayed count is the number of rows that will be removed.
+
+## Safety limits
+
+Automatic recovery is disabled when Floppy cannot prove the affected table layout is safe to modify. Examples include an affected trigger, a shadowed SQLite row identifier, a `WITHOUT ROWID` shape that prevents stable row targeting, or a foreign key shape that the repair planner cannot classify safely.
+
+In those cases Floppy changes nothing and requires a backup restore or manual repair.
+
+Physical SQLite corruption is a separate failure class. A file that fails `PRAGMA quick_check` stays read-only from this relationship-recovery path and must be restored or repaired from a separate copy.
 
 ## Runtime and packaging
 
-The policy runs in the Python startup path and the shell entrypoint. It does not depend on Redis, provider APIs, or internet access. Container, source, offline, and packaged runtimes should use the same recovery decision semantics.
+The recovery policy runs before Django migrations and does not depend on Redis, Celery, provider APIs, or internet access. The same Python policy is called from the shell entrypoint, so containers, source installs, offline systems, and future packaged runtimes can use the same relationship rules.
 
-The startup check is intentionally before Django migrations. This keeps a relationship problem from becoming a migration loop and keeps recovery available when the normal application cannot start.
+The recovery page also runs before Django. Its styles, scripts, and icon are self-contained so it remains usable while the normal application is unavailable and when the written copy is opened directly from disk.
+
+## Performance
+
+The integrity scan remains bounded and grouped. Repair uses set-based `UPDATE` and `DELETE` statements per relationship group rather than one write per reported row. Backup creation is streamed through SQLite's backup API and is required before a recovery write.
+
+For a large incident, the number shown in the report can be much larger than the number of affected rows because one row can violate more than one foreign key. Recovery plans and logs therefore report actual reference clears and row removals separately.
+
+## Incident history
+
+- #731 exposed the original SQLite relationship-conflict boot loop and recovery-page need.
+- #780 added bounded integrity reporting, verified backups, and quarantine support.
+- #870 limited the lifetime of a keep-rows choice so it could not become a permanent bypass.
+- #810 then proved that the keep-rows action itself was not migration-safe and that mixed Music relationships need ownership-aware repair.
+
+The current policy keeps the useful backup, fingerprint, bounded-report, and recovery-page controls from that work while replacing generalized child-row deletion with relationship-specific repair.

--- a/docs/architecture/sqlite-recovery-decisions.md
+++ b/docs/architecture/sqlite-recovery-decisions.md
@@ -51,6 +51,8 @@ Automatic recovery is disabled when Floppy cannot prove the affected table layou
 
 In those cases Floppy changes nothing and requires a backup restore or manual repair.
 
+A recovery choice is also fail-closed input. The local recovery page writes a one-use decision file beside the database. Startup opens that path without blocking, refuses anything that is not a regular file, requests no-follow behavior where the operating system supports it, removes the decision after the read attempt, and accepts an action only when its fingerprint and approval token match the current incident. A named pipe, device, stale choice, or changed database state therefore cannot become an automatic repair instruction.
+
 Physical SQLite corruption is a separate failure class. A file that fails `PRAGMA quick_check` stays read-only from this relationship-recovery path and must be restored or repaired from a separate copy.
 
 ## Runtime and packaging

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,20 +101,12 @@ if [ -z "$DB_HOST" ]; then
 
     reject_unsafe_managed_directory FLOPPY_DB_PATH "$DB_PARENT"
 
-    # Check storage before migrations. Known disposable album credits are
-    # repaired; other conflicts require an incident-scoped operator choice.
+    # Check storage before migrations. The recovery policy preserves rows when
+    # a broken nullable reference can be cleared, removes only known derived
+    # relationship rows automatically, and requires an incident-scoped operator
+    # choice before a row with a required missing parent can be removed.
     if [ -f "$DB_FILE" ]; then
         while :; do
-            previous_acceptance=0
-            if ! previous_acceptance=$(python -c 'from config.sqlite_recovery_policy import reopen_previous_acceptance; import sys; print("1" if reopen_previous_acceptance(sys.argv[1]) else "0")' "$DB_FILE"); then
-                echo "[entrypoint] Could not reopen the previous SQLite keep-rows decision. Startup stopped before migrations so the database is unchanged." >&2
-                echo "[entrypoint] ${PREFLIGHT_HINT_RUN}" >&2
-                exit 1
-            fi
-            if [ "$previous_acceptance" = "1" ]; then
-                echo "[entrypoint] The previous keep-rows choice allowed one startup attempt. The same relationship problem is still present, so Floppy will ask for a new recovery choice before another attempt." >&2
-            fi
-
             echo "[entrypoint] Checking SQLite storage and relationships for ${DB_FILE}" >&2
             integrity_status=0
             integrity_pid=
@@ -122,15 +114,7 @@ if [ -z "$DB_HOST" ]; then
             # can never drift apart.
             integrity_timeout=600
             trap 'kill "$integrity_pid" 2>/dev/null || :; wait "$integrity_pid" 2>/dev/null || :; exit 0' TERM INT
-            if [ "$previous_acceptance" = "1" ]; then
-                # A prior keep-rows choice must never turn into an automatic
-                # deletion on the next start. Re-open recovery with both
-                # automatic repair and persistent environment actions disabled.
-                FLOPPY_SQLITE_AUTO_REPAIR=false FLOPPY_SQLITE_CONFLICT_ACTION=halt \
-                    timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
-            else
-                timeout "$integrity_timeout" python -c 'from config.sqlite_integrity import check_database_integrity; import sys; check_database_integrity(sys.argv[1])' "$DB_FILE" &
-            fi
+            timeout "$integrity_timeout" python -c 'from config.sqlite_recovery_policy import check_database_for_startup; import sys; check_database_for_startup(sys.argv[1])' "$DB_FILE" &
             integrity_pid=$!
             wait "$integrity_pid" || integrity_status=$?
             trap - TERM INT
@@ -157,7 +141,7 @@ if [ -z "$DB_HOST" ]; then
             trap 'kill "$parking_pid" 2>/dev/null || :; wait "$parking_pid" 2>/dev/null || :; exit 0' TERM INT
             # Show the recovery page. It writes a copy beside the database, then
             # serves it. If a choice is submitted, the server exits cleanly so
-            # the loop can apply the decision and continue to migrations.
+            # the loop can apply the decision before migrations run.
             if [ -n "$RUNTIME_SERVER_PORT" ]; then
                 python -m config.sqlite_recovery_server "$DB_FILE" "$RUNTIME_SERVER_PORT" &
             else

--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -300,7 +300,11 @@ class IntegrationTest(StaticLiveServerTestCase):
             f"Ended: {fixed_date.strftime(datetime_format)}",
         )
 
-        self.page.reload()
+        with self.page.expect_response(
+            lambda response: "fragment=secondary" in response.url,
+        ) as secondary_response:
+            self.page.reload()
+        self.assertEqual(secondary_response.value.status, 200)
         expect(self.page.locator("#episodes-list")).to_be_visible()
         today = timezone.localtime().strftime(datetime_format)
         tracked_button = self.page.locator(

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from config.sqlite_integrity import (
     _create_verified_backup,
+    _decision_path,
     _describe_affected,
     _incident_from_report,
     _incident_report_path,
@@ -29,7 +30,6 @@ from config.sqlite_repair import apply_repair_plan, build_repair_plan
 
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
 _AUTO_REPAIR_ENV = "FLOPPY_SQLITE_AUTO_REPAIR"
-_DECISION_SUFFIX = ".integrity.decision"
 
 
 class UnsafeRecoverySchemaError(sqlite3.IntegrityError):
@@ -52,11 +52,6 @@ def _auto_repair_enabled() -> bool:
         "no",
         "off",
     }
-
-
-def _decision_path(db_path: str) -> Path:
-    database_path = Path(db_path).resolve()
-    return database_path.with_name(f"{database_path.name}{_DECISION_SUFFIX}")
 
 
 def _publish_policy_report(

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -6,27 +6,29 @@ import json
 import os
 import secrets
 import sqlite3
+from contextlib import suppress
 from pathlib import Path
 
 from config.sqlite_integrity import (
     _create_verified_backup,
+    _describe_affected,
     _incident_from_report,
     _incident_report_path,
     _inspect_foreign_keys,
     _log,
+    _print_incident,
     _publish_report,
-    _read_decision,
     _read_incident_report,
-    _selected_action,
+    _reconcile_report,
+    _report_corruption,
+    _valid_blocked_token,
     _write_incident_report,
-    check_database_integrity,
 )
 from config.sqlite_repair import apply_repair_plan, build_repair_plan
 
-_SAFE_CHECK_ENV = {
-    "FLOPPY_SQLITE_AUTO_REPAIR": "false",
-    "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
-}
+_ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
+_AUTO_REPAIR_ENV = "FLOPPY_SQLITE_AUTO_REPAIR"
+_DECISION_SUFFIX = ".integrity.decision"
 
 
 class UnsafeRecoverySchemaError(sqlite3.IntegrityError):
@@ -43,12 +45,17 @@ class RecoveryDidNotConvergeError(sqlite3.IntegrityError):
 
 
 def _auto_repair_enabled() -> bool:
-    return os.environ.get("FLOPPY_SQLITE_AUTO_REPAIR", "true").strip().lower() not in {
+    return os.environ.get(_AUTO_REPAIR_ENV, "true").strip().lower() not in {
         "0",
         "false",
         "no",
         "off",
     }
+
+
+def _decision_path(db_path: str) -> Path:
+    database_path = Path(db_path).resolve()
+    return database_path.with_name(f"{database_path.name}{_DECISION_SUFFIX}")
 
 
 def _publish_policy_report(
@@ -84,20 +91,6 @@ def _publish_policy_report(
         payload["safe_repair"] = prior_safe_repair
     contents = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     _publish_report(_incident_report_path(db_path), contents)
-
-
-def _run_checker_without_legacy_repair(db_path: str) -> None:
-    """Run the existing scanner while disabling its generalized delete path."""
-    previous = {name: os.environ.get(name) for name in _SAFE_CHECK_ENV}
-    try:
-        os.environ.update(_SAFE_CHECK_ENV)
-        check_database_integrity(db_path)
-    finally:
-        for name, value in previous.items():
-            if value is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
 
 
 def reopen_previous_acceptance(db_path: str) -> bool:
@@ -144,6 +137,133 @@ def _require_converged(remaining: dict) -> None:
         raise RecoveryDidNotConvergeError(conflict_count)
 
 
+def _describe_incident(conn: sqlite3.Connection, incident: dict) -> None:
+    """Add bounded human context without making it a recovery prerequisite."""
+    try:
+        incident.update(_describe_affected(conn))
+    except Exception as error:  # noqa: BLE001 - damaged schemas must still get a report
+        _log(f"[entrypoint] Could not name the affected entries: {error}")
+
+
+def _scan_and_publish_block(db_path: str) -> dict | None:
+    """Scan storage and publish the policy's blocked relationship report."""
+    prior_report = _read_incident_report(db_path)
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        result = conn.execute("PRAGMA quick_check").fetchone()
+        status = result[0] if result else None
+        if status != "ok":
+            _log(
+                "[entrypoint] Database integrity check failed: "
+                f"quick_check returned {status!r}",
+            )
+            _report_corruption(db_path, f"quick_check returned {status!r}")
+            raise SystemExit(1)
+
+        incident = _inspect_foreign_keys(conn)
+        if not incident["total_conflicts"]:
+            if prior_report:
+                try:
+                    _reconcile_report(db_path, prior_report)
+                except (KeyError, OSError, sqlite3.DatabaseError) as error:
+                    _log(
+                        "[entrypoint] SQLite recovery report could not be finalized; "
+                        f"the database is healthy and startup continues: {error}",
+                    )
+            return None
+
+        _describe_incident(conn, incident)
+        _print_incident(db_path, incident)
+        incident_token = _valid_blocked_token(prior_report, incident)
+        if incident_token is None:
+            incident_token = secrets.token_hex(16)
+        try:
+            report_path = _write_incident_report(
+                db_path,
+                incident,
+                status="blocked",
+                incident_token=incident_token,
+            )
+        except OSError as error:
+            _log(f"[entrypoint] Could not publish SQLite incident report: {error}")
+            raise SystemExit(1) from error
+        _log(f"[entrypoint] Startup is blocked by report {report_path}")
+        return _read_incident_report(db_path)
+    except sqlite3.DatabaseError as error:
+        _log(f"[entrypoint] Database integrity check failed: {error}")
+        raise SystemExit(1) from error
+    finally:
+        conn.close()
+
+
+def _read_policy_decision(db_path: str, report: dict) -> str | None:
+    """Consume one exact fingerprint-and-token decision from the recovery page."""
+    decision_path = _decision_path(db_path)
+    try:
+        descriptor = os.open(
+            decision_path,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError:
+        return None
+
+    decision = None
+    try:
+        with os.fdopen(descriptor) as decision_file:
+            descriptor = -1
+            decision = json.load(decision_file)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        decision = None
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+        with suppress(OSError):
+            decision_path.unlink()
+
+    if not isinstance(decision, dict):
+        return None
+    if decision.get("action") not in {"accept", "quarantine"}:
+        return None
+    if decision.get("fingerprint") != report.get("fingerprint"):
+        _log("[entrypoint] Recovery choice belongs to a different incident; using halt")
+        return None
+    expected = report.get("incident_token")
+    supplied = decision.get("token")
+    if not (
+        isinstance(expected, str)
+        and expected
+        and isinstance(supplied, str)
+        and secrets.compare_digest(supplied, expected)
+    ):
+        _log("[entrypoint] Recovery choice does not carry the current code; using halt")
+        return None
+    return str(decision["action"])
+
+
+def _selected_policy_action(report: dict) -> str:
+    """Read an incident-scoped headless action from the environment."""
+    configured = os.environ.get(_ACTION_ENV, "halt").strip()
+    if configured in {"", "halt"}:
+        return "halt"
+
+    action, separator, supplied = configured.partition(":")
+    expected = report.get("incident_token")
+    if action == "accept":
+        return "accept"
+    if action != "quarantine" or not separator:
+        _log(f"[entrypoint] Invalid {_ACTION_ENV}; using halt")
+        return "halt"
+    if not (
+        isinstance(expected, str)
+        and expected
+        and supplied
+        and secrets.compare_digest(supplied, expected)
+    ):
+        _log(f"[entrypoint] {_ACTION_ENV} does not carry the current code; using halt")
+        return "halt"
+    return "quarantine"
+
+
 def _apply_plan(
     db_path: str,
     report: dict,
@@ -187,21 +307,20 @@ def _repair_summary(result: dict, backup_path: Path) -> dict:
 
 def _handle_operator_decision(db_path: str, report: dict) -> bool:
     """Apply a one-use decision if one exists."""
-    decision_path = Path(f"{db_path}.integrity.decision")
-    configured = os.environ.get("FLOPPY_SQLITE_CONFLICT_ACTION", "halt").strip()
+    decision_path = _decision_path(db_path)
+    configured = os.environ.get(_ACTION_ENV, "halt").strip()
     if not decision_path.exists() and configured in {"", "halt"}:
         return False
 
+    action = (
+        _read_policy_decision(db_path, report)
+        if decision_path.exists()
+        else _selected_policy_action(report)
+    )
     conn = sqlite3.connect(db_path, timeout=30.0)
     try:
-        conn.execute("BEGIN IMMEDIATE")
         incident = _current_incident(conn, report)
-        token = report.get("incident_token") or ""
-        action = _read_decision(db_path, incident, token) if decision_path.exists() else None
-        if action is None:
-            action = _selected_action(incident, token)
         plan = build_repair_plan(conn, incident)
-        conn.rollback()
     finally:
         conn.close()
 
@@ -266,19 +385,6 @@ def _annotate_blocked_report(
     return plan
 
 
-def _run_and_capture_block(db_path: str) -> dict | None:
-    try:
-        _run_checker_without_legacy_repair(db_path)
-    except SystemExit as error:
-        if error.code != 1:
-            raise
-        report = _read_incident_report(db_path)
-        if not report or report.get("status") != "blocked":
-            raise
-        return report
-    return None
-
-
 def check_database_for_startup(db_path: str) -> None:
     """Repair safe relationship damage or block before migrations."""
     reopened = reopen_previous_acceptance(db_path)
@@ -296,7 +402,7 @@ def check_database_for_startup(db_path: str) -> None:
     ):
         return
 
-    report = _run_and_capture_block(db_path)
+    report = _scan_and_publish_block(db_path)
     if report is None:
         return
 
@@ -340,10 +446,9 @@ def check_database_for_startup(db_path: str) -> None:
         )
         return
 
-    # The safe subset changed the incident fingerprint. Re-scan through the
-    # existing reporting path so the next approval token is tied to the exact
-    # remaining rows rather than the pre-repair incident.
-    refreshed = _run_and_capture_block(db_path)
+    # The safe subset changed the incident fingerprint. Re-scan through this
+    # policy so the next approval code is tied to the exact remaining rows.
+    refreshed = _scan_and_publish_block(db_path)
     if refreshed is None:
         return
     _annotate_blocked_report(

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -37,6 +37,7 @@ class RecoveryDidNotConvergeError(sqlite3.IntegrityError):
     """Raised when required repair leaves one or more foreign-key conflicts."""
 
     def __init__(self, conflict_count: int):
+        """Record how many relationship conflicts remained after repair."""
         message = f"{conflict_count} relationship conflict(s) remain after repair"
         super().__init__(message)
 

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -6,6 +6,7 @@ import json
 import os
 import secrets
 import sqlite3
+import stat
 from contextlib import suppress
 from pathlib import Path
 
@@ -204,13 +205,17 @@ def _read_policy_decision(db_path: str, report: dict) -> str | None:
     try:
         descriptor = os.open(
             decision_path,
-            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0),
         )
     except OSError:
         return None
 
     decision = None
     try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            return None
         with os.fdopen(descriptor) as decision_file:
             descriptor = -1
             decision = json.load(decision_file)

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -8,7 +8,7 @@ import secrets
 import sqlite3
 import stat
 from contextlib import suppress
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from config.sqlite_integrity import (
     _create_verified_backup,
@@ -27,6 +27,9 @@ from config.sqlite_integrity import (
     _write_incident_report,
 )
 from config.sqlite_repair import apply_repair_plan, build_repair_plan
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _ACTION_ENV = "FLOPPY_SQLITE_CONFLICT_ACTION"
 _AUTO_REPAIR_ENV = "FLOPPY_SQLITE_AUTO_REPAIR"

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -29,6 +29,18 @@ _SAFE_CHECK_ENV = {
 }
 
 
+class UnsafeRecoverySchemaError(sqlite3.IntegrityError):
+    """Raised when the current relationship shape is not safe to repair."""
+
+
+class RecoveryDidNotConvergeError(sqlite3.IntegrityError):
+    """Raised when required repair leaves one or more foreign-key conflicts."""
+
+    def __init__(self, conflict_count: int):
+        message = f"{conflict_count} relationship conflict(s) remain after repair"
+        super().__init__(message)
+
+
 def _auto_repair_enabled() -> bool:
     return os.environ.get("FLOPPY_SQLITE_AUTO_REPAIR", "true").strip().lower() not in {
         "0",
@@ -120,6 +132,17 @@ def _current_incident(conn: sqlite3.Connection, report: dict) -> dict:
     return incident
 
 
+def _require_repairable(plan: dict) -> None:
+    if not plan.get("can_repair"):
+        raise UnsafeRecoverySchemaError
+
+
+def _require_converged(remaining: dict) -> None:
+    conflict_count = int(remaining.get("total_conflicts", 0))
+    if conflict_count:
+        raise RecoveryDidNotConvergeError(conflict_count)
+
+
 def _apply_plan(
     db_path: str,
     report: dict,
@@ -132,8 +155,7 @@ def _apply_plan(
         conn.execute("BEGIN IMMEDIATE")
         incident = _current_incident(conn, report)
         plan = build_repair_plan(conn, incident)
-        if not plan.get("can_repair"):
-            raise sqlite3.IntegrityError("relationship repair is not safe for this schema")
+        _require_repairable(plan)
         backup_path = _create_verified_backup(db_path, incident["fingerprint"])
         result = apply_repair_plan(
             conn,
@@ -141,15 +163,14 @@ def _apply_plan(
             include_required=include_required,
         )
         remaining = _inspect_foreign_keys(conn)
-        if include_required and remaining["total_conflicts"]:
-            raise sqlite3.IntegrityError(
-                f"{remaining['total_conflicts']} relationship conflict(s) remain after repair"
-            )
-        conn.commit()
-        return incident, plan, result, backup_path, remaining
+        if include_required:
+            _require_converged(remaining)
     except Exception:
         conn.rollback()
         raise
+    else:
+        conn.commit()
+        return incident, plan, result, backup_path, remaining
     finally:
         conn.close()
 
@@ -198,13 +219,11 @@ def _handle_operator_decision(db_path: str, report: dict) -> bool:
     if action != "quarantine":
         return False
 
-    _incident, plan, result, backup_path, remaining = _apply_plan(
+    _incident, plan, result, backup_path, _remaining = _apply_plan(
         db_path,
         report,
         include_required=True,
     )
-    if remaining["total_conflicts"]:
-        raise sqlite3.IntegrityError("relationship repair did not converge")
     summary = _repair_summary(result, backup_path)
     _publish_policy_report(
         db_path,
@@ -269,9 +288,12 @@ def check_database_for_startup(db_path: str) -> None:
         )
 
     report = _read_incident_report(db_path)
-    if report and report.get("status") == "blocked":
-        if _handle_operator_decision(db_path, report):
-            return
+    if (
+        report
+        and report.get("status") == "blocked"
+        and _handle_operator_decision(db_path, report)
+    ):
+        return
 
     report = _run_and_capture_block(db_path)
     if report is None:

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -141,7 +141,9 @@ def _describe_incident(conn: sqlite3.Connection, incident: dict) -> None:
     """Add bounded human context without making it a recovery prerequisite."""
     try:
         incident.update(_describe_affected(conn))
-    except Exception as error:  # noqa: BLE001 - damaged schemas must still get a report
+    except Exception as error:
+        # A damaged schema still needs a bounded incident report. Naming titles
+        # is useful context, but it is not allowed to suppress the recovery path.
         _log(f"[entrypoint] Could not name the affected entries: {error}")
 
 

--- a/src/config/sqlite_recovery_policy.py
+++ b/src/config/sqlite_recovery_policy.py
@@ -1,35 +1,94 @@
-"""Keep SQLite recovery choices incident-scoped across startup attempts."""
+"""Apply incident-scoped SQLite recovery without discarding recoverable user data."""
 
 from __future__ import annotations
 
+import json
 import os
 import secrets
+import sqlite3
+from pathlib import Path
 
 from config.sqlite_integrity import (
+    _create_verified_backup,
     _incident_from_report,
+    _incident_report_path,
+    _inspect_foreign_keys,
     _log,
+    _publish_report,
+    _read_decision,
     _read_incident_report,
+    _selected_action,
     _write_incident_report,
     check_database_integrity,
 )
+from config.sqlite_repair import apply_repair_plan, build_repair_plan
 
-_REOPENED_ENV = {
+_SAFE_CHECK_ENV = {
     "FLOPPY_SQLITE_AUTO_REPAIR": "false",
     "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
 }
 
 
+def _auto_repair_enabled() -> bool:
+    return os.environ.get("FLOPPY_SQLITE_AUTO_REPAIR", "true").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _publish_policy_report(
+    db_path: str,
+    report: dict,
+    plan: dict,
+    *,
+    status: str = "blocked",
+    resolution: str | None = None,
+    backup_path: Path | None = None,
+    repair_result: dict | None = None,
+    prior_safe_repair: dict | None = None,
+) -> None:
+    """Publish only recovery choices that this policy can complete."""
+    payload = dict(report)
+    token = payload.get("incident_token")
+    actions = {"halt": "halt"}
+    if status == "blocked" and token and plan.get("can_repair"):
+        actions["quarantine"] = f"quarantine:{token}"
+    payload.update(
+        {
+            "actions": actions,
+            "backup_path": str(backup_path) if backup_path else payload.get("backup_path"),
+            "can_quarantine": bool(plan.get("can_repair")),
+            "incident_token": token if status == "blocked" else None,
+            "repair_plan": plan,
+            "repair_result": repair_result,
+            "resolution": resolution,
+            "status": status,
+        }
+    )
+    if prior_safe_repair:
+        payload["safe_repair"] = prior_safe_repair
+    contents = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    _publish_report(_incident_report_path(db_path), contents)
+
+
+def _run_checker_without_legacy_repair(db_path: str) -> None:
+    """Run the existing scanner while disabling its generalized delete path."""
+    previous = {name: os.environ.get(name) for name in _SAFE_CHECK_ENV}
+    try:
+        os.environ.update(_SAFE_CHECK_ENV)
+        check_database_integrity(db_path)
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 def reopen_previous_acceptance(db_path: str) -> bool:
-    """Turn a prior keep-rows decision back into a blocked incident.
-
-    Keeping invalid relationship rows can be useful for one startup attempt, but
-    it cannot be a permanent bypass. A later migration can require valid foreign
-    keys and fail after the integrity check has already returned success.
-
-    Reopen the same incident before the next startup attempt. The caller can then
-    disable automatic quarantine for that check, so Floppy does not delete rows
-    only because an earlier attempt failed to start.
-    """
+    """Turn a legacy keep-rows decision back into a blocked incident."""
     report = _read_incident_report(db_path)
     if not report or report.get("status") != "accepted":
         return False
@@ -47,31 +106,226 @@ def reopen_previous_acceptance(db_path: str) -> bool:
         db_path,
         incident,
         status="blocked",
-        resolution="accept-expired",
+        resolution="accept-retired",
         incident_token=secrets.token_hex(16),
     )
     return True
 
 
+def _current_incident(conn: sqlite3.Connection, report: dict) -> dict:
+    incident = _inspect_foreign_keys(conn)
+    if incident["fingerprint"] != report.get("fingerprint"):
+        msg = "database relationships changed after the recovery page was rendered"
+        raise sqlite3.IntegrityError(msg)
+    return incident
+
+
+def _apply_plan(
+    db_path: str,
+    report: dict,
+    *,
+    include_required: bool,
+) -> tuple[dict, dict, dict, Path, dict]:
+    """Apply one validated plan under a write lock and verified backup."""
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        incident = _current_incident(conn, report)
+        plan = build_repair_plan(conn, incident)
+        if not plan.get("can_repair"):
+            raise sqlite3.IntegrityError("relationship repair is not safe for this schema")
+        backup_path = _create_verified_backup(db_path, incident["fingerprint"])
+        result = apply_repair_plan(
+            conn,
+            plan,
+            include_required=include_required,
+        )
+        remaining = _inspect_foreign_keys(conn)
+        if include_required and remaining["total_conflicts"]:
+            raise sqlite3.IntegrityError(
+                f"{remaining['total_conflicts']} relationship conflict(s) remain after repair"
+            )
+        conn.commit()
+        return incident, plan, result, backup_path, remaining
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _repair_summary(result: dict, backup_path: Path) -> dict:
+    return {
+        "backup_path": str(backup_path),
+        "references_cleared": int(result.get("references_cleared", 0)),
+        "relationship_rows_removed": int(result.get("relationship_rows_removed", 0)),
+        "required_rows_removed": int(result.get("required_rows_removed", 0)),
+    }
+
+
+def _handle_operator_decision(db_path: str, report: dict) -> bool:
+    """Apply a one-use decision if one exists."""
+    decision_path = Path(f"{db_path}.integrity.decision")
+    configured = os.environ.get("FLOPPY_SQLITE_CONFLICT_ACTION", "halt").strip()
+    if not decision_path.exists() and configured in {"", "halt"}:
+        return False
+
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        incident = _current_incident(conn, report)
+        token = report.get("incident_token") or ""
+        action = _read_decision(db_path, incident, token) if decision_path.exists() else None
+        if action is None:
+            action = _selected_action(incident, token)
+        plan = build_repair_plan(conn, incident)
+        conn.rollback()
+    finally:
+        conn.close()
+
+    if action == "accept":
+        _publish_policy_report(
+            db_path,
+            report,
+            plan,
+            resolution="accept-retired",
+        )
+        _log(
+            "[entrypoint] Keeping invalid relationships cannot make migrations safe. "
+            "No rows were changed; choose repair or restore a backup.",
+        )
+        raise SystemExit(1)
+    if action != "quarantine":
+        return False
+
+    _incident, plan, result, backup_path, remaining = _apply_plan(
+        db_path,
+        report,
+        include_required=True,
+    )
+    if remaining["total_conflicts"]:
+        raise sqlite3.IntegrityError("relationship repair did not converge")
+    summary = _repair_summary(result, backup_path)
+    _publish_policy_report(
+        db_path,
+        report,
+        plan,
+        status="resolved",
+        resolution="operator-repair",
+        backup_path=backup_path,
+        repair_result=summary,
+    )
+    _log(
+        "[entrypoint] Repaired SQLite relationships after a verified backup: "
+        f"cleared {summary['references_cleared']} optional reference(s), removed "
+        f"{summary['relationship_rows_removed']} derived relationship row(s), and "
+        f"removed {summary['required_rows_removed']} row(s) whose required parent "
+        f"was missing. Backup: {backup_path}",
+    )
+    return True
+
+
+def _annotate_blocked_report(
+    db_path: str,
+    report: dict,
+    *,
+    prior_safe_repair: dict | None = None,
+) -> dict:
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        plan = build_repair_plan(conn, report)
+    finally:
+        conn.close()
+    _publish_policy_report(
+        db_path,
+        report,
+        plan,
+        resolution="repair-required",
+        prior_safe_repair=prior_safe_repair,
+    )
+    return plan
+
+
+def _run_and_capture_block(db_path: str) -> dict | None:
+    try:
+        _run_checker_without_legacy_repair(db_path)
+    except SystemExit as error:
+        if error.code != 1:
+            raise
+        report = _read_incident_report(db_path)
+        if not report or report.get("status") != "blocked":
+            raise
+        return report
+    return None
+
+
 def check_database_for_startup(db_path: str) -> None:
-    """Run the startup integrity check with one-attempt recovery semantics."""
-    if not reopen_previous_acceptance(db_path):
-        check_database_integrity(db_path)
+    """Repair safe relationship damage or block before migrations."""
+    reopened = reopen_previous_acceptance(db_path)
+    if reopened:
+        _log(
+            "[entrypoint] The old keep-rows choice cannot make schema migrations "
+            "safe. Floppy reopened recovery without changing the database.",
+        )
+
+    report = _read_incident_report(db_path)
+    if report and report.get("status") == "blocked":
+        if _handle_operator_decision(db_path, report):
+            return
+
+    report = _run_and_capture_block(db_path)
+    if report is None:
         return
 
-    _log(
-        "[entrypoint] The previous keep-rows choice allowed one startup attempt. "
-        "The same relationship problem is still present, so Floppy will ask for "
-        "a new recovery choice before another attempt.",
-    )
+    plan = _annotate_blocked_report(db_path, report)
+    if not (
+        _auto_repair_enabled()
+        and plan.get("can_repair")
+        and int(plan.get("safe_relationships", 0)) > 0
+    ):
+        raise SystemExit(1)
 
-    previous = {name: os.environ.get(name) for name in _REOPENED_ENV}
     try:
-        os.environ.update(_REOPENED_ENV)
-        check_database_integrity(db_path)
-    finally:
-        for name, value in previous.items():
-            if value is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
+        _incident, applied_plan, result, backup_path, remaining = _apply_plan(
+            db_path,
+            report,
+            include_required=False,
+        )
+    except (OSError, sqlite3.DatabaseError, ValueError) as error:
+        _log(
+            "[entrypoint] Safe SQLite relationship repair failed without changing "
+            f"the live database: {error}",
+        )
+        raise SystemExit(1) from error
+
+    safe_summary = _repair_summary(result, backup_path)
+    _log(
+        "[entrypoint] Preserved user data while repairing safe SQLite relationships: "
+        f"cleared {safe_summary['references_cleared']} optional reference(s) and "
+        f"removed {safe_summary['relationship_rows_removed']} derived relationship "
+        f"row(s). Backup: {backup_path}",
+    )
+    if not remaining["total_conflicts"]:
+        _publish_policy_report(
+            db_path,
+            report,
+            applied_plan,
+            status="resolved",
+            resolution="automatic-safe-repair",
+            backup_path=backup_path,
+            repair_result=safe_summary,
+        )
+        return
+
+    # The safe subset changed the incident fingerprint. Re-scan through the
+    # existing reporting path so the next approval token is tied to the exact
+    # remaining rows rather than the pre-repair incident.
+    refreshed = _run_and_capture_block(db_path)
+    if refreshed is None:
+        return
+    _annotate_blocked_report(
+        db_path,
+        refreshed,
+        prior_safe_repair=safe_summary,
+    )
+    raise SystemExit(1)

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -154,9 +154,7 @@ def _asset_data_uri(name: str) -> str:
 def _masthead() -> str:
     """Show the Floppy mark, so the page reads as part of the app."""
     icon = _asset_data_uri("android-chrome-192x192.png")
-    mark = (
-        f"<img src='{icon}' alt='' width='36' height='36'>" if icon else ""
-    )
+    mark = f"<img src='{icon}' alt='' width='36' height='36'>" if icon else ""
     return f"<header class='masthead'>{mark}<span>Floppy</span></header>"
 
 
@@ -175,9 +173,10 @@ def _backup_card() -> str:
         )
     else:
         action = (
-            "<p class='note'>Floppy writes a copy of the database to the "
+            "<p class='note'>Floppy writes a verified copy of the database to the "
             "<code>sqlite-recovery</code> folder beside <code>db.sqlite3</code> "
-            "before it removes any entry. Copy the file from there.</p>"
+            "before it changes a broken relationship or removes a row. Copy the "
+            "file from there.</p>"
             f"<p class='note'>To download the file from this page instead, set "
             f"<code>{_DOWNLOAD_ENV}=true</code> and start Floppy again. Keep it "
             "off at other times, because this page has no sign-in.</p>"
@@ -224,7 +223,47 @@ def _affected_list(report: dict) -> str:
         )
     if not rows:
         return ""
-    return "<div class='card'><h2>What is affected</h2><ul>" + "".join(rows) + "</ul></div>"
+    return (
+        "<div class='card'><h2>What is affected</h2><ul>"
+        + "".join(rows)
+        + "</ul></div>"
+    )
+
+
+def _repair_plan_card(report: dict) -> str:
+    """Explain safe work already done and any destructive work still required."""
+    plan = report.get("repair_plan") or {}
+    safe_repair = report.get("safe_repair") or {}
+    parts = []
+    cleared = _count(safe_repair.get("references_cleared"))
+    derived = _count(safe_repair.get("relationship_rows_removed"))
+    if cleared or derived:
+        parts.append(
+            "<p>Floppy already preserved the affected tracking rows where it could: "
+            f"it cleared {cleared} broken optional reference(s) and removed "
+            f"{derived} derived relationship row(s). A verified backup was created "
+            "before those changes.</p>"
+        )
+
+    required = _count(plan.get("required_relationships"))
+    if required:
+        parts.append(
+            f"<p>{required} broken required relationship(s) remain. Those child "
+            "rows cannot exist validly without their missing parent. Repairing the "
+            "database removes only those remaining rows from the live database; "
+            "the verified backup keeps their original data.</p>"
+        )
+
+    safe_pending = _count(plan.get("safe_relationships"))
+    if safe_pending:
+        parts.append(
+            f"<p>{safe_pending} relationship(s) can be repaired without deleting "
+            "their user-owned child rows.</p>"
+        )
+
+    if not parts:
+        return ""
+    return "<div class='card'><h2>Repair plan</h2>" + "".join(parts) + "</div>"
 
 
 def render_page(
@@ -257,7 +296,9 @@ def render_page(
             f"<ul>{corruption_reasons}</ul></div>",
             "<div class='card'><h2>Keep a copy of the damaged file</h2>"
             "<p>Keep the damaged file before you replace it. A repair tool can "
-            "still read data from it.</p>" + _backup_card() + "</div>",
+            "still read data from it.</p>"
+            + _backup_card()
+            + "</div>",
             "<div class='card'><h2>How to restore</h2><ol>"
             "<li>Stop Floppy.</li>"
             "<li>Replace <code>db.sqlite3</code> with your known-good backup.</li>"
@@ -267,57 +308,76 @@ def render_page(
         return _document("".join(parts))
 
     total = _count(report.get("total_conflicts"))
-    can_quarantine = bool(report.get("can_quarantine"))
+    actions = report.get("actions") or {}
+    can_accept = "accept" in actions
+    can_repair = bool("quarantine" in actions and report.get("can_quarantine"))
     parts = [
-        "<h1>Your data is safe. Nothing was deleted.</h1>",
-        f"<p>Floppy found {total} entries that point to a record that is no "
-        "longer in the database. Floppy paused so that you can choose what to "
-        "do. No entry was changed.</p>",
+        "<h1>Your data is safe. Floppy paused before migrations.</h1>",
+        f"<p>Floppy found {total} broken relationship(s). One row can have more "
+        "than one broken relationship, so this number is not a count of rows to "
+        "remove. Floppy paused before migrations so recovery cannot silently "
+        "discard user data.</p>",
+        _repair_plan_card(report),
         _affected_list(report),
     ]
 
     if interactive:
-        parts.append(
-            "<div class='card'><h2>Keep the entries, then start</h2>"
-            "<p>Floppy starts and changes no data. The affected entries stay "
-            "hidden until you repair them.</p>"
-            "<form method='POST' action='/accept'>"
-            "<button>Keep everything and start Floppy</button></form></div>",
-        )
-        if can_quarantine:
+        if can_accept:
             parts.append(
-                "<div class='card'><h2>Remove the entries, then start</h2>"
-                "<p>Floppy saves a backup of the database first. Then it "
-                f"removes the {total} entries above and starts. You cannot "
-                "undo this, but the backup keeps the entries.</p>"
+                "<div class='card'><h2>Keep the entries, then start</h2>"
+                "<p>This legacy choice keeps every invalid relationship. Use it "
+                "only when the current recovery policy explicitly allows it.</p>"
+                "<form method='POST' action='/accept'>"
+                "<button>Keep everything and start Floppy</button></form></div>",
+            )
+        if can_repair:
+            required = _count((report.get("repair_plan") or {}).get("required_relationships"))
+            if required:
+                explanation = (
+                    "Floppy creates and verifies a backup first. It preserves "
+                    "nullable tracking rows by clearing only their broken references. "
+                    "Rows whose required parent is still missing must be removed from "
+                    "the live database so SQLite can validate migrations; their original "
+                    "data remains in the backup."
+                )
+            else:
+                explanation = (
+                    "Floppy creates and verifies a backup first, then repairs the "
+                    "broken relationships without removing user-owned rows when the "
+                    "schema permits that."
+                )
+            parts.append(
+                "<div class='card'><h2>Repair the relationships, then start</h2>"
+                f"<p>{explanation}</p>"
                 "<form method='POST' action='/quarantine'>"
-                f"<button>Remove {total} entries and start Floppy</button>"
+                "<button>Repair relationships and start Floppy</button>"
                 "</form></div>",
             )
-        else:
+        elif not can_accept:
             parts.append(
                 "<div class='card'><h2>Repair these entries yourself</h2>"
-                "<p>Floppy cannot remove these entries safely. The container "
-                "log gives the reason.</p></div>",
+                "<p>Floppy cannot prove that an automatic write is safe for this "
+                "schema. Restore a backup or inspect the technical details before "
+                "you change the database.</p></div>",
             )
     else:
         parts.append(
             "<div class='card'><h2>How to choose</h2>"
-            "<p>This is a copy on disk. To choose an action, open Floppy at "
-            f"port {port} while the container runs.</p></div>",
+            "<p>This is a copy on disk. To choose an available action, open Floppy "
+            f"at port {port} while the container runs.</p></div>",
         )
 
     parts.append(
         "<div class='card'><h2>Use a backup instead</h2><ol>"
         "<li>Stop Floppy.</li>"
         "<li>Replace <code>db.sqlite3</code> with your backup.</li>"
-        "<li>Start Floppy.</li></ol>" + _backup_card() + "</div>",
+        "<li>Start Floppy.</li></ol>"
+        + _backup_card()
+        + "</div>",
     )
     parts.append(_help_card())
     public = {
-        key: value
-        for key, value in report.items()
-        if key not in _SECRET_REPORT_KEYS
+        key: value for key, value in report.items() if key not in _SECRET_REPORT_KEYS
     }
     parts.append(
         "<details><summary>Technical details for a bug report</summary>"
@@ -463,7 +523,11 @@ class _Handler(BaseHTTPRequestHandler):
             size = db_file.stat().st_size
             handle = db_file.open("rb")
         except OSError as error:
-            self._send(404, f"could not read database: {error}", "text/plain; charset=utf-8")
+            self._send(
+                404,
+                f"could not read database: {error}",
+                "text/plain; charset=utf-8",
+            )
             return
         with handle:
             self.send_response(200)
@@ -511,6 +575,17 @@ class _Handler(BaseHTTPRequestHandler):
         if action is None or not report:
             self._send(404, "not found", "text/plain; charset=utf-8")
             return
+        if action not in (report.get("actions") or {}):
+            self._send(
+                403,
+                _document(
+                    "<h1>That recovery choice is not available.</h1>"
+                    "<p>Floppy changed nothing. Reload the recovery page and use "
+                    "one of the choices shown for the current database state.</p>"
+                ),
+                "text/html; charset=utf-8",
+            )
+            return
         if not self._is_same_origin():
             self._send(403, "cross-site request", "text/plain; charset=utf-8")
             return
@@ -537,7 +612,7 @@ class _Handler(BaseHTTPRequestHandler):
                     403,
                     _document(
                         "<h1>Cannot automatically repair</h1><p>These entries "
-                        "cannot be removed automatically.</p>",
+                        "cannot be changed automatically.</p>",
                     ),
                     "text/html; charset=utf-8",
                 )
@@ -587,9 +662,5 @@ def serve(db_path: str, port: object | None = None) -> None:
 
 
 if __name__ == "__main__":
-    cli_port = (
-        sys.argv[_PORT_ARG_INDEX]
-        if len(sys.argv) > _PORT_ARG_INDEX
-        else None
-    )
+    cli_port = sys.argv[_PORT_ARG_INDEX] if len(sys.argv) > _PORT_ARG_INDEX else None
     serve(sys.argv[_DB_PATH_ARG_INDEX], cli_port)

--- a/src/config/sqlite_recovery_server.py
+++ b/src/config/sqlite_recovery_server.py
@@ -349,7 +349,13 @@ def render_page(
             parts.append(
                 "<div class='card'><h2>Repair the relationships, then start</h2>"
                 f"<p>{explanation}</p>"
+                "<p class='note'>Enter the current approval code from the container "
+                "log. The code is tied to this exact database state and changes if "
+                "Floppy safely repairs part of the incident first.</p>"
                 "<form method='POST' action='/quarantine'>"
+                "<p><label for='recovery-token'>Approval code</label><br>"
+                "<input id='recovery-token' name='token' required autocomplete='off' "
+                "spellcheck='false' inputmode='text'></p>"
                 "<button>Repair relationships and start Floppy</button>"
                 "</form></div>",
             )
@@ -596,13 +602,16 @@ class _Handler(BaseHTTPRequestHandler):
                 return
             supplied = (fields.get("token") or [""])[0].strip()
             expected = report.get("incident_token") or ""
-            if supplied and expected and not secrets.compare_digest(supplied, expected):
+            if not supplied or not expected or not secrets.compare_digest(
+                supplied,
+                expected,
+            ):
                 self._send(
                     403,
                     _document(
-                        "<h1>That code is not correct.</h1><p>The code belongs "
-                        "to an earlier problem. Open this page again to get the "
-                        "current one. No entry was changed.</p>",
+                        "<h1>That code is not correct.</h1><p>Use the current "
+                        "approval code from the container log. The code changes "
+                        "when the database state changes. No entry was changed.</p>",
                     ),
                     "text/html; charset=utf-8",
                 )

--- a/src/config/sqlite_repair.py
+++ b/src/config/sqlite_repair.py
@@ -142,15 +142,17 @@ def build_repair_plan(conn: sqlite3.Connection, incident: dict) -> dict:
 
 
 def _broken_reference_where(group: dict) -> str:
-    child = _quote_identifier(group["child_column"])
+    child_column = _quote_identifier(group["child_column"])
     parent_table = _quote_identifier(group["parent"])
     parent_column = _quote_identifier(group["parent_column"])
     # Identifiers come only from SQLite schema inspection and are quoted above;
-    # no request, report, provider, or user value is interpolated here.
+    # no request, report, provider, or user value is interpolated here. Qualify
+    # the child column explicitly so self-referential foreign keys cannot resolve
+    # the name against the inner parent alias.
     return (
-        f"{child} IS NOT NULL AND NOT EXISTS ("  # noqa: S608
+        f"child.{child_column} IS NOT NULL AND NOT EXISTS ("  # noqa: S608
         f"SELECT 1 FROM main.{parent_table} AS parent "
-        f"WHERE parent.{parent_column} = {child})"
+        f"WHERE parent.{parent_column} = child.{child_column})"
     )
 
 
@@ -182,17 +184,18 @@ def apply_repair_plan(
         if action == "clear_reference":
             column = _quote_identifier(group["child_column"])
             result = conn.execute(
-                f"UPDATE main.{table} SET {column} = NULL WHERE {where}"  # noqa: S608
+                f"UPDATE main.{table} AS child SET {column} = NULL "  # noqa: S608
+                f"WHERE {where}"
             )
             counts["references_cleared"] += result.rowcount
         elif action == "remove_relationship":
             result = conn.execute(
-                f"DELETE FROM main.{table} WHERE {where}"  # noqa: S608
+                f"DELETE FROM main.{table} AS child WHERE {where}"  # noqa: S608
             )
             counts["relationship_rows_removed"] += result.rowcount
         elif action == "remove_row":
             result = conn.execute(
-                f"DELETE FROM main.{table} WHERE {where}"  # noqa: S608
+                f"DELETE FROM main.{table} AS child WHERE {where}"  # noqa: S608
             )
             counts["required_rows_removed"] += result.rowcount
         else:

--- a/src/config/sqlite_repair.py
+++ b/src/config/sqlite_repair.py
@@ -24,6 +24,7 @@ class UnsupportedRepairActionError(ValueError):
     """Raised when a repair group names an action the executor does not support."""
 
     def __init__(self, action: object):
+        """Describe the unsupported action without exposing provider data."""
         super().__init__(f"unsupported repair action {action!r}")
 
 
@@ -146,8 +147,8 @@ def _broken_reference_where(group: dict) -> str:
     parent_column = _quote_identifier(group["parent_column"])
     # Identifiers come only from SQLite schema inspection and are quoted above;
     # no request, report, provider, or user value is interpolated here.
-    return (  # noqa: S608
-        f"{child} IS NOT NULL AND NOT EXISTS ("
+    return (
+        f"{child} IS NOT NULL AND NOT EXISTS ("  # noqa: S608
         f"SELECT 1 FROM main.{parent_table} AS parent "
         f"WHERE parent.{parent_column} = {child})"
     )

--- a/src/config/sqlite_repair.py
+++ b/src/config/sqlite_repair.py
@@ -2,11 +2,29 @@
 
 from __future__ import annotations
 
-import sqlite3
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
 
 # These rows only describe a relationship between parent catalog records. If a
 # required parent is gone, the relationship row has no independent user state.
 _DERIVED_RELATION_TABLES = frozenset({"app_albumartist"})
+
+
+class UnsafeRepairPlanError(ValueError):
+    """Raised when a repair plan cannot be applied automatically."""
+
+
+class UnsupportedRepairRelationshipError(ValueError):
+    """Raised when a plan contains a relationship the executor cannot repair."""
+
+
+class UnsupportedRepairActionError(ValueError):
+    """Raised when a repair group names an action the executor does not support."""
+
+    def __init__(self, action: object):
+        super().__init__(f"unsupported repair action {action!r}")
 
 
 def _quote_identifier(identifier: str) -> str:
@@ -126,7 +144,9 @@ def _broken_reference_where(group: dict) -> str:
     child = _quote_identifier(group["child_column"])
     parent_table = _quote_identifier(group["parent"])
     parent_column = _quote_identifier(group["parent_column"])
-    return (
+    # Identifiers come only from SQLite schema inspection and are quoted above;
+    # no request, report, provider, or user value is interpolated here.
+    return (  # noqa: S608
         f"{child} IS NOT NULL AND NOT EXISTS ("
         f"SELECT 1 FROM main.{parent_table} AS parent "
         f"WHERE parent.{parent_column} = {child})"
@@ -141,7 +161,7 @@ def apply_repair_plan(
 ) -> dict:
     """Apply the plan inside the caller's transaction and return actual counts."""
     if not plan.get("can_repair"):
-        raise ValueError("repair plan is not safe to apply automatically")
+        raise UnsafeRepairPlanError
 
     counts = {
         "references_cleared": 0,
@@ -152,7 +172,7 @@ def apply_repair_plan(
     for group in plan.get("groups", []):
         action = group["action"]
         if action == "manual":
-            raise ValueError("repair plan contains an unsupported relationship")
+            raise UnsupportedRepairRelationshipError
         if action == "remove_row" and not include_required:
             continue
 
@@ -175,6 +195,6 @@ def apply_repair_plan(
             )
             counts["required_rows_removed"] += result.rowcount
         else:
-            raise ValueError(f"unsupported repair action {action!r}")
+            raise UnsupportedRepairActionError(action)
 
     return counts

--- a/src/config/sqlite_repair.py
+++ b/src/config/sqlite_repair.py
@@ -1,0 +1,180 @@
+"""Plan and apply data-preserving SQLite foreign-key recovery."""
+
+from __future__ import annotations
+
+import sqlite3
+
+# These rows only describe a relationship between parent catalog records. If a
+# required parent is gone, the relationship row has no independent user state.
+_DERIVED_RELATION_TABLES = frozenset({"app_albumartist"})
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _foreign_key_definition(
+    conn: sqlite3.Connection,
+    table: str,
+    foreign_key_id: int,
+) -> dict | None:
+    rows = list(
+        conn.execute(
+            'SELECT id, seq, "table", "from", "to", on_update, on_delete, match '
+            "FROM pragma_foreign_key_list(?, 'main') WHERE id = ? ORDER BY seq",
+            [table, foreign_key_id],
+        )
+    )
+    # Compound keys need coordinated multi-column repair. Do not guess.
+    if len(rows) != 1 or rows[0][1] != 0:
+        return None
+
+    _id, _seq, parent, child_column, parent_column, _update, _delete, _match = rows[0]
+    if not all(
+        isinstance(value, str) and value
+        for value in (parent, child_column, parent_column)
+    ):
+        return None
+
+    column = conn.execute(
+        'SELECT name, "notnull" FROM pragma_table_xinfo(?, \'main\') WHERE name = ?',
+        [table, child_column],
+    ).fetchone()
+    if not column:
+        return None
+
+    return {
+        "child_column": child_column,
+        "nullable": not bool(column[1]),
+        "parent": parent,
+        "parent_column": parent_column,
+    }
+
+
+def build_repair_plan(conn: sqlite3.Connection, incident: dict) -> dict:
+    """Classify each broken relationship by the least destructive repair."""
+    groups = []
+    unsupported = []
+    safe_relationships = 0
+    required_relationships = 0
+
+    for group in incident.get("groups", []):
+        table = str(group.get("table") or "")
+        parent = str(group.get("parent") or "")
+        foreign_key_id = int(group.get("foreign_key_id", -1))
+        count = int(group.get("count", 0))
+        definition = _foreign_key_definition(conn, table, foreign_key_id)
+
+        if definition is None or definition["parent"] != parent:
+            action = "manual"
+            unsupported.append(
+                f"{table or '<unknown>'} foreign key {foreign_key_id} "
+                "cannot be repaired safely",
+            )
+            child_column = None
+            parent_column = None
+            automatic = False
+        elif definition["nullable"]:
+            action = "clear_reference"
+            child_column = definition["child_column"]
+            parent_column = definition["parent_column"]
+            automatic = True
+            safe_relationships += count
+        elif table in _DERIVED_RELATION_TABLES:
+            action = "remove_relationship"
+            child_column = definition["child_column"]
+            parent_column = definition["parent_column"]
+            automatic = True
+            safe_relationships += count
+        else:
+            action = "remove_row"
+            child_column = definition["child_column"]
+            parent_column = definition["parent_column"]
+            automatic = False
+            required_relationships += count
+
+        groups.append(
+            {
+                "action": action,
+                "automatic": automatic,
+                "child_column": child_column,
+                "count": count,
+                "foreign_key_id": foreign_key_id,
+                "parent": parent,
+                "parent_column": parent_column,
+                "table": table,
+            }
+        )
+
+    technical_reasons = list(incident.get("unsafe_reasons", []))
+    if not incident.get("can_quarantine", False):
+        technical_reasons.append(
+            "the affected table layout is not safe for automatic writes"
+        )
+
+    can_repair = not unsupported and not technical_reasons
+    return {
+        "can_repair": can_repair,
+        "groups": groups,
+        "required_relationships": required_relationships,
+        "safe_relationships": safe_relationships,
+        "unsupported_reasons": [*unsupported, *technical_reasons],
+    }
+
+
+def _broken_reference_where(group: dict) -> str:
+    child = _quote_identifier(group["child_column"])
+    parent_table = _quote_identifier(group["parent"])
+    parent_column = _quote_identifier(group["parent_column"])
+    return (
+        f"{child} IS NOT NULL AND NOT EXISTS ("
+        f"SELECT 1 FROM main.{parent_table} AS parent "
+        f"WHERE parent.{parent_column} = {child})"
+    )
+
+
+def apply_repair_plan(
+    conn: sqlite3.Connection,
+    plan: dict,
+    *,
+    include_required: bool,
+) -> dict:
+    """Apply the plan inside the caller's transaction and return actual counts."""
+    if not plan.get("can_repair"):
+        raise ValueError("repair plan is not safe to apply automatically")
+
+    counts = {
+        "references_cleared": 0,
+        "relationship_rows_removed": 0,
+        "required_rows_removed": 0,
+    }
+
+    for group in plan.get("groups", []):
+        action = group["action"]
+        if action == "manual":
+            raise ValueError("repair plan contains an unsupported relationship")
+        if action == "remove_row" and not include_required:
+            continue
+
+        table = _quote_identifier(group["table"])
+        where = _broken_reference_where(group)
+        if action == "clear_reference":
+            column = _quote_identifier(group["child_column"])
+            result = conn.execute(
+                f"UPDATE main.{table} SET {column} = NULL WHERE {where}"  # noqa: S608
+            )
+            counts["references_cleared"] += result.rowcount
+        elif action == "remove_relationship":
+            result = conn.execute(
+                f"DELETE FROM main.{table} WHERE {where}"  # noqa: S608
+            )
+            counts["relationship_rows_removed"] += result.rowcount
+        elif action == "remove_row":
+            result = conn.execute(
+                f"DELETE FROM main.{table} WHERE {where}"  # noqa: S608
+            )
+            counts["required_rows_removed"] += result.rowcount
+        else:
+            raise ValueError(f"unsupported repair action {action!r}")
+
+    return counts

--- a/src/config/tests/test_sqlite_data_preserving_recovery.py
+++ b/src/config/tests/test_sqlite_data_preserving_recovery.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from django.test import SimpleTestCase
 
+from config import sqlite_recovery_server
 from config.sqlite_recovery_policy import check_database_for_startup
 
 
@@ -116,6 +117,12 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
             self.assertEqual(report["safe_repair"]["references_cleared"], 2)
             self.assertEqual(report["safe_repair"]["relationship_rows_removed"], 1)
             self.assertTrue(Path(report["safe_repair"]["backup_path"]).is_file())
+
+            page = sqlite_recovery_server.render_page(report, interactive=True)
+            self.assertNotIn("action='/accept'", page)
+            self.assertIn("broken relationship", page)
+            self.assertIn("One row can have more than one broken relationship", page)
+            self.assertIn("Repair relationships and start Floppy", page)
 
             Path(f"{db_path}.integrity.decision").write_text(
                 json.dumps(

--- a/src/config/tests/test_sqlite_data_preserving_recovery.py
+++ b/src/config/tests/test_sqlite_data_preserving_recovery.py
@@ -1,0 +1,207 @@
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from config.sqlite_recovery_policy import check_database_for_startup
+
+
+class SqliteDataPreservingRecoveryTests(SimpleTestCase):
+    """Recovery must preserve rows when only optional relationships are broken."""
+
+    def _create_mixed_music_incident(self, tmp_dir):
+        db_path = str(Path(tmp_dir) / "db.sqlite3")
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            PRAGMA foreign_keys=OFF;
+            CREATE TABLE app_item (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                season_number INTEGER
+            );
+            CREATE TABLE app_album (id INTEGER PRIMARY KEY);
+            CREATE TABLE app_track (id INTEGER PRIMARY KEY);
+            CREATE TABLE app_artist (id INTEGER PRIMARY KEY);
+            CREATE TABLE app_music (
+                id INTEGER PRIMARY KEY,
+                item_id INTEGER NOT NULL REFERENCES app_item(id),
+                album_id INTEGER REFERENCES app_album(id),
+                track_id INTEGER REFERENCES app_track(id)
+            );
+            CREATE TABLE app_albumartist (
+                id INTEGER PRIMARY KEY,
+                album_id INTEGER NOT NULL REFERENCES app_album(id),
+                artist_id INTEGER NOT NULL REFERENCES app_artist(id)
+            );
+            CREATE TABLE app_albumtracker (
+                id INTEGER PRIMARY KEY,
+                album_id INTEGER NOT NULL REFERENCES app_album(id),
+                notes TEXT
+            );
+            INSERT INTO app_item VALUES (1, 'Preserve this music entry', NULL);
+            INSERT INTO app_artist VALUES (30);
+            INSERT INTO app_music VALUES (1, 10, 20);
+            """
+        )
+        # Use explicit column lists so this fixture stays readable if the table
+        # layout above changes during review.
+        conn.execute(
+            "INSERT INTO app_music (id, item_id, album_id, track_id) "
+            "VALUES (1, 1, 10, 20)"
+        )
+        conn.execute(
+            "INSERT INTO app_albumartist (id, album_id, artist_id) VALUES (1, 10, 30)"
+        )
+        conn.execute(
+            "INSERT INTO app_albumtracker (id, album_id, notes) "
+            "VALUES (1, 10, 'keep my album tracking state')"
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    @staticmethod
+    def _read_report(db_path):
+        return json.loads(Path(f"{db_path}.integrity.json").read_text())
+
+    def test_mixed_music_damage_preserves_tracking_until_explicit_repair(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self._create_mixed_music_incident(tmp_dir)
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "true",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                self.assertRaises(SystemExit) as blocked,
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            self.assertEqual(blocked.exception.code, 1)
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT album_id, track_id FROM app_music WHERE id = 1"
+                ).fetchone(),
+                (None, None),
+            )
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0],
+                0,
+            )
+            self.assertEqual(
+                conn.execute(
+                    "SELECT notes FROM app_albumtracker WHERE id = 1"
+                ).fetchone()[0],
+                "keep my album tracking state",
+            )
+            remaining = conn.execute("PRAGMA foreign_key_check").fetchall()
+            self.assertEqual(len(remaining), 1)
+            self.assertEqual(remaining[0][0], "app_albumtracker")
+            conn.close()
+
+            report = self._read_report(db_path)
+            self.assertEqual(report["status"], "blocked")
+            self.assertNotIn("accept", report["actions"])
+            self.assertIn("quarantine", report["actions"])
+            self.assertEqual(report["repair_plan"]["safe_relationships"], 0)
+            self.assertEqual(report["repair_plan"]["required_relationships"], 1)
+            self.assertEqual(report["safe_repair"]["references_cleared"], 2)
+            self.assertEqual(report["safe_repair"]["relationship_rows_removed"], 1)
+            self.assertTrue(Path(report["safe_repair"]["backup_path"]).is_file())
+
+            Path(f"{db_path}.integrity.decision").write_text(
+                json.dumps(
+                    {
+                        "action": "quarantine",
+                        "fingerprint": report["fingerprint"],
+                        "token": report["incident_token"],
+                    }
+                )
+            )
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "true",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0], 1)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0],
+                0,
+            )
+            conn.close()
+
+            resolved = self._read_report(db_path)
+            self.assertEqual(resolved["status"], "resolved")
+            self.assertEqual(resolved["resolution"], "operator-repair")
+            self.assertEqual(resolved["repair_result"]["required_rows_removed"], 1)
+            self.assertTrue(Path(resolved["backup_path"]).is_file())
+
+    def test_legacy_accept_is_rejected_without_modifying_rows(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self._create_mixed_music_incident(tmp_dir)
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                self.assertRaises(SystemExit),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            report = self._read_report(db_path)
+            Path(f"{db_path}.integrity.decision").write_text(
+                json.dumps(
+                    {
+                        "action": "accept",
+                        "fingerprint": report["fingerprint"],
+                        "token": report["incident_token"],
+                    }
+                )
+            )
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                self.assertRaises(SystemExit),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0], 1)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0],
+                1,
+            )
+            self.assertGreater(len(conn.execute("PRAGMA foreign_key_check").fetchall()), 0)
+            conn.close()
+
+            refreshed = self._read_report(db_path)
+            self.assertNotIn("accept", refreshed["actions"])
+            self.assertEqual(refreshed["resolution"], "accept-retired")

--- a/src/config/tests/test_sqlite_data_preserving_recovery.py
+++ b/src/config/tests/test_sqlite_data_preserving_recovery.py
@@ -45,7 +45,6 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
             );
             INSERT INTO app_item VALUES (1, 'Preserve this music entry', NULL);
             INSERT INTO app_artist VALUES (30);
-            INSERT INTO app_music VALUES (1, 10, 20);
             """
         )
         # Use explicit column lists so this fixture stays readable if the table
@@ -141,7 +140,10 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
 
             conn = sqlite3.connect(db_path)
             self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
-            self.assertEqual(conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0], 1)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0],
+                1,
+            )
             self.assertEqual(
                 conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0],
                 0,
@@ -194,12 +196,18 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
                 check_database_for_startup(db_path)
 
             conn = sqlite3.connect(db_path)
-            self.assertEqual(conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0], 1)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0],
+                1,
+            )
             self.assertEqual(
                 conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0],
                 1,
             )
-            self.assertGreater(len(conn.execute("PRAGMA foreign_key_check").fetchall()), 0)
+            self.assertGreater(
+                len(conn.execute("PRAGMA foreign_key_check").fetchall()),
+                0,
+            )
             conn.close()
 
             refreshed = self._read_report(db_path)

--- a/src/config/tests/test_sqlite_data_preserving_recovery.py
+++ b/src/config/tests/test_sqlite_data_preserving_recovery.py
@@ -69,6 +69,18 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
     def _read_report(db_path):
         return json.loads(Path(f"{db_path}.integrity.json").read_text())
 
+    @staticmethod
+    def _assert_tracking_rows_unchanged(db_path):
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0] == 1
+            assert (
+                conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0]
+                == 1
+            )
+        finally:
+            conn.close()
+
     def test_mixed_music_damage_preserves_tracking_until_explicit_repair(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self._create_mixed_music_incident(tmp_dir)
@@ -202,21 +214,82 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
             ):
                 check_database_for_startup(db_path)
 
-            conn = sqlite3.connect(db_path)
-            self.assertEqual(
-                conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0],
-                1,
-            )
-            self.assertEqual(
-                conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0],
-                1,
-            )
-            self.assertGreater(
-                len(conn.execute("PRAGMA foreign_key_check").fetchall()),
-                0,
-            )
-            conn.close()
-
+            self._assert_tracking_rows_unchanged(db_path)
             refreshed = self._read_report(db_path)
             self.assertNotIn("accept", refreshed["actions"])
             self.assertEqual(refreshed["resolution"], "accept-retired")
+
+    def test_bare_headless_quarantine_is_rejected_without_modifying_rows(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self._create_mixed_music_incident(tmp_dir)
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                self.assertRaises(SystemExit),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "quarantine",
+                    },
+                ),
+                self.assertRaises(SystemExit),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            self._assert_tracking_rows_unchanged(db_path)
+            self.assertTrue(self._read_report(db_path)["incident_token"])
+
+    def test_decision_without_current_code_is_consumed_and_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = self._create_mixed_music_incident(tmp_dir)
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                self.assertRaises(SystemExit),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            report = self._read_report(db_path)
+            decision_path = Path(f"{db_path}.integrity.decision")
+            decision_path.write_text(
+                json.dumps(
+                    {
+                        "action": "quarantine",
+                        "fingerprint": report["fingerprint"],
+                    }
+                )
+            )
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "FLOPPY_SQLITE_AUTO_REPAIR": "false",
+                        "FLOPPY_SQLITE_CONFLICT_ACTION": "halt",
+                    },
+                ),
+                self.assertRaises(SystemExit),
+                mock.patch("sys.stderr"),
+            ):
+                check_database_for_startup(db_path)
+
+            self.assertFalse(decision_path.exists())
+            self._assert_tracking_rows_unchanged(db_path)
+            self.assertTrue(self._read_report(db_path)["incident_token"])

--- a/src/config/tests/test_sqlite_data_preserving_recovery.py
+++ b/src/config/tests/test_sqlite_data_preserving_recovery.py
@@ -69,14 +69,16 @@ class SqliteDataPreservingRecoveryTests(SimpleTestCase):
     def _read_report(db_path):
         return json.loads(Path(f"{db_path}.integrity.json").read_text())
 
-    @staticmethod
-    def _assert_tracking_rows_unchanged(db_path):
+    def _assert_tracking_rows_unchanged(self, db_path):
         conn = sqlite3.connect(db_path)
         try:
-            assert conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0] == 1
-            assert (
-                conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0]
-                == 1
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_music").fetchone()[0],
+                1,
+            )
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM app_albumtracker").fetchone()[0],
+                1,
             )
         finally:
             conn.close()

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -933,7 +933,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "python": (
                     "#!/bin/sh\n"
                     'case "$*" in\n'
-                    "  *check_database_integrity*)\n"
+                    "  *check_database_for_startup*)\n"
                     '    echo "[entrypoint] bounded integrity failure" >&2\n'
                     "    exit 1\n"
                     "    ;;\n"
@@ -1040,7 +1040,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             python_wrapper.write_text(
                 "#!/bin/sh\n"
                 'case "$2" in\n'
-                "  *check_database_integrity*)\n"
+                "  *check_database_for_startup*)\n"
                 '    echo "$$" > "$CHECKER_PID_FILE"\n'
                 '    echo "[entrypoint] checker waiting" >&2\n'
                 "    exec /bin/sleep 30\n"
@@ -1274,9 +1274,9 @@ class SqliteIntegrityTests(SimpleTestCase):
         script = ENTRYPOINT.read_text()
         check = (
             'timeout "$integrity_timeout" python -c '
-            "'from config.sqlite_integrity import "
-            "check_database_integrity; import sys; "
-            'check_database_integrity(sys.argv[1])\' "$DB_FILE"'
+            "'from config.sqlite_recovery_policy import "
+            "check_database_for_startup; import sys; "
+            'check_database_for_startup(sys.argv[1])\' "$DB_FILE"'
         )
 
         self.assertIn(check, script)
@@ -1476,5 +1476,3 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             self.assertFalse(decision.exists())
             self.assertEqual(self.read_incident_report(db_path)["status"], "corrupt")
-
-

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -208,7 +208,6 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             output = stderr.getvalue()
             self.assertIn("does not carry the current incident token", output)
-            # The operator must be sent to the token, never to the fingerprint.
             report = self.read_incident_report(db_path)
             self.assertIn(f"accept:{report['incident_token']}", output)
             self.assertNotIn(f"accept:{report['fingerprint']}", output)
@@ -333,10 +332,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 live.close()
 
                 if decoy_name:
-                    decoy_path = self.create_orphan_database(
-                        tmp_dir,
-                        db_name=decoy_name,
-                    )
+                    decoy_path = self.create_orphan_database(tmp_dir, db_name=decoy_name)
                     decoy = sqlite3.connect(decoy_path)
                     decoy.execute("CREATE TABLE marker (value TEXT)")
                     decoy.execute("INSERT INTO marker VALUES ('decoy')")
@@ -347,20 +343,14 @@ class SqliteIntegrityTests(SimpleTestCase):
                     check_database_integrity(db_path)
                 token = self.read_incident_report(db_path)["incident_token"]
                 with (
-                    mock.patch.dict(
-                        os.environ,
-                        {_ACTION_ENV: f"quarantine:{token}"},
-                    ),
+                    mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{token}"}),
                     mock.patch("sys.stderr"),
                 ):
                     check_database_integrity(db_path)
 
                 report = self.read_incident_report(db_path)
                 backup = sqlite3.connect(report["backup_path"])
-                self.assertEqual(
-                    backup.execute("SELECT value FROM marker").fetchone()[0],
-                    "live",
-                )
+                self.assertEqual(backup.execute("SELECT value FROM marker").fetchone()[0], "live")
                 self.assertEqual(backup.execute("SELECT COUNT(*) FROM child").fetchone()[0], 1)
                 backup.close()
 
@@ -399,9 +389,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 check_database_integrity(db_path)
             old_token = self.read_incident_report(db_path)["incident_token"]
             action = f"quarantine:{old_token}"
-            with mock.patch.dict(os.environ, {_ACTION_ENV: action}), mock.patch(
-                "sys.stderr"
-            ):
+            with mock.patch.dict(os.environ, {_ACTION_ENV: action}), mock.patch("sys.stderr"):
                 check_database_integrity(db_path)
 
             conn = sqlite3.connect(db_path)
@@ -445,10 +433,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertNotIn("quarantine", report["actions"])
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -491,8 +476,6 @@ class SqliteIntegrityTests(SimpleTestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_orphan_database(tmp_dir)
             conn = sqlite3.connect(db_path)
-            # sqlite_schema.tbl_name keeps the spelling used by CREATE TRIGGER,
-            # but SQLite still fires the trigger for the canonical table name.
             conn.executescript(
                 """
                 CREATE TABLE unrelated (id INTEGER PRIMARY KEY);
@@ -512,10 +495,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertNotIn("quarantine", report["actions"])
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -552,9 +532,7 @@ class SqliteIntegrityTests(SimpleTestCase):
 
             self.assertFalse(report["can_quarantine"])
             self.assertNotIn("quarantine", report["actions"])
-            self.assertTrue(
-                any("shadows hidden row identity" in reason for reason in report["unsafe_reasons"])
-            )
+            self.assertTrue(any("shadows hidden row identity" in reason for reason in report["unsafe_reasons"]))
             conn = sqlite3.connect(db_path)
             self.assertEqual(
                 conn.execute("SELECT rowid, parent_id FROM child ORDER BY parent_id").fetchall(),
@@ -573,10 +551,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             report = self.read_incident_report(db_path)
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -608,14 +583,8 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_connect(database, *args, **kwargs)
 
             with (
-                mock.patch(
-                    "config.sqlite_integrity.sqlite3.connect",
-                    side_effect=connect,
-                ),
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
+                mock.patch("config.sqlite_integrity.sqlite3.connect", side_effect=connect),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -634,14 +603,8 @@ class SqliteIntegrityTests(SimpleTestCase):
             report = self.read_incident_report(db_path)
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
-                mock.patch(
-                    "config.sqlite_integrity.os.link",
-                    side_effect=FileExistsError("collision"),
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch("config.sqlite_integrity.os.link", side_effect=FileExistsError("collision")),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -655,16 +618,10 @@ class SqliteIntegrityTests(SimpleTestCase):
     def test_verified_backup_survives_call_during_exception_handling(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_orphan_database(tmp_dir)
-            # Cleanup must key off this call's own outcome. A caller that is
-            # already handling an unrelated exception must still get a backup,
-            # otherwise rows are deleted against a file that was just removed.
             try:
                 json.loads("{")
             except ValueError:
-                backup_path = sqlite_integrity._create_verified_backup(
-                    db_path,
-                    "0" * 64,
-                )
+                backup_path = sqlite_integrity._create_verified_backup(db_path, "0" * 64)
 
             self.assertTrue(backup_path.is_file())
             backup = sqlite3.connect(f"file:{backup_path}?mode=ro", uri=True)
@@ -685,15 +642,8 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_write(*args, **kwargs)
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
-                mock.patch.object(
-                    sqlite_integrity,
-                    "_write_incident_report",
-                    side_effect=fail_resolved,
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.object(sqlite_integrity, "_write_incident_report", side_effect=fail_resolved),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -729,15 +679,8 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_fsync_directory(directory)
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"},
-                ),
-                mock.patch.object(
-                    sqlite_integrity,
-                    "_fsync_directory",
-                    side_effect=fail_after_resolved_replace,
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"}),
+                mock.patch.object(sqlite_integrity, "_fsync_directory", side_effect=fail_after_resolved_replace),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -781,15 +724,8 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_fsync_directory(directory)
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"},
-                ),
-                mock.patch.object(
-                    sqlite_integrity,
-                    "_fsync_directory",
-                    side_effect=fail_resolved_and_restoration,
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"}),
+                mock.patch.object(sqlite_integrity, "_fsync_directory", side_effect=fail_resolved_and_restoration),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -816,15 +752,8 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_write(*args, **kwargs)
 
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
-                mock.patch.object(
-                    sqlite_integrity,
-                    "_write_incident_report",
-                    side_effect=fail_resolved,
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.object(sqlite_integrity, "_write_incident_report", side_effect=fail_resolved),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -832,14 +761,11 @@ class SqliteIntegrityTests(SimpleTestCase):
 
             prepared = self.read_incident_report(db_path)
             self.assertEqual(prepared["status"], "prepared")
-            # The operator prunes sqlite-recovery/ after reading the report.
             Path(prepared["backup_path"]).unlink()
 
             with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
                 check_database_integrity(db_path)
 
-            # The delete is already committed and the relationships are clean,
-            # so bookkeeping must not wedge an otherwise healthy container.
             self.assertIn("could not be finalized", stderr.getvalue())
             self.assertEqual(self.read_incident_report(db_path)["status"], "prepared")
 
@@ -864,19 +790,13 @@ class SqliteIntegrityTests(SimpleTestCase):
                 check_database_integrity(db_path)
             report = self.read_incident_report(db_path)
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
 
             conn = sqlite3.connect(db_path)
-            self.assertEqual(
-                conn.execute("SELECT COUNT(*) FROM main.floppy_fk_conflicts").fetchone()[0],
-                0,
-            )
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM main.floppy_fk_conflicts").fetchone()[0], 0)
             conn.close()
 
     def test_wal_backup_is_complete_and_restorable(self):
@@ -903,10 +823,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 check_database_integrity(db_path)
             report = self.read_incident_report(db_path)
             with (
-                mock.patch.dict(
-                    os.environ,
-                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
-                ),
+                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
@@ -933,7 +850,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "python": (
                     "#!/bin/sh\n"
                     'case "$*" in\n'
-                    "  *check_database_integrity*)\n"
+                    "  *check_database_for_startup*)\n"
                     '    echo "[entrypoint] bounded integrity failure" >&2\n'
                     "    exit 1\n"
                     "    ;;\n"
@@ -947,9 +864,6 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "sleep": (
                     "#!/bin/sh\n"
                     'echo "$$" > "$PARKING_PID_FILE"\n'
-                    # Sleep for the interval the entrypoint asked for. A shorter
-                    # fixed sleep ends, the parking loop starts another one, and
-                    # the pid file is overwritten while the test reads it.
                     'exec /bin/sleep "$@"\n'
                 ),
             }
@@ -988,9 +902,6 @@ class SqliteIntegrityTests(SimpleTestCase):
                     and time.monotonic() < deadline
                 ):
                     time.sleep(0.02)
-                # Two faults leave parking_child_before_term False and they need
-                # opposite fixes: the wait ran out before the pid file appeared,
-                # or the file appeared naming a process that had already exited.
                 waited_seconds = time.monotonic() - started_waiting
                 pid_file_appeared = (tmp_path / "parking.pid").is_file()
                 parked_before_term = process.poll() is None
@@ -1021,7 +932,6 @@ class SqliteIntegrityTests(SimpleTestCase):
             )
             self.assertEqual(process.returncode, 0)
             self.assertEqual(output.count("bounded integrity failure"), 1)
-            # "Parks once" means the outer loop did not run the check again.
             self.assertEqual(output.count("Checking SQLite storage"), 1, output)
             self.assertNotIn("Still checking SQLite integrity", output)
             self.assertIn("SQLite startup is paused", output)
@@ -1040,7 +950,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             python_wrapper.write_text(
                 "#!/bin/sh\n"
                 'case "$2" in\n'
-                "  *check_database_integrity*)\n"
+                "  *check_database_for_startup*)\n"
                 '    echo "$$" > "$CHECKER_PID_FILE"\n'
                 '    echo "[entrypoint] checker waiting" >&2\n'
                 "    exec /bin/sleep 30\n"
@@ -1073,10 +983,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                     text=True,
                 )
                 deadline = time.monotonic() + 5
-                while (
-                    "checker waiting" not in output_path.read_text()
-                    and time.monotonic() < deadline
-                ):
+                while "checker waiting" not in output_path.read_text() and time.monotonic() < deadline:
                     time.sleep(0.02)
                 process.terminate()
                 process.wait(timeout=5)
@@ -1134,10 +1041,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_connect(path, *args, **kwargs)
 
             with (
-                mock.patch(
-                    "config.sqlite_integrity.sqlite3.connect",
-                    side_effect=connect,
-                ),
+                mock.patch("config.sqlite_integrity.sqlite3.connect", side_effect=connect),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
@@ -1181,19 +1085,13 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_connect(path, *args, **kwargs)
 
             with (
-                mock.patch(
-                    "config.sqlite_integrity.sqlite3.connect",
-                    side_effect=connect,
-                ),
+                mock.patch("config.sqlite_integrity.sqlite3.connect", side_effect=connect),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
 
             verify = sqlite3.connect(db_path)
-            self.assertEqual(
-                verify.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0],
-                0,
-            )
+            self.assertEqual(verify.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0], 0)
             verify.close()
 
     def test_busy_database_reports_lock_action(self):
@@ -1274,13 +1172,12 @@ class SqliteIntegrityTests(SimpleTestCase):
         script = ENTRYPOINT.read_text()
         check = (
             'timeout "$integrity_timeout" python -c '
-            "'from config.sqlite_integrity import "
-            "check_database_integrity; import sys; "
-            'check_database_integrity(sys.argv[1])\' "$DB_FILE"'
+            "'from config.sqlite_recovery_policy import "
+            "check_database_for_startup; import sys; "
+            'check_database_for_startup(sys.argv[1])\' "$DB_FILE"'
         )
 
         self.assertIn(check, script)
-        # The bound and the message it reports must come from one definition.
         self.assertIn("integrity_timeout=600", script)
         self.assertIn('"$DB_FILE" &', script)
         self.assertNotIn("kill -0", script)
@@ -1323,11 +1220,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 raise sqlite3.DatabaseError(message)
 
             with (
-                mock.patch.object(
-                    sqlite_integrity,
-                    "_describe_affected",
-                    raise_damaged,
-                ),
+                mock.patch.object(sqlite_integrity, "_describe_affected", raise_damaged),
                 self.assertRaises(SystemExit) as ctx,
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -1336,7 +1229,6 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             output = stderr.getvalue()
             self.assertIn("Could not name the affected entries", output)
-            # The operator still gets the report and the way out of the incident.
             report = self.read_incident_report(db_path)
             self.assertEqual(report["status"], "blocked")
             self.assertIn(f"accept:{report['incident_token']}", output)
@@ -1420,14 +1312,12 @@ class SqliteIntegrityTests(SimpleTestCase):
             for i in range(15):
                 file_path = recovery_dir / f"db-backup-{i:02d}.sqlite3"
                 file_path.write_text("backup")
-                # Set distinct mtimes
                 os.utime(file_path, (1000 + i * 10, 1000 + i * 10))
 
             sqlite_integrity._prune_recovery_backups(recovery_dir, max_keep=10)
 
             remaining = sorted(p.name for p in recovery_dir.glob("*.sqlite3"))
             self.assertEqual(len(remaining), 10)
-            # The 5 oldest (00 to 04) must have been pruned
             self.assertNotIn("db-backup-00.sqlite3", remaining)
             self.assertNotIn("db-backup-04.sqlite3", remaining)
             self.assertIn("db-backup-14.sqlite3", remaining)
@@ -1476,5 +1366,3 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             self.assertFalse(decision.exists())
             self.assertEqual(self.read_incident_report(db_path)["status"], "corrupt")
-
-

--- a/src/config/tests/test_sqlite_integrity.py
+++ b/src/config/tests/test_sqlite_integrity.py
@@ -208,6 +208,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             output = stderr.getvalue()
             self.assertIn("does not carry the current incident token", output)
+            # The operator must be sent to the token, never to the fingerprint.
             report = self.read_incident_report(db_path)
             self.assertIn(f"accept:{report['incident_token']}", output)
             self.assertNotIn(f"accept:{report['fingerprint']}", output)
@@ -332,7 +333,10 @@ class SqliteIntegrityTests(SimpleTestCase):
                 live.close()
 
                 if decoy_name:
-                    decoy_path = self.create_orphan_database(tmp_dir, db_name=decoy_name)
+                    decoy_path = self.create_orphan_database(
+                        tmp_dir,
+                        db_name=decoy_name,
+                    )
                     decoy = sqlite3.connect(decoy_path)
                     decoy.execute("CREATE TABLE marker (value TEXT)")
                     decoy.execute("INSERT INTO marker VALUES ('decoy')")
@@ -343,14 +347,20 @@ class SqliteIntegrityTests(SimpleTestCase):
                     check_database_integrity(db_path)
                 token = self.read_incident_report(db_path)["incident_token"]
                 with (
-                    mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{token}"}),
+                    mock.patch.dict(
+                        os.environ,
+                        {_ACTION_ENV: f"quarantine:{token}"},
+                    ),
                     mock.patch("sys.stderr"),
                 ):
                     check_database_integrity(db_path)
 
                 report = self.read_incident_report(db_path)
                 backup = sqlite3.connect(report["backup_path"])
-                self.assertEqual(backup.execute("SELECT value FROM marker").fetchone()[0], "live")
+                self.assertEqual(
+                    backup.execute("SELECT value FROM marker").fetchone()[0],
+                    "live",
+                )
                 self.assertEqual(backup.execute("SELECT COUNT(*) FROM child").fetchone()[0], 1)
                 backup.close()
 
@@ -389,7 +399,9 @@ class SqliteIntegrityTests(SimpleTestCase):
                 check_database_integrity(db_path)
             old_token = self.read_incident_report(db_path)["incident_token"]
             action = f"quarantine:{old_token}"
-            with mock.patch.dict(os.environ, {_ACTION_ENV: action}), mock.patch("sys.stderr"):
+            with mock.patch.dict(os.environ, {_ACTION_ENV: action}), mock.patch(
+                "sys.stderr"
+            ):
                 check_database_integrity(db_path)
 
             conn = sqlite3.connect(db_path)
@@ -433,7 +445,10 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertNotIn("quarantine", report["actions"])
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -476,6 +491,8 @@ class SqliteIntegrityTests(SimpleTestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_orphan_database(tmp_dir)
             conn = sqlite3.connect(db_path)
+            # sqlite_schema.tbl_name keeps the spelling used by CREATE TRIGGER,
+            # but SQLite still fires the trigger for the canonical table name.
             conn.executescript(
                 """
                 CREATE TABLE unrelated (id INTEGER PRIMARY KEY);
@@ -495,7 +512,10 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertNotIn("quarantine", report["actions"])
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -532,7 +552,9 @@ class SqliteIntegrityTests(SimpleTestCase):
 
             self.assertFalse(report["can_quarantine"])
             self.assertNotIn("quarantine", report["actions"])
-            self.assertTrue(any("shadows hidden row identity" in reason for reason in report["unsafe_reasons"]))
+            self.assertTrue(
+                any("shadows hidden row identity" in reason for reason in report["unsafe_reasons"])
+            )
             conn = sqlite3.connect(db_path)
             self.assertEqual(
                 conn.execute("SELECT rowid, parent_id FROM child ORDER BY parent_id").fetchall(),
@@ -551,7 +573,10 @@ class SqliteIntegrityTests(SimpleTestCase):
             report = self.read_incident_report(db_path)
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -583,8 +608,14 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_connect(database, *args, **kwargs)
 
             with (
-                mock.patch("config.sqlite_integrity.sqlite3.connect", side_effect=connect),
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch(
+                    "config.sqlite_integrity.sqlite3.connect",
+                    side_effect=connect,
+                ),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -603,8 +634,14 @@ class SqliteIntegrityTests(SimpleTestCase):
             report = self.read_incident_report(db_path)
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
-                mock.patch("config.sqlite_integrity.os.link", side_effect=FileExistsError("collision")),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
+                mock.patch(
+                    "config.sqlite_integrity.os.link",
+                    side_effect=FileExistsError("collision"),
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -618,10 +655,16 @@ class SqliteIntegrityTests(SimpleTestCase):
     def test_verified_backup_survives_call_during_exception_handling(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_orphan_database(tmp_dir)
+            # Cleanup must key off this call's own outcome. A caller that is
+            # already handling an unrelated exception must still get a backup,
+            # otherwise rows are deleted against a file that was just removed.
             try:
                 json.loads("{")
             except ValueError:
-                backup_path = sqlite_integrity._create_verified_backup(db_path, "0" * 64)
+                backup_path = sqlite_integrity._create_verified_backup(
+                    db_path,
+                    "0" * 64,
+                )
 
             self.assertTrue(backup_path.is_file())
             backup = sqlite3.connect(f"file:{backup_path}?mode=ro", uri=True)
@@ -642,8 +685,15 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_write(*args, **kwargs)
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
-                mock.patch.object(sqlite_integrity, "_write_incident_report", side_effect=fail_resolved),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
+                mock.patch.object(
+                    sqlite_integrity,
+                    "_write_incident_report",
+                    side_effect=fail_resolved,
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -679,8 +729,15 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_fsync_directory(directory)
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"}),
-                mock.patch.object(sqlite_integrity, "_fsync_directory", side_effect=fail_after_resolved_replace),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"},
+                ),
+                mock.patch.object(
+                    sqlite_integrity,
+                    "_fsync_directory",
+                    side_effect=fail_after_resolved_replace,
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -724,8 +781,15 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_fsync_directory(directory)
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"}),
-                mock.patch.object(sqlite_integrity, "_fsync_directory", side_effect=fail_resolved_and_restoration),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{blocked['incident_token']}"},
+                ),
+                mock.patch.object(
+                    sqlite_integrity,
+                    "_fsync_directory",
+                    side_effect=fail_resolved_and_restoration,
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -752,8 +816,15 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_write(*args, **kwargs)
 
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
-                mock.patch.object(sqlite_integrity, "_write_incident_report", side_effect=fail_resolved),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
+                mock.patch.object(
+                    sqlite_integrity,
+                    "_write_incident_report",
+                    side_effect=fail_resolved,
+                ),
                 self.assertRaises(SystemExit),
                 mock.patch("sys.stderr"),
             ):
@@ -761,11 +832,14 @@ class SqliteIntegrityTests(SimpleTestCase):
 
             prepared = self.read_incident_report(db_path)
             self.assertEqual(prepared["status"], "prepared")
+            # The operator prunes sqlite-recovery/ after reading the report.
             Path(prepared["backup_path"]).unlink()
 
             with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
                 check_database_integrity(db_path)
 
+            # The delete is already committed and the relationships are clean,
+            # so bookkeeping must not wedge an otherwise healthy container.
             self.assertIn("could not be finalized", stderr.getvalue())
             self.assertEqual(self.read_incident_report(db_path)["status"], "prepared")
 
@@ -790,13 +864,19 @@ class SqliteIntegrityTests(SimpleTestCase):
                 check_database_integrity(db_path)
             report = self.read_incident_report(db_path)
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
 
             conn = sqlite3.connect(db_path)
-            self.assertEqual(conn.execute("SELECT COUNT(*) FROM main.floppy_fk_conflicts").fetchone()[0], 0)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM main.floppy_fk_conflicts").fetchone()[0],
+                0,
+            )
             conn.close()
 
     def test_wal_backup_is_complete_and_restorable(self):
@@ -823,7 +903,10 @@ class SqliteIntegrityTests(SimpleTestCase):
                 check_database_integrity(db_path)
             report = self.read_incident_report(db_path)
             with (
-                mock.patch.dict(os.environ, {_ACTION_ENV: f"quarantine:{report['incident_token']}"}),
+                mock.patch.dict(
+                    os.environ,
+                    {_ACTION_ENV: f"quarantine:{report['incident_token']}"},
+                ),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
@@ -850,7 +933,7 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "python": (
                     "#!/bin/sh\n"
                     'case "$*" in\n'
-                    "  *check_database_for_startup*)\n"
+                    "  *check_database_integrity*)\n"
                     '    echo "[entrypoint] bounded integrity failure" >&2\n'
                     "    exit 1\n"
                     "    ;;\n"
@@ -864,6 +947,9 @@ class SqliteIntegrityTests(SimpleTestCase):
                 "sleep": (
                     "#!/bin/sh\n"
                     'echo "$$" > "$PARKING_PID_FILE"\n'
+                    # Sleep for the interval the entrypoint asked for. A shorter
+                    # fixed sleep ends, the parking loop starts another one, and
+                    # the pid file is overwritten while the test reads it.
                     'exec /bin/sleep "$@"\n'
                 ),
             }
@@ -902,6 +988,9 @@ class SqliteIntegrityTests(SimpleTestCase):
                     and time.monotonic() < deadline
                 ):
                     time.sleep(0.02)
+                # Two faults leave parking_child_before_term False and they need
+                # opposite fixes: the wait ran out before the pid file appeared,
+                # or the file appeared naming a process that had already exited.
                 waited_seconds = time.monotonic() - started_waiting
                 pid_file_appeared = (tmp_path / "parking.pid").is_file()
                 parked_before_term = process.poll() is None
@@ -932,6 +1021,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             )
             self.assertEqual(process.returncode, 0)
             self.assertEqual(output.count("bounded integrity failure"), 1)
+            # "Parks once" means the outer loop did not run the check again.
             self.assertEqual(output.count("Checking SQLite storage"), 1, output)
             self.assertNotIn("Still checking SQLite integrity", output)
             self.assertIn("SQLite startup is paused", output)
@@ -950,7 +1040,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             python_wrapper.write_text(
                 "#!/bin/sh\n"
                 'case "$2" in\n'
-                "  *check_database_for_startup*)\n"
+                "  *check_database_integrity*)\n"
                 '    echo "$$" > "$CHECKER_PID_FILE"\n'
                 '    echo "[entrypoint] checker waiting" >&2\n'
                 "    exec /bin/sleep 30\n"
@@ -983,7 +1073,10 @@ class SqliteIntegrityTests(SimpleTestCase):
                     text=True,
                 )
                 deadline = time.monotonic() + 5
-                while "checker waiting" not in output_path.read_text() and time.monotonic() < deadline:
+                while (
+                    "checker waiting" not in output_path.read_text()
+                    and time.monotonic() < deadline
+                ):
                     time.sleep(0.02)
                 process.terminate()
                 process.wait(timeout=5)
@@ -1041,7 +1134,10 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_connect(path, *args, **kwargs)
 
             with (
-                mock.patch("config.sqlite_integrity.sqlite3.connect", side_effect=connect),
+                mock.patch(
+                    "config.sqlite_integrity.sqlite3.connect",
+                    side_effect=connect,
+                ),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
@@ -1085,13 +1181,19 @@ class SqliteIntegrityTests(SimpleTestCase):
                 return real_connect(path, *args, **kwargs)
 
             with (
-                mock.patch("config.sqlite_integrity.sqlite3.connect", side_effect=connect),
+                mock.patch(
+                    "config.sqlite_integrity.sqlite3.connect",
+                    side_effect=connect,
+                ),
                 mock.patch("sys.stderr"),
             ):
                 check_database_integrity(db_path)
 
             verify = sqlite3.connect(db_path)
-            self.assertEqual(verify.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0], 0)
+            self.assertEqual(
+                verify.execute("SELECT COUNT(*) FROM app_albumartist").fetchone()[0],
+                0,
+            )
             verify.close()
 
     def test_busy_database_reports_lock_action(self):
@@ -1172,12 +1274,13 @@ class SqliteIntegrityTests(SimpleTestCase):
         script = ENTRYPOINT.read_text()
         check = (
             'timeout "$integrity_timeout" python -c '
-            "'from config.sqlite_recovery_policy import "
-            "check_database_for_startup; import sys; "
-            'check_database_for_startup(sys.argv[1])\' "$DB_FILE"'
+            "'from config.sqlite_integrity import "
+            "check_database_integrity; import sys; "
+            'check_database_integrity(sys.argv[1])\' "$DB_FILE"'
         )
 
         self.assertIn(check, script)
+        # The bound and the message it reports must come from one definition.
         self.assertIn("integrity_timeout=600", script)
         self.assertIn('"$DB_FILE" &', script)
         self.assertNotIn("kill -0", script)
@@ -1220,7 +1323,11 @@ class SqliteIntegrityTests(SimpleTestCase):
                 raise sqlite3.DatabaseError(message)
 
             with (
-                mock.patch.object(sqlite_integrity, "_describe_affected", raise_damaged),
+                mock.patch.object(
+                    sqlite_integrity,
+                    "_describe_affected",
+                    raise_damaged,
+                ),
                 self.assertRaises(SystemExit) as ctx,
                 mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
             ):
@@ -1229,6 +1336,7 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             output = stderr.getvalue()
             self.assertIn("Could not name the affected entries", output)
+            # The operator still gets the report and the way out of the incident.
             report = self.read_incident_report(db_path)
             self.assertEqual(report["status"], "blocked")
             self.assertIn(f"accept:{report['incident_token']}", output)
@@ -1312,12 +1420,14 @@ class SqliteIntegrityTests(SimpleTestCase):
             for i in range(15):
                 file_path = recovery_dir / f"db-backup-{i:02d}.sqlite3"
                 file_path.write_text("backup")
+                # Set distinct mtimes
                 os.utime(file_path, (1000 + i * 10, 1000 + i * 10))
 
             sqlite_integrity._prune_recovery_backups(recovery_dir, max_keep=10)
 
             remaining = sorted(p.name for p in recovery_dir.glob("*.sqlite3"))
             self.assertEqual(len(remaining), 10)
+            # The 5 oldest (00 to 04) must have been pruned
             self.assertNotIn("db-backup-00.sqlite3", remaining)
             self.assertNotIn("db-backup-04.sqlite3", remaining)
             self.assertIn("db-backup-14.sqlite3", remaining)
@@ -1366,3 +1476,5 @@ class SqliteIntegrityTests(SimpleTestCase):
             self.assertEqual(ctx.exception.code, 1)
             self.assertFalse(decision.exists())
             self.assertEqual(self.read_incident_report(db_path)["status"], "corrupt")
+
+

--- a/src/config/tests/test_sqlite_recovery_policy.py
+++ b/src/config/tests/test_sqlite_recovery_policy.py
@@ -1,5 +1,7 @@
 import json
+import os
 import tempfile
+import unittest
 from pathlib import Path
 
 from django.test import SimpleTestCase
@@ -78,3 +80,23 @@ class SqliteRecoveryPolicyTests(SimpleTestCase):
 
             self.assertFalse(reopened)
             self.assertEqual(report_path.read_text(), before)
+
+    @unittest.skipUnless(
+        hasattr(os, "mkfifo") and hasattr(os, "O_NONBLOCK"),
+        "requires POSIX FIFO support",
+    )
+    def test_non_regular_decision_file_is_rejected_without_blocking(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = str(Path(tmp_dir) / "db.sqlite3")
+            Path(db_path).touch()
+            decision_path = sqlite_recovery_policy._decision_path(db_path)
+            os.mkfifo(decision_path)
+            report = {
+                "fingerprint": "a" * 64,
+                "incident_token": "b" * 32,
+            }
+
+            decision = sqlite_recovery_policy._read_policy_decision(db_path, report)
+
+            self.assertIsNone(decision)
+            self.assertFalse(decision_path.exists())

--- a/src/config/tests/test_sqlite_recovery_policy.py
+++ b/src/config/tests/test_sqlite_recovery_policy.py
@@ -48,7 +48,7 @@ class SqliteRecoveryPolicyTests(SimpleTestCase):
             self.assertTrue(reopened)
             report = json.loads(Path(f"{db_path}.integrity.json").read_text())
             self.assertEqual(report["status"], "blocked")
-            self.assertEqual(report["resolution"], "accept-expired")
+            self.assertEqual(report["resolution"], "accept-retired")
             self.assertEqual(report["fingerprint"], "a" * 64)
             self.assertEqual(len(report["incident_token"]), 32)
             self.assertIn("accept", report["actions"])

--- a/src/config/tests/test_sqlite_recovery_server.py
+++ b/src/config/tests/test_sqlite_recovery_server.py
@@ -167,25 +167,20 @@ class RecoveryPageTests(SimpleTestCase):
             )
             conn.close()
 
-    def test_1_click_quarantine_records_the_choice(self):
+    def test_quarantine_without_code_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = self.create_incident(tmp_dir)
             report = self.block_startup(db_path)
             base = self.serve(db_path)
 
-            response = self.post(f"{base}/quarantine")
-            self.assertEqual(response.status, 200)
-            body = response.read().decode()
-            self.assertIn("Floppy has your choice.", body)
-            # The app needs minutes to migrate and start. A timed reload would
-            # land on a connection error and read as a failed repair.
-            self.assertNotIn("http-equiv='refresh'", body)
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                self.post(f"{base}/quarantine")
+            self.assertEqual(ctx.exception.code, 403)
+            self.assertFalse(Path(f"{db_path}.integrity.decision").exists())
 
-            decision = json.loads(
-                Path(f"{db_path}.integrity.decision").read_text(),
-            )
-            self.assertEqual(decision["action"], "quarantine")
-            self.assertEqual(decision["fingerprint"], report["fingerprint"])
+            page = recovery.render_page(report, interactive=True)
+            self.assertIn("name='token' required", page)
+            self.assertIn("Approval code", page)
 
     def test_recovery_server_sends_no_cache_headers(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -204,15 +199,22 @@ class RecoveryPageTests(SimpleTestCase):
             report = self.block_startup(db_path)
             base = self.serve(db_path)
 
-            self.post(
+            response = self.post(
                 f"{base}/quarantine",
                 {"token": report["incident_token"]},
-            ).read()
+            )
+            self.assertEqual(response.status, 200)
+            body = response.read().decode()
+            self.assertIn("Floppy has your choice.", body)
+            # The app needs minutes to migrate and start. A timed reload would
+            # land on a connection error and read as a failed repair.
+            self.assertNotIn("http-equiv='refresh'", body)
 
             decision = json.loads(
                 Path(f"{db_path}.integrity.decision").read_text(),
             )
             self.assertEqual(decision["action"], "quarantine")
+            self.assertEqual(decision["fingerprint"], report["fingerprint"])
 
     def test_the_page_is_written_beside_the_database_and_is_readable(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -514,4 +516,3 @@ class RecoveryPageTests(SimpleTestCase):
         report = {"total_conflicts": 2, "can_quarantine": True, "affected": []}
         page = recovery.render_page(report, interactive=True)
         self.assertIsNone(re.search(r"<a\b[^>]*>\s*<button", page))
-

--- a/src/config/tests/test_sqlite_repair.py
+++ b/src/config/tests/test_sqlite_repair.py
@@ -1,0 +1,46 @@
+import sqlite3
+
+from django.test import SimpleTestCase
+
+from config.sqlite_integrity import _inspect_foreign_keys
+from config.sqlite_repair import apply_repair_plan, build_repair_plan
+
+
+class SqliteRepairPlannerTests(SimpleTestCase):
+    """The generic repair executor must preserve relationship semantics."""
+
+    def test_self_referential_nullable_fk_clears_only_the_broken_reference(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(
+                """
+                PRAGMA foreign_keys=OFF;
+                CREATE TABLE node (
+                    id INTEGER PRIMARY KEY,
+                    parent_id INTEGER REFERENCES node(id)
+                );
+                INSERT INTO node VALUES (1, NULL);
+                INSERT INTO node VALUES (2, 1);
+                INSERT INTO node VALUES (3, 99);
+                """
+            )
+            incident = _inspect_foreign_keys(conn)
+            self.assertEqual(incident["total_conflicts"], 1)
+
+            plan = build_repair_plan(conn, incident)
+            self.assertTrue(plan["can_repair"])
+            self.assertEqual(plan["groups"][0]["action"], "clear_reference")
+
+            result = apply_repair_plan(conn, plan, include_required=False)
+
+            self.assertEqual(result["references_cleared"], 1)
+            self.assertEqual(
+                conn.execute("SELECT parent_id FROM node WHERE id = 2").fetchone()[0],
+                1,
+            )
+            self.assertIsNone(
+                conn.execute("SELECT parent_id FROM node WHERE id = 3").fetchone()[0]
+            )
+            self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
+        finally:
+            conn.close()

--- a/src/config/tests/test_sqlite_repair.py
+++ b/src/config/tests/test_sqlite_repair.py
@@ -3,7 +3,11 @@ import sqlite3
 from django.test import SimpleTestCase
 
 from config.sqlite_integrity import _inspect_foreign_keys
-from config.sqlite_repair import apply_repair_plan, build_repair_plan
+from config.sqlite_repair import (
+    UnsafeRepairPlanError,
+    apply_repair_plan,
+    build_repair_plan,
+)
 
 
 class SqliteRepairPlannerTests(SimpleTestCase):
@@ -42,5 +46,46 @@ class SqliteRepairPlannerTests(SimpleTestCase):
                 conn.execute("SELECT parent_id FROM node WHERE id = 3").fetchone()[0]
             )
             self.assertEqual(conn.execute("PRAGMA foreign_key_check").fetchall(), [])
+        finally:
+            conn.close()
+
+    def test_compound_foreign_key_fails_closed_without_writing(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(
+                """
+                PRAGMA foreign_keys=OFF;
+                CREATE TABLE parent (
+                    part_a INTEGER NOT NULL,
+                    part_b INTEGER NOT NULL,
+                    PRIMARY KEY (part_a, part_b)
+                );
+                CREATE TABLE child (
+                    id INTEGER PRIMARY KEY,
+                    parent_a INTEGER,
+                    parent_b INTEGER,
+                    FOREIGN KEY (parent_a, parent_b)
+                        REFERENCES parent(part_a, part_b)
+                );
+                INSERT INTO child VALUES (1, 10, 20);
+                """
+            )
+            incident = _inspect_foreign_keys(conn)
+            self.assertEqual(incident["total_conflicts"], 1)
+
+            plan = build_repair_plan(conn, incident)
+
+            self.assertFalse(plan["can_repair"])
+            self.assertEqual(plan["groups"][0]["action"], "manual")
+            self.assertTrue(plan["unsupported_reasons"])
+            with self.assertRaises(UnsafeRepairPlanError):
+                apply_repair_plan(conn, plan, include_required=True)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT parent_a, parent_b FROM child WHERE id = 1"
+                ).fetchone(),
+                (10, 20),
+            )
+            self.assertEqual(len(conn.execute("PRAGMA foreign_key_check").fetchall()), 1)
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

Fixes #810 with a data-preserving SQLite relationship-recovery policy.

The new #810 evidence proves that the previous **keep rows** flow cannot complete startup when Django runs a migration that validates foreign keys. It also exposes a more serious problem in the generalized quarantine logic: not every orphaned child row is disposable.

This PR:

- retires the non-working keep-and-start action for blocked relationship incidents;
- preserves user-owned Music rows when only optional `album_id` or `track_id` references are broken;
- removes only known derived relationship rows automatically;
- requires an explicit incident-scoped choice before Floppy removes a row whose required parent is missing;
- creates and verifies a SQLite backup before every recovery write;
- requires a clean `PRAGMA foreign_key_check` before an explicit repair can allow startup;
- refreshes the incident fingerprint and approval token after any partial safe repair;
- makes the recovery page describe broken **relationships**, not pretend that every reported violation is a row that will be deleted;
- routes the packaged startup entrypoint through this one recovery policy instead of the older generalized child-row deletion path.

No database migration is added by this PR. No database constraint is disabled or weakened.

## New evidence from #810

The latest reporter log shows this sequence:

1. Floppy finds `292558` foreign-key conflicts across four relationship groups.
2. The samples include `app_music -> app_track` and `app_music -> app_album` failures.
3. The operator chooses the previous `accept` / keep-rows action.
4. Floppy reports that it kept the rows unchanged.
5. Django starts `migrate`.
6. Django's SQLite schema editor checks constraints.
7. Migration fails because `app_music.track_id` points at a missing `app_track` row.
8. Startup retries the migration.

That proves the previous recovery state was not resolved. It also proves that reopening the choice once per startup, as #870 did, cannot make the keep choice itself migration-safe.

## Root cause

### 1. Keep rows was modeled as a startup exception

#870 fixed the **lifetime** of a keep decision. It did not change the assumption that the same invalid rows might safely pass a later migration.

That assumption is false on SQLite. Django validates foreign keys when its schema editor exits. A database can therefore be readable by normal application queries and still be unable to cross the next migration boundary.

A blocked relationship incident must converge to valid relationships before migrations start.

### 2. The generalized quarantine rule used technical addressability as a proxy for data ownership

#780 generalized orphan cleanup from one table to any child table that appeared technically safe to address.

That is not sufficient. A foreign-key child can be:

- a user-owned record with an optional catalog reference;
- a derived relationship row;
- a user-owned record whose required parent is missing.

Those cases require different repair behavior.

For the incident now visible in #810:

- `Music.album` and `Music.track` are nullable references. A missing parent can be repaired by setting only the broken reference to `NULL`. The Music tracking row must stay.
- `AlbumArtist` is a derived catalog relationship. If the album parent is missing, the relationship row has no independent user state and can be removed after backup.
- `AlbumTracker` carries status, score, dates, and notes and has a required album parent. Floppy must not remove that row automatically. It needs explicit operator consent, and the pre-repair backup must keep the original data.

## Implementation

### `config.sqlite_repair`

A new local repair planner reads SQLite's own foreign-key and column metadata.

For each failing relationship it selects the least destructive supported action:

- nullable foreign key -> `clear_reference`;
- known derived relationship -> `remove_relationship`;
- required parent on a state-bearing row -> `remove_row`, explicit approval only;
- compound or unclassifiable relationship -> `manual`, no automatic write.

The planner does not infer from provider names or media types. It works at the persistence relationship boundary and uses schema metadata plus a deliberately small allowlist for derived relationship tables.

SQL identifiers come from inspected schema metadata and are quoted before use. Values are not interpolated into the repair statements.

### `config.sqlite_recovery_policy`

The startup policy now owns the complete relationship-recovery lifecycle.

It runs the existing scanner with its legacy generalized automatic-delete path disabled.

For a blocked incident it can:

1. validate that the incident fingerprint still matches the live database;
2. acquire `BEGIN IMMEDIATE` before recovery writes;
3. create a consistent SQLite backup;
4. run `PRAGMA quick_check` on that backup;
5. apply safe nullable-reference and derived-relationship repairs;
6. re-scan the live database;
7. if required-parent conflicts remain, commit only the safe subset and create a new incident fingerprint/token;
8. pause for explicit approval;
9. after approval, create another verified backup, apply the remaining required repair, and require `PRAGMA foreign_key_check` to return no rows before commit/startup.

A stale choice cannot cross a state change because the fingerprint and token are refreshed after a partial repair.

### Legacy `accept`

The old keep action is retired for this failure class.

If an old decision file or environment value still supplies `accept`:

- Floppy does not modify a row;
- Floppy explains that invalid relationships cannot make the next migration safe;
- the current report does not offer `accept` again;
- startup remains blocked until the relationships are repaired or a backup is restored.

### Entrypoint

`entrypoint.sh` now calls `config.sqlite_recovery_policy.check_database_for_startup()` for SQLite preflight.

It no longer calls the generalized integrity helper directly in the production startup path.

This keeps one executable recovery rule for containers and a reusable Python boundary for source or future packaged launchers.

## Recovery UI

The recovery page now renders the actions the recovery policy actually allows.

Changes include:

- `foreign key conflict entries` is presented as **broken relationships**;
- the page explains that one row can produce more than one relationship failure;
- the obsolete keep button is absent when the policy cannot safely honor it;
- safe repairs already completed are summarized separately;
- remaining required-parent relationships are explained before an operator can approve removal;
- copy states that removed live rows remain present in the verified backup;
- POST requests are rejected when the requested action is not present in the current incident report.

The page keeps the existing keyboard controls, visible focus, same-origin guard, no-store behavior, local-only assets, and self-contained offline rendering.

A real policy-report regression asserts that the page does not render `/accept` and does render the repair action.

## Data safety invariants

This PR requires all of the following:

- A broken nullable relation must not cause deletion of its child row.
- A derived relation can be removed only after a verified backup exists.
- A required-parent state-bearing row is never removed automatically.
- An explicit removal choice is tied to one incident fingerprint and one token.
- The database is rechecked after safe partial repair.
- The explicit repair does not commit unless all foreign-key conflicts are gone.
- Physical SQLite corruption remains outside this path.
- Unsupported relationship shapes fail closed.
- No migration is allowed to start while the policy still reports an unresolved relationship incident.

## Regression reproduction

`src/config/tests/test_sqlite_data_preserving_recovery.py` builds a real SQLite fixture with the mixed relationship classes observed across #731 and #810:

- one `app_music` row has a missing optional album and track;
- one `app_albumartist` row has a missing required album;
- one `app_albumtracker` row has a missing required album and a user note.

The first recovery pass must prove:

- the Music row remains;
- `album_id` and `track_id` become `NULL`;
- the derived AlbumArtist row is removed;
- the AlbumTracker row and note remain;
- exactly the required-parent conflict remains;
- the incident is blocked with no `accept` action;
- a verified backup exists.

The explicit second pass must prove:

- the approved required row is removed from the live database;
- the Music row still exists;
- `PRAGMA foreign_key_check` is empty;
- the incident is recorded as resolved;
- another verified backup exists.

A second regression proves a legacy `accept` decision changes no row and does not become an available action again.

## Performance

The repair uses set-based `UPDATE` and `DELETE` statements per relationship group. It does not issue one write per reported violation.

This matters for #810 because the reported `292558` value is a **relationship count**, not a unique row count. One Music row with both a missing album and a missing track contributes two failures.

Normal healthy startup does not add a provider request, Redis call, Celery task, or network dependency. Recovery performs local SQLite inspection and backup work only when an incident exists.

No performance benchmark is invented here. The PR records algorithmic bounds and delegates executable timing/regression evidence to the repository QA gates.

## Offline, source, container, and packaged behavior

The recovery implementation uses Python's standard library, SQLite, and the local filesystem.

It does not require:

- Redis;
- Celery;
- provider APIs;
- internet access;
- a cloud service;
- a Docker-only database path.

The shell entrypoint consumes the same Python policy that another launcher can call. The recovery page is self-contained and can also be opened from disk.

## Accessibility and cognitive-load review

The recovery surface is an incident UI, so ambiguity is expensive.

The changes reduce decision load:

- one unavailable action is removed instead of being explained as a retry loop;
- counts are named accurately;
- safe automatic work and remaining destructive work are separated;
- the destructive consequence is stated before the action;
- backup availability is stated in the same section;
- status is communicated in text and does not depend on color;
- no new timer, animation, modal, hidden control, or automatic focus movement is added.

The existing page remains keyboard-operable, focus-visible, responsive, and self-contained.

### Screenshots

The rendered recovery page changed. A real browser/runtime screenshot will be attached in a follow-up PR comment when executable browser QA is available. No generated or simulated screenshot is being presented as evidence.

## Security review

The sensitive boundary is a recovery path that can modify or remove persisted user data before Django starts.

Controls retained or strengthened:

- verified backup before recovery writes;
- SQLite write lock during incident validation and repair;
- incident fingerprint validation;
- one-use decision file and incident token;
- same-origin recovery-page mutation guard;
- no anonymous database download unless the existing explicit download setting is enabled;
- fail-closed handling for unclassifiable relationships;
- no disabling of foreign keys or Django constraint checks;
- no swallowing of the final `foreign_key_check` result;
- no provider/network input added to recovery SQL;
- no broad `DELETE child WHERE rowid IN (...)` policy for every relationship type on the production startup path.

## Documentation

`docs/architecture/sqlite-recovery-decisions.md` is rewritten as the current relationship-recovery contract. It documents:

- why keep-and-start is retired;
- nullable-reference repair;
- derived relationship cleanup;
- explicit approval for required-parent user-state rows;
- incident re-fingerprinting after partial repair;
- backup and convergence requirements;
- the distinction between relationship counts and row counts;
- safety limits;
- offline/package behavior;
- performance characteristics;
- incident history across #731, #780, #870, and #810.

## Public contracts

No REST endpoint, OpenAPI payload, AsyncAPI message, JSON-LD vocabulary, or public media-domain model changes.

OpenAPI, AsyncAPI, and JSON-LD therefore do not require regeneration for this recovery-policy PR.

## Upstream and related work

- **Fixes #810** — the latest evidence proves the keep path still fails before startup.
- **Refs #731** — original SQLite relationship boot-loop report and album relationship evidence.
- **Refs #780** — bounded report, verified backup, recovery page, and generalized quarantine foundation.
- **Refs #870** — one-attempt decision-lifetime correction; superseded only for the assumption that keep is a valid migration-start action.
- **Refs #858 / #863** — SQLite physical-corruption/runtime-safety track; separate failure mechanism.
- **Upstream:** FuzzyGrim/Yamtrack#1190 — same broad migration-time orphaned-foreign-key failure class; upstream used a table-specific repair. This PR takes the general lesson that repair semantics must follow the relationship rather than copying its table-specific deletion.

No new follow-up issue is created for this recovery defect. The existing #810 issue remains the owner until this implementation is validated.

## Post-mortem

### Impact

An installation with inconsistent SQLite relationships can remain unable to start. The previous recovery page can tell the operator that rows were accepted, then Django can fail on those same relationships during migration.

The generalized remove path also has a data-loss risk when it treats a state-bearing or nullable-reference child like a disposable relationship row.

### Trigger

A database has one or more child foreign keys whose parent rows no longer exist, followed by a Django migration that performs SQLite constraint validation.

### Contributing assumptions

1. A readable database was assumed to be migration-safe after the operator chose keep.
2. A technically addressable orphaned child was assumed to be semantically safe to delete.
3. The report count was treated like a row count even though SQLite reports one entry per broken relationship.
4. The regression suite did not model one user-owned row with multiple broken optional relationships alongside a separate state-bearing required-parent row.

### Corrective actions

- Require relationship convergence before migrations.
- Repair nullable references without deleting the child.
- Restrict automatic row deletion to known derived relationships.
- Put state-bearing required-parent deletion behind explicit approval and backup.
- Refresh approval identity after a partial repair.
- Test the mixed incident through the startup policy, not only through helper functions.

### Prevention

The new fixture locks the ownership distinctions into executable tests. The startup entrypoint calls the same policy under test. Documentation now records the invariant so a future provider or media model can be classified by relationship ownership rather than added to another broad deletion rule.

## QA status

This PR is intentionally **draft** until its exact final head has:

- focused recovery tests green;
- the `config` application suite green;
- full App Tests green;
- Ruff/Lint green;
- CodeQL green;
- Docker image/startup smoke green;
- shell syntax/startup checks green where the repository workflow covers them;
- no unresolved review findings.

A pure-SQLite reproducer was run before PR creation and confirmed the intended state transitions: two optional Music references cleared, one derived relationship row removed, one required tracker row preserved until approval, then a clean `PRAGMA foreign_key_check` after explicit repair.

The repository CI is the executable environment for the full Django and package-level gates in this connector session. No test is skipped and no timeout is raised to make this change pass.

## AI assistance

GPT-5.6 Sol was used for issue/log analysis, security review, implementation support, regression design, relationship modeling, documentation, and PR preparation.