### PR TITLE
Prevent duplicate list infinite-scroll pages

### DIFF
--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -354,6 +354,11 @@ class ListsViewTests(TestCase):
         response = self.client.get(reverse("lists"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["custom_lists"]), 20)  # 20 per page
+        self.assertContains(
+            response,
+            'hx-trigger="revealed threshold:200px once"',
+            html=False,
+        )
 
         # Test second page
         response = self.client.get(reverse("lists") + "?page=2")

--- a/src/templates/lists/components/list_grid.html
+++ b/src/templates/lists/components/list_grid.html
@@ -2,7 +2,7 @@
 {% load user_tags %}
 
 {% for custom_list in custom_lists %}
-  <div {% if forloop.last and custom_lists.has_next %} hx-get="{% if profile_username %}{% url 'user_profile' profile_username %}?page={{ custom_lists.next_page_number }}{% else %}{% url 'lists' %}?page={{ custom_lists.next_page_number }}{% endif %}" hx-trigger="revealed threshold:200px" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" {% endif %}
+  <div {% if forloop.last and custom_lists.has_next %} hx-get="{% if profile_username %}{% url 'user_profile' profile_username %}?page={{ custom_lists.next_page_number }}{% else %}{% url 'lists' %}?page={{ custom_lists.next_page_number }}{% endif %}" hx-trigger="revealed threshold:200px once" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" {% endif %}
        x-data="{ showModal: false }">
     <div class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative hover:ring-2 hover:ring-indigo-500 transition-all search-result-card-square group{% if request.user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}"
          style="aspect-ratio: 3/2 !important;">


### PR DESCRIPTION
## Summary
Prevents the same infinite-scroll page from being requested and inserted more than once on custom-list grids.

**Root cause:** the final card remained eligible for repeated HTMX `revealed` events after requesting the next page.

**Solution:** make that pagination trigger one-shot. The final card appended by the next page becomes the only element able to request another page.

**Screenshots:** before/after captures were produced during manual QA; GitHub attachment upload is still pending.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 Sol)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped code inspection, targeted Django testing, repository-wide Ruff, and manual browser QA.

## How It Was Tested
- `SECRET=test-only scripts/test.sh lists.tests.test_views.ListsViewTests.test_lists_view_pagination` → Passed.
- `uv run --no-sync ruff check src` → Passed.
- Manual browser comparison with 21 lists → Base rendered 20 initially and 22 after scrolling; this PR rendered 20 initially, 21 after scrolling, and remained at 21 after another scroll.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Failed only on the two current-`latest` list-column expectations for the newly added `synopsis` column; neither failing test is changed by this PR.

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Fixes #890.
