### PR TITLE
Refresh compact episode controls after watch changes

### DIFF
--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -505,16 +505,18 @@ def _write_episode_save_oob(
         # Season-progress spans only exist on the season page — nothing to target here.
         return
 
-    response.write(
-        render_to_string(
-            "app/components/detail_episode_track_button.html",
-            {
-                "episode": episode,
-                "track_button_oob": True,
-            },
-            request=request,
-        ),
-    )
+    for target_suffix in ("", "-list"):
+        response.write(
+            render_to_string(
+                "app/components/detail_episode_track_button.html",
+                {
+                    "episode": episode,
+                    "target_suffix": target_suffix,
+                    "track_button_oob": True,
+                },
+                request=request,
+            ),
+        )
     response.write(
         render_to_string(
             "app/components/detail_episode_history_line.html",
@@ -791,13 +793,18 @@ def episode_history_poll(request, season_id):
             .first()
         )
 
-        response.write(
-            render_to_string(
-                "app/components/detail_episode_track_button.html",
-                {"episode": episode, "track_button_oob": True},
-                request=request,
-            ),
-        )
+        for target_suffix in ("", "-list"):
+            response.write(
+                render_to_string(
+                    "app/components/detail_episode_track_button.html",
+                    {
+                        "episode": episode,
+                        "target_suffix": target_suffix,
+                        "track_button_oob": True,
+                    },
+                    request=request,
+                ),
+            )
         response.write(
             render_to_string(
                 "app/components/detail_episode_history_line.html",

--- a/src/app/tests/views/test_crud.py
+++ b/src/app/tests/views/test_crud.py
@@ -710,7 +710,24 @@ class CreateMedia(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'id="episode-track-button-', html=False)
+        self.assertContains(
+            response,
+            'id="episode-track-button-',
+            count=2,
+            html=False,
+        )
+        self.assertContains(response, '-list" hx-swap-oob="true"', html=False)
+        latest_episode = Episode.objects.filter(
+            item__media_id="1668",
+            related_season__user=self.user,
+            item__episode_number=1,
+        ).latest("id")
+        self.assertContains(
+            response,
+            f'"instance_id": "{latest_episode.id}"',
+            count=2,
+            html=False,
+        )
         self.assertContains(response, 'id="episode-history-', html=False)
         self.assertContains(response, 'hx-swap-oob="true"', html=False)
         self.assertContains(response, "Watched 2 times")

--- a/src/app/tests/views/test_episode_history_poll.py
+++ b/src/app/tests/views/test_episode_history_poll.py
@@ -52,6 +52,11 @@ class EpisodeHistoryPollTests(TestCase):
             f'id="episode-track-button-{self.episode_item.id}"',
             html=False,
         )
+        self.assertContains(
+            response,
+            f'id="episode-track-button-{self.episode_item.id}-list"',
+            html=False,
+        )
         self.assertContains(response, 'hx-swap-oob="true"', html=False)
         self.assertContains(response, "season-progress-mobile-", html=False)
         self.assertContains(response, "season-progress-desktop-", html=False)

--- a/src/templates/app/components/detail_episode_track_button.html
+++ b/src/templates/app/components/detail_episode_track_button.html
@@ -1,21 +1,22 @@
 {% load app_tags %}
 
-<div id="episode-track-button-{{ episode.item.id }}{{ target_suffix }}"
-     {% if track_button_oob %}hx-swap-oob="true"{% endif %}>
-  {% with watched=episode.history|watched_count %}
+{# djlint:off #}
+<div id="episode-track-button-{{ episode.item.id }}{{ target_suffix }}"{% if track_button_oob %} hx-swap-oob="true"{% endif %}>
+{# djlint:on #}
+{% with watched=episode.history|watched_count %}
   <button hx-get="{% media_view_url 'track_modal' episode %}"
-          {# With a watch on record the modal edits it (instance_id) so the fields prefill and Delete works; "Add new entry" inside the modal covers rewatches. #}
-          hx-vals='{"return_url": "{{ detail_return_url|default:request.path|urlencode }}", "episode_number": "{{ episode.episode_number }}", {% if episode.history %}"instance_id": "{{ episode.history.0.id }}"{% else %}"is_create": "1"{% endif %}}'
-          hx-target="#{% component_id 'track' episode %}{{ target_suffix }}"
-          hx-trigger="click"
-          @click="trackOpen = true"
-          title="Track Episode"
-          class="p-2 {% if watched > 0 %}bg-indigo-600 hover:bg-indigo-700{% elif episode.history %}bg-amber-600 hover:bg-amber-700{% else %}bg-gray-600 hover:bg-gray-500{% endif %} text-white rounded-full transition duration-300 cursor-pointer">
+    {# With a watch on record the modal edits it (instance_id) so the fields prefill and Delete works; "Add new entry" inside the modal covers rewatches. #}
+    hx-vals='{"return_url": "{{ detail_return_url|default:request.path|urlencode }}", "episode_number": "{{ episode.episode_number }}", {% if episode.history %}"instance_id": "{{ episode.history.0.id }}"{% else %}"is_create": "1"{% endif %}}'
+    hx-target="#{% component_id 'track' episode %}{{ target_suffix }}"
+    hx-trigger="click"
+    @click="trackOpen = true"
+    title="Track Episode"
+    class="p-2 {% if watched > 0 %}bg-indigo-600 hover:bg-indigo-700{% elif episode.history %}bg-amber-600 hover:bg-amber-700{% else %}bg-gray-600 hover:bg-gray-500{% endif %} text-white rounded-full transition duration-300 cursor-pointer">
     {% if episode.history %}
       {% include "app/icons/eye.svg" with classes="w-4 h-4" %}
     {% else %}
       {% include "app/icons/eye-closed.svg" with classes="w-4 h-4" %}
     {% endif %}
   </button>
-  {% endwith %}
+{% endwith %}
 </div>


### PR DESCRIPTION
## Summary
Refreshes both card and compact-list episode controls immediately after episode watch changes.

**Root cause:** HTMX responses refreshed only the card control, leaving the compact control stale and without the newest watch identifier.

**Solution:** render out-of-band updates for both control targets after episode saves and from the episode-history poller. No layout or styling is changed.

**Screenshots:** before/after captures were produced during manual QA; GitHub attachment upload is still pending.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 Sol)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped code inspection, targeted Django testing, repository-wide Ruff, focused template linting, and manual browser QA.

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_crud.CreateMedia.test_create_episode_htmx_returns_inline_detail_updates app.tests.views.test_episode_history_poll` → Passed (4 tests).
- `uv run --no-sync ruff check src` → Passed.
- `uv run --no-sync djlint src/templates/app/components/detail_episode_track_button.html --check` → Passed.
- Manual browser comparison of the history-poll response → Base returned one out-of-band episode-control target; this PR returned both the card and `-list` targets, each with `hx-swap-oob="true"`.
- `SECRET=test-only scripts/test.sh config.tests.test_sqlite_integrity.SqliteIntegrityTests.test_entrypoint_term_during_integrity_check_stops_before_migrations` → Passed when rerun locally after its CI-only failure.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Failed on the two current-`latest` list-column expectations for the newly added `synopsis` column and one unrelated SQLite signal-timing test; none is changed by this PR.

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Fixes #818.
Fixes #819.
