### PR TITLE
Refresh episode deletes without reloading the season page

### DIFF
--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -380,11 +380,77 @@ def media_delete(request):
             media_type,
             instance_id,
         )
+        if media_type == MediaTypes.EPISODE.value:
+            episode_item = media.item
+            related_season = media.related_season
         start_date = getattr(media, "start_date", None)
         end_date = getattr(media, "end_date", None)
         created_at = getattr(media, "created_at", None)
         media.delete()
         logger.info("%s deleted successfully.", media)
+
+        if media_type == MediaTypes.EPISODE.value and request.headers.get(
+            "HX-Request",
+        ):
+            related_season._sync_status_after_episode_change()
+            cache_utils.clear_time_left_cache_for_user(related_season.user_id)
+            cache_utils.clear_media_list_cache_for_user(related_season.user_id)
+            history_day_key = history_cache.history_day_key(
+                end_date or start_date or created_at,
+            )
+            if history_day_key:
+                history_cache.invalidate_history_days(
+                    request.user.id,
+                    day_keys=[history_day_key],
+                    logging_styles=("sessions", "repeats"),
+                    reason="media_delete",
+                    force=True,
+                )
+
+            episode_history = list(
+                Episode.objects.filter(
+                    related_season=related_season,
+                    item=episode_item,
+                )
+                .select_related("item", "related_season")
+                .order_by("-end_date", "-created_at"),
+            )
+            episode = episode_history[0] if episode_history else media
+            episode.history = episode_history
+            episode.collection_entry = (
+                CollectionEntry.objects.filter(
+                    item=episode_item,
+                    user=request.user,
+                )
+                .select_related("item")
+                .first()
+            )
+
+            response = HttpResponse()
+            _write_episode_save_oob(
+                response,
+                request,
+                episode=episode,
+                related_season=related_season,
+                media_id=episode_item.media_id,
+                source=episode_item.source,
+                season_number=episode_item.season_number,
+                episode_number=episode_item.episode_number,
+                next_path=request.GET.get("next") or "",
+            )
+            response["HX-Trigger"] = json.dumps(
+                {
+                    "closeModal": {},
+                    "showToast": {
+                        "message": f"Removed watch for episode {episode_item.episode_number}.",
+                        "type": "success",
+                    },
+                },
+            )
+            response["Cache-Control"] = "no-cache, no-store, must-revalidate"
+            response["Pragma"] = "no-cache"
+            response["Expires"] = "0"
+            return response
 
         if media_type in (MediaTypes.GAME.value, MediaTypes.BOARDGAME.value):
             history_day_keys = history_cache.history_day_keys_for_range(

--- a/src/app/tests/views/test_crud.py
+++ b/src/app/tests/views/test_crud.py
@@ -1639,6 +1639,28 @@ class DeleteMedia(TestCase):
             0,
         )
 
+    def test_unwatch_episode_htmx_updates_episode_controls(self):
+        """HTMX episode deletes update the list without redirecting the page."""
+        response = self.client.post(
+            reverse("media_delete") + "?next=/details/tmdb/tv/1668/friends/season/1",
+            data={
+                "instance_id": self.episode.id,
+                "media_type": MediaTypes.EPISODE.value,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("HX-Redirect", response)
+        self.assertContains(response, 'id="episode-track-button-', html=False)
+        self.assertContains(response, 'id="episode-history-', html=False)
+        self.assertContains(response, "season-progress-mobile-", html=False)
+        self.assertContains(response, "season-progress-desktop-", html=False)
+        trigger = json.loads(response["HX-Trigger"])
+        self.assertEqual(trigger["closeModal"], {})
+        self.assertEqual(trigger["showToast"]["type"], "success")
+        self.assertFalse(Episode.objects.filter(pk=self.episode.id).exists())
+
     @patch("app.signals._handle_media_cache_change")
     def test_unwatch_episode_removes_warm_history_cache_entry(
         self,

--- a/src/app/tests/views/test_track_modal.py
+++ b/src/app/tests/views/test_track_modal.py
@@ -262,10 +262,12 @@ class TrackModalViewTests(TestCase):
         # Bound to a real watch, so Delete is live and a rewatch is still one
         # click away via "Add new entry".
         self.assertEqual(response.context["general_existing_instance"], episode)
-        delete_start = content.index('formaction="/media_delete')
+        delete_start = content.index('hx-post="/media_delete')
         delete_button = content[delete_start : content.index("</button>", delete_start)]
         self.assertIn("bg-red-700", delete_button)
         self.assertNotIn("disabled", delete_button)
+        self.assertIn('hx-post="/media_delete', content)
+        self.assertIn('hx-include="closest form"', content)
         self.assertIn("is_create=1", response.context["episode_create_url"])
         self.assertContains(response, "Add new entry")
 

--- a/src/templates/app/components/fill_track.html
+++ b/src/templates/app/components/fill_track.html
@@ -175,10 +175,19 @@
                 Add
               {% endif %}
             </button>
-            <button type="submit"
-                    formaction="{{ general_delete_formaction }}"
-                    class="px-4 py-2 rounded-md transition duration-300 {% if general_existing_instance %}bg-red-700 text-white hover:bg-red-800 cursor-pointer{% else %}bg-gray-600 text-gray-300 cursor-not-allowed{% endif %}"
-                    {% if not general_existing_instance %}disabled{% endif %}>Delete</button>
+            {% if media_type == "episode" %}
+              <button type="button"
+                      hx-post="{{ general_delete_formaction }}"
+                      hx-include="closest form"
+                      hx-swap="none"
+                      class="px-4 py-2 rounded-md transition duration-300 {% if general_existing_instance %}bg-red-700 text-white hover:bg-red-800 cursor-pointer{% else %}bg-gray-600 text-gray-300 cursor-not-allowed{% endif %}"
+                      {% if not general_existing_instance %}disabled{% endif %}>Delete</button>
+            {% else %}
+              <button type="submit"
+                      formaction="{{ general_delete_formaction }}"
+                      class="px-4 py-2 rounded-md transition duration-300 {% if general_existing_instance %}bg-red-700 text-white hover:bg-red-800 cursor-pointer{% else %}bg-gray-600 text-gray-300 cursor-not-allowed{% endif %}"
+                      {% if not general_existing_instance %}disabled{% endif %}>Delete</button>
+            {% endif %}
             {% if episode_create_url %}
               <button type="button"
                       hx-get="{{ episode_create_url }}"


### PR DESCRIPTION
## Summary
Deletes an episode watch through HTMX without reloading the season page or losing the user's scroll position.

**Root cause:** episode deletes fell through to the generic HTMX response, which returned `HX-Redirect` and reloaded the page.

**Solution:** handle only episode HTMX deletes inline, refresh the episode controls, history, and season progress out of band, synchronize season state, and close the modal. Other media deletion behavior is unchanged.

**Screenshots:** before/after captures were produced during manual QA; GitHub attachment upload is still pending.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 Sol)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped view and template inspection, targeted Django testing, repository-wide Ruff, and manual browser QA.

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_crud.DeleteMedia.test_unwatch_episode_htmx_updates_episode_controls app.tests.views.test_track_modal.TrackModalViewTests.test_track_modal_view_existing_episode_exposes_score` → Passed (2 tests).
- `uv run --no-sync ruff check src` → Passed.
- Manual browser comparison → Base Delete used a form action; this PR used `hx-post="/media_delete?next=/history"` with `hx-swap="none"`, preserving the current page.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Failed only on the two current-`latest` list-column expectations for the newly added `synopsis` column; neither failing test is changed by this PR.

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Fixes #820.
