### PR TITLE
fix(ci): restore full-tree import ordering

### DIFF
--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -36,8 +36,8 @@ from integrations import (
     koito_api,
     lastfm_api,
     pocketcasts_api,
-    stremio_catalog,
     psn_api,
+    stremio_catalog,
     stremio_queue,
     tasks,
     xbox_api,
@@ -3259,10 +3259,7 @@ def stremio_addon_subtitles(request, token, media_type, media_id):
         media_type not in {"movie", "series"}
         or len(media_id) > STREMIO_MAX_MEDIA_ID_LENGTH
         or not STREMIO_MEDIA_ID_PATTERN.fullmatch(media_id)
-        or (
-            media_type == "movie"
-            and ":" in media_id
-        )
+        or (media_type == "movie" and ":" in media_id)
     ):
         logger.info(
             "stremio_queue status=limited reason=invalid_media_id user_id=%s "


### PR DESCRIPTION
## Summary

Fix the full-tree Ruff `I001` failure exposed after #874 merged to `latest`.

Push run `32200533528`, job `95913197167`, checked out `latest` at `119723461b5b183071c4a85f9b2c58b3b145584e` and ran the non-PR lint path:

```text
uv run --no-sync ruff check src
```

Ruff reported one error in `src/integrations/views.py`: the `from integrations import (...)` block was not sorted.

## Root cause

The combined integrations import list contains both the existing PlayStation module and the later Stremio catalog module. Their final merged order placed `stremio_catalog` before `psn_api`.

PR checks gate only changed Python lines. A later push to `latest` runs the complete `src` tree, so the composition defect was exposed after merge rather than on the original feature branch.

## Change

- Move `psn_api` before `stremio_catalog` in the existing import block.
- Keep all imported modules and behavior unchanged.
- Keep the nearby Stremio media-ID guard semantically unchanged; the connector normalized that expression to one line while writing the file.
- Do not change Ruff configuration and do not add a lint suppression.

## Security review

This changes import ordering and formatting only. It adds no input, authorization, persistence, network, subprocess, SQL, secret, or filesystem behavior. No security boundary changes.

## Performance

No runtime path, query, allocation, request, or task behavior changes.

## Offline and packaged behavior

No runtime dependency or deployment behavior changes. Docker, source, offline, and future packaged execution are unaffected.

## Public contracts and documentation

No REST API, OpenAPI, AsyncAPI, JSON-LD, domain vocabulary, configuration, migration, or user-facing behavior changes. No documentation regeneration is required.

## UI / accessibility

Not applicable. No template, CSS, script, copy, layout, focus, motion, or interaction changes. Screenshots are not applicable.

## Validation

The source failure is directly reproducible from the merged `latest` run above. This PR is draft until the repository CI confirms the final merge ref.

Expected primary gate:

```text
uv run --no-sync ruff check src
```

Standard App Tests, CodeQL, and Docker checks are also left enabled; no check is skipped or weakened.

## Relationships

- Refs #874 — its merge triggered the full-tree push lint that exposed this baseline defect.
- Refs #856 — Stremio catalog integration provenance for the affected import block.
- Refs #824 — PlayStation integration provenance for the affected import block.
- Refs #881 — current `latest` advanced with unrelated workflow-permissions hardening while this fix was prepared; GitHub should validate the prospective merge against that base.

No new issue is needed for this mechanical CI repair.

## Post-mortem

**Impact:** `latest` push lint is red even though the merged application code is otherwise usable.

**Why it escaped:** PR lint limits Ruff failures to changed lines. The full-tree push gate applies Ruff to all of `src`, so a composed import-order defect can survive individual PR checks and fail only after merge.

**Correction:** restore canonical import ordering without suppressing the rule.

**Prevention:** keep the full-tree push lint as the final baseline check. This failure shows why that gate is useful.

## AI assistance

GPT-5.6 Sol was used to inspect the failing GitHub Actions log, trace the merged source state, prepare the minimal repair, and review the resulting diff. Human maintainer review remains authoritative.