### PR TITLE
ci(release): separate development and stable container publication

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,12 +2,6 @@ name: Docker Image
 
 on:
   workflow_dispatch:
-    inputs:
-      bootstrap_ghcr:
-        description: "Use GHCR_TOKEN once to create the renamed floppy package"
-        required: false
-        default: false
-        type: boolean
   push:
     branches:
       - "release"
@@ -186,14 +180,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # This ensures all tags are fetched for git describe
+          fetch-depth: 0 # Required for version metadata and stable-tag validation.
 
       - name: Get version from git
         id: get-version
         run: |
           VERSION=$(git describe --tags 2>/dev/null || echo "dev")
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using version: $VERSION"
+
+      - name: Validate stable release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid stable release tag::Expected vX.Y.Z, got $GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          git fetch --no-tags origin release:refs/remotes/origin/release
+          tag_commit=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          release_commit=$(git rev-parse refs/remotes/origin/release)
+
+          if [[ "$tag_commit" != "$release_commit" ]]; then
+            echo "::error title=Stable release tag is not release HEAD::Tag $GITHUB_REF_NAME resolves to $tag_commit, but release is $release_commit. Create the release tag from the verified release HEAD."
+            exit 1
+          fi
+
+          echo "Stable release tag $GITHUB_REF_NAME is anchored to release HEAD $release_commit"
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v4
@@ -206,41 +222,40 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           # Dual-publish during the rename grace period: the legacy path keeps
-          # receiving identical tags so pre-rename deployments still get
-          # updates. Drop the second line once traffic to it has died off.
+          # receiving identical approved tags so pre-rename deployments still
+          # get updates. Drop the second line only after that migration is done.
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             ${{ env.REGISTRY }}/${{ env.LEGACY_IMAGE_NAME }}
           tags: |
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/latest' }}
-            type=raw,value=release,enable=${{ github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/latest' }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      # Pull requests build both architectures to prove the image still
-      # cross-compiles, but they must never write to the registry. A pr-N tag
-      # has no consumer and lands in the same public package users pull from,
-      # where nothing distinguishes it from a release. Publishing happens on
-      # push to latest/release and on v* tags only.
+      # Publication contract:
+      # - PR: build only, never authenticate or publish (#782/#793).
+      # - latest branch: publish the moving :dev channel only (#797).
+      # - release branch: validate only; a branch update is not a release.
+      # - vX.Y.Z tag at exact release HEAD: publish stable aliases and semver.
+      # - workflow_dispatch: validation only; it is not a publication backdoor.
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/latest' || startsWith(github.ref, 'refs/tags/v'))
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          # The one-time bootstrap is needed because floppy was created by a
-          # PAT-based push, while the existing yamtrack package is already
-          # associated with this repository. Normal builds stay on GITHUB_TOKEN.
-          username: ${{ inputs.bootstrap_ghcr == true && 'dannyvfilms' || github.actor }}
-          password: ${{ inputs.bootstrap_ghcr == true && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/latest' || startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing Floppy
+
+This document is the maintainer runbook for Floppy container releases.
+
+The release workflow has one stable publication path. A branch update is not a release.
+
+## Container channels
+
+| Git event | Container result |
+|---|---|
+| Pull request | Build and smoke-test only. Nothing is published. |
+| Push or merge to `latest` | Publish the moving `:dev` channel. |
+| Push or merge to `release` | Build and smoke-test only. Stable tags do not move. |
+| Manual workflow dispatch | Validation only. Nothing is published. |
+| `vX.Y.Z` tag at the exact `release` HEAD | Publish `:latest`, `:release`, `:X.Y.Z`, `:X.Y`, and `:X`. |
+
+The same approved tags are published to the legacy `yamtrack` package during the rename grace period. Do not add a second publication path for that package.
+
+## Why this contract exists
+
+`latest` is the integration branch. It changes often and is not the stable release line. Its container is therefore `:dev`.
+
+`release` is the stable candidate branch. Moving that branch prepares or reconciles release state, but it does not publish a stable image.
+
+`:latest` is Docker's default channel and is treated as stable. It moves only when a maintainer creates a version tag from the verified `release` HEAD.
+
+Pull requests never authenticate to GHCR and never publish registry tags. This preserves the behavior established by #782 and merged PR #793. The stable/default and development channel split follows #797.
+
+## Current release-line reconciliation
+
+The currently published stable release is `v26.8.13` at commit `bc11aab42b29abfa4b8fe14f450ee33c890dd2a8`.
+
+The historical `release` branch diverged before that tag. It also has one release-only funding commit. The funding file is byte-for-byte identical in `v26.8.13`, so there is no unique release-tree content to recover.
+
+Do **not** force-reset `release` to the tag. Reconcile it with a merge so both histories remain reachable. The reconciled application tree must match `v26.8.13`; only release-policy workflow/documentation changes may differ.
+
+Reconciliation is not a new release. Because a `release` branch push does not publish, aligning the branch to the existing `v26.8.13` state cannot move stable container tags.
+
+## Create a future stable release
+
+1. Prepare and validate the intended release on `latest`.
+2. Open a PR from the intended release state into `release`.
+3. Run the required application, migration, Docker, security, and upgrade-path QA. Merge only when the release candidate is accepted.
+4. Confirm the exact `release` HEAD that will ship.
+5. In GitHub Releases, create a new tag named exactly `vX.Y.Z` and target **the current `release` HEAD**. Do not create the stable tag from `latest`, another branch, or an older release commit.
+6. Publish the GitHub Release. The Docker workflow verifies that the tag resolves to the exact current `release` HEAD before registry login.
+7. After smoke and multi-architecture build succeed, the workflow automatically publishes:
+   - `ghcr.io/dannyvfilms/floppy:latest`
+   - `ghcr.io/dannyvfilms/floppy:release`
+   - `ghcr.io/dannyvfilms/floppy:X.Y.Z`
+   - `ghcr.io/dannyvfilms/floppy:X.Y`
+   - `ghcr.io/dannyvfilms/floppy:X`
+   - the same approved aliases to the legacy package during the rename grace period.
+8. Verify the tag workflow and the published image before announcing the release.
+
+No separate registry command is required. Do not run a manual workflow to publish stable images.
+
+## Failure behavior
+
+The workflow fails before registry login if:
+
+- the tag does not match `vX.Y.Z`;
+- the tag points anywhere other than the exact current `release` HEAD.
+
+A direct push to `release` cannot publish stable tags. A manual workflow dispatch cannot publish stable tags. A pull request cannot publish any registry tag.
+
+If a release was tagged from the wrong commit, do not move or reuse that version tag. Correct the release state and create a new version according to the project versioning policy.
+
+## Development images
+
+Every accepted push to `latest` continues to build, smoke-test, and publish `:dev`. This is the opt-in moving integration channel.
+
+Do not use `:dev` in the default self-hosting instructions. Users who follow the normal install path should remain on stable `:latest` unless they deliberately choose the development channel.
+
+## Related history
+
+- #782 — PR builds were writing public `pr-N` package versions.
+- #793 — stopped PR publication while preserving multi-architecture build coverage.
+- #797 — separated the stable/default channel from the moving integration channel.
+
+These controls are one contract. Do not change tag generation, registry login conditions, or `push:` behavior independently without re-validating all three event classes: PR, development branch, and stable release tag.


### PR DESCRIPTION
## Summary

Make the GHCR release contract explicit and mechanically enforceable.

This PR changes only release workflow policy and maintainer documentation. It does not advance the `release` branch and does not publish a stable image.

### Publication contract

| Event | Result |
|---|---|
| Pull request | Build and smoke-test only. No registry login or publish. |
| Push/merge to `latest` | Publish `:dev` only. |
| Push/merge to `release` | Build and smoke-test only. Stable tags do not move. |
| Manual workflow dispatch | Validation only. Nothing is published. |
| `vX.Y.Z` tag at exact `release` HEAD | Publish `:latest`, `:release`, `:X.Y.Z`, `:X.Y`, and `:X`. |

Stable publication now fails before GHCR login if the tag is not strict `vX.Y.Z` or does not resolve to the exact current `release` HEAD.

## Why

#782 and merged #793 established that PRs must never write public package versions. #797 established the desired channel split: the moving integration branch should be opt-in and the default Docker channel should be stable.

The current workflow still publishes `:latest` from `latest` and publishes `:release` on every `release` branch push. That leaves stable publication coupled to branch movement and makes `:latest` mean development.

This PR removes both ambiguities:

- `latest` becomes the moving `:dev` publisher;
- `release` becomes a non-publishing stable candidate branch;
- a version tag at verified `release` HEAD becomes the only stable publication event.

## Current v26.8.13 reconciliation

The currently published stable tag `v26.8.13` resolves to `bc11aab42b29abfa4b8fe14f450ee33c890dd2a8`.

Current `release` is an older divergent line: it is one commit ahead of the old merge base and 1,508 commits behind `v26.8.13`. Its only release-only tree change is `.github/FUNDING.yml`, and that file is byte-for-byte identical in `v26.8.13`.

Therefore the branch can be reconciled without losing application, fork, upstream-port, or release-only content. The follow-up reconciliation will be merge-based, not a force reset, so both histories remain reachable. Its resulting application tree must match `v26.8.13`; only the new release-control workflow may differ.

This PR deliberately does **not** perform that reconciliation. The workflow policy must land first so a later `release` branch reconciliation cannot accidentally publish a new stable container.

## Maintainer release flow

`RELEASING.md` is the authoritative runbook.

For a future release:

1. prepare and validate the intended release state;
2. promote it into `release` through review;
3. confirm the exact `release` HEAD;
4. create a GitHub Release with tag `vX.Y.Z` targeting that exact HEAD;
5. the workflow validates the tag, smoke-tests the image, builds both architectures, and publishes stable aliases automatically.

Manual workflow dispatch cannot publish. A direct push to `release` cannot publish. An incorrectly targeted tag fails before registry login.

## Security review

- No application auth, API, model, database, migration, or runtime behavior changes.
- PRs continue to build both amd64 and arm64 but cannot authenticate to GHCR.
- Manual dispatch is no longer a publication backdoor; the obsolete bootstrap input is removed.
- Stable publication is bound to one immutable-style event class: a strict version tag at exact `release` HEAD.
- Registry credentials are requested only for `latest` branch pushes and valid tag-push jobs; the release tag gate runs before login.
- The legacy `yamtrack` package keeps the same approved tags during the rename grace period; no second release path is introduced.

## Performance / coverage

PR multi-architecture build coverage from #793 is preserved. No application test coverage is removed. This PR does not add another Docker build lane.

## Offline / package behavior

Not applicable to application runtime. This changes only GHCR publication policy. Source installs, packaged installs, Docker runtime behavior, and offline application behavior are unchanged.

## UI / accessibility

Not applicable. No user interface, template, focus, motion, copy layout, or interaction changes. Screenshots are not applicable.

## API / contract surfaces

No REST API, OpenAPI, AsyncAPI, JSON-LD, or domain-vocabulary change. No contract regeneration is required.

## QA plan

- inspect exact two-file diff;
- validate YAML/workflow expressions;
- verify PR run: GHCR login skipped and `push: false` while amd64/arm64 still build;
- verify `latest` push after merge publishes only `:dev`;
- create separate history-preserving `v26.8.13 -> release` reconciliation only after this policy is active;
- verify that reconciliation push does not authenticate or publish;
- for the next real release, verify the `vX.Y.Z` tag publishes the stable aliases automatically.

## Relationships

Fixes the remaining implementation gap in #797.
Refs #782 and merged #793.
Preserves the cleanup/tag protections introduced by #793.

## Post-mortem

**What went wrong:** PR publication and branch-channel semantics were fixed separately. #793 correctly stopped PR package writes, but stable/default publication still followed the fast-moving `latest` branch and `release` branch movement still published a container.

**Why it persisted:** the workflow expressed publication as a broad "not a PR" condition instead of an allowlist of release events.

**Correction:** publication is now allowlisted by event and ref. `latest` publishes only `:dev`; stable aliases require a version tag at exact `release` HEAD.

**Prevention:** the release runbook documents one promotion path and the workflow fails closed before registry login for a mistargeted stable tag.

## AI assistance

GPT-5.6 Sol / OpenAI Codex Security was used to inspect #782, #797, #793, compare `release` with `v26.8.13`, design the fail-closed publication contract, and prepare the workflow and documentation. Human maintainer review remains authoritative.