### PR TITLE
Prefer provider episode titles in season API responses

### DIFF
--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -423,12 +423,14 @@ class EpisodeSerializer(serializers.ModelSerializer):
                 lists_by_item_id = context.get("lists_by_item_id", {})
                 lists = lists_by_item_id.get(item.id, [])
 
+        serialized_item = ItemSerializer().to_representation(item) if item else None
+        if serialized_item is not None:
+            serialized_item["title"] = instance.get("name") or serialized_item["title"]
+
         return {
             "id": item.id if item is not None else None,
             "consumption_id": episode.id if episode is not None else None,
-            "item": ItemSerializer().to_representation(item)
-            if item is not None
-            else None,
+            "item": serialized_item,
             "item_id": ItemIdField().to_representation(item)
             if item is not None
             else None,

--- a/src/api/tests/test_media_season.py
+++ b/src/api/tests/test_media_season.py
@@ -954,7 +954,7 @@ class MediaSeasonTests(FloppyApiTestCase):
                     "episode_number": episode_item.episode_number,
                     "season_number": episode_item.season_number,
                     "show_id": tv_item.media_id,
-                    "name": episode_item.title,
+                    "name": f"Provider episode {episode_item.episode_number}",
                     "overview": "",
                     "vote_average": 0.0,
                     "vote_count": 0,
@@ -994,6 +994,7 @@ class MediaSeasonTests(FloppyApiTestCase):
         )
         self.assertTrue(first_result["tracked"])
         self.assertEqual(first_result["consumption_id"], tracked_episode.id)
+        self.assertEqual(first_result["item"]["title"], "Provider episode 1")
 
     @patch("api.views.services.get_media_metadata", side_effect=Exception("boom"))
     def test_season_episodes_get_invalid_media_id_returns_internal_server_error(


### PR DESCRIPTION
## Summary
Returns provider episode names consistently for tracked and untracked episodes in season API responses.

**Root cause:** tracked episodes serialized the stored episode `Item` title, which can contain the show title, while untracked episodes used the provider episode name.

**Solution:** prefer the provider episode name and retain the persisted title only as a fallback. Tracking identity, history, and stored metadata are unchanged.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 Sol)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped serializer inspection, targeted Django testing, repository-wide Ruff, Spectacular OpenAPI validation, API contract testing, and domain-vocabulary verification.

## How It Was Tested
- `SECRET=test-only scripts/test.sh api.tests.test_media_season` → Passed (42 tests).
- `uv run --no-sync ruff check src` → Passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Failed only on the two current-`latest` list-column expectations for the newly added `synopsis` column; neither failing test is changed by this PR.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified (if API endpoints changed)
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Refs #888.
