### PR TITLE
Potential fix for code scanning alert no. 1168: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -2,6 +2,10 @@ name: Cleanup Docker Images
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   ghcr-cleanup-image:
     name: ghcr cleanup action


### PR DESCRIPTION
Potential fix for [https://github.com/dannyvfilms/Floppy/security/code-scanning/1168](https://github.com/dannyvfilms/Floppy/security/code-scanning/1168)

Add an explicit `permissions` block in `.github/workflows/image-cleanup.yml` so the workflow does not rely on inherited defaults.  
Best single fix without changing intended functionality: define permissions at the workflow root (applies to all jobs), granting only what this cleanup job needs. Since it deletes GHCR images/tags, it needs package write access; for checkout-free workflow behavior, `contents: read` is a safe minimal baseline.

Edit region: near the top of `.github/workflows/image-cleanup.yml`, immediately after the `on:` block and before `jobs:`.

No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
