### PR TITLE
Potential fix for code scanning alert no. 1167: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dry-image-cleanup.yml
+++ b/.github/workflows/dry-image-cleanup.yml
@@ -6,6 +6,9 @@ jobs:
   ghcr-cleanup-image:
     name: ghcr cleanup action
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1


### PR DESCRIPTION
Potential fix for [https://github.com/dannyvfilms/Floppy/security/code-scanning/1167](https://github.com/dannyvfilms/Floppy/security/code-scanning/1167)

Add an explicit `permissions` block at the job level for `ghcr-cleanup-image` in `.github/workflows/dry-image-cleanup.yml`.

Best single fix without changing functionality:
- In `.github/workflows/dry-image-cleanup.yml`, under `jobs -> ghcr-cleanup-image`, add:
  - `contents: read` (safe baseline for repository content access)
  - `packages: write` (needed for container package cleanup/delete operations in GHCR)

This keeps behavior intact for dry-run and validation while ensuring the token is explicitly scoped and not dependent on repository/org defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
