### PR TITLE
Prevent repeated media grid page loads

### DIFF
--- a/src/app/tests/views/test_media_list.py
+++ b/src/app/tests/views/test_media_list.py
@@ -3024,8 +3024,8 @@ class MediaListViewTests(TestCase):
         self.assertNotContains(response, 'id="column-refresh-runner"')
         self.assertNotContains(response, 'hx-trigger="runColumnRefresh"')
 
-    def test_table_header_and_row_cells_match_for_pagination(self):
-        """Table pagination rows should always match header column count."""
+    def test_paginated_media_layouts_render_correctly(self):
+        """Grid and table pagination retain their layout-specific safeguards."""
         extra_ids = [f"extra-{i}" for i in range(6, 41)]
         Item.objects.bulk_create(
             [
@@ -3061,6 +3061,17 @@ class MediaListViewTests(TestCase):
         )
 
         headers = {"HTTP_HX_REQUEST": "true"}
+        grid_page = self.client.get(
+            reverse("medialist", args=[MediaTypes.MOVIE.value])
+            + "?layout=grid&page=1",
+            **headers,
+        )
+        self.assertContains(
+            grid_page,
+            'hx-trigger="revealed threshold:200px once"',
+            html=False,
+        )
+
         first_page = self.client.get(
             reverse("medialist", args=[MediaTypes.MOVIE.value])
             + "?layout=table&page=1",

--- a/src/templates/app/components/media_grid_items.html
+++ b/src/templates/app/components/media_grid_items.html
@@ -2,7 +2,7 @@
 {% load user_tags %}
 
 {% for media in media_list %}
-  <div {% if forloop.last and media_list.has_next %} hx-get="{% url 'medialist' media_type %}?page={{ media_list.next_page_number }}" hx-trigger="revealed threshold:200px" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" {% endif %}>
+  <div {% if forloop.last and media_list.has_next %} hx-get="{% url 'medialist' media_type %}?page={{ media_list.next_page_number }}" hx-trigger="revealed threshold:200px once" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" {% endif %}>
     {% include "app/components/media_card.html" with media=media item=media.item title=media.item from_grid=True user=user current_sort=current_sort card_media_type=media_type score_chip_mode='conditional' progress_chip_mode='conditional' time_left_chip_mode='conditional' show_release_year_placeholder=True show_progress_chip=False %}
     {% if current_sort == 'critic_rating' %}
       {% if media.item.provider_rating is not None %}


### PR DESCRIPTION
## Summary
Prevents repeated requests for the same page in TV, movie, and anime media grids.

**Root cause:** the grid pagination sentinel remained active after becoming visible, unlike the table and collection pagination paths.

**Solution:** make the grid sentinel one-shot so it is replaced by the next page before another request can occur.

**Screenshots:** before/after captures were produced during manual QA; GitHub attachment upload is still pending.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 Sol)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped code inspection, targeted Django testing, repository-wide Ruff, and manual browser QA.

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list.MediaListViewTests.test_paginated_media_layouts_render_correctly` → Passed.
- `uv run --no-sync ruff check src` → Passed.
- Manual browser comparison with 45 movies → This PR rendered 32 initially, 45 after the first scroll, and remained at 45 after a subsequent scroll; no layout regression was observed.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Failed only on the two current-`latest` list-column expectations for the newly added `synopsis` column; neither failing test is changed by this PR.

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Fixes #883.
Fixes #895.
