### PR TITLE
Fix multiword API list sorting

### DIFF
--- a/src/api/helpers.py
+++ b/src/api/helpers.py
@@ -641,11 +641,12 @@ def validate_body(body, media_type):
 
 def parse_sort_filter(sort_filter):
     """Parse a sort_filter string into (field, direction) tuple."""
-    if sort_filter and sort_filter != "":
-        parts = sort_filter.split("_", 1)
-        if len(parts) == 2:  # noqa: PLR2004
-            return parts[0], parts[1]
-        return parts[0], ""
+    if sort_filter:
+        for direction in ("asc", "desc"):
+            suffix = f"_{direction}"
+            if sort_filter.endswith(suffix):
+                return sort_filter.removesuffix(suffix), direction
+        return sort_filter, ""
     return "", ""
 
 
@@ -724,6 +725,9 @@ _AGGREGATED_SORT_KEYS = {
     "itemid": itemid_key_compare,
     "mediaid": _sort_mediaid,
     "progress": lambda media: int(getattr(media, "progress", 0) or 0),
+    "release_datetime": lambda media: _sort_nullable(
+        getattr(_item_from_result(media), "release_datetime", None),
+    ),
     "source": _sort_source,
     "started": lambda media: _sort_nullable(getattr(media, "start_date", None)),
     "title": _sort_title,

--- a/src/api/tests/test_lists.py
+++ b/src/api/tests/test_lists.py
@@ -1,5 +1,9 @@
-from django.urls import reverse
+from datetime import timedelta
 
+from django.urls import reverse
+from django.utils import timezone
+
+from app.models import MediaTypes
 from lists.models import CustomList, CustomListItem
 
 from .base import FloppyApiTestCase
@@ -623,6 +627,35 @@ class ListsTests(FloppyApiTestCase):
         payload = response.json()
         titles = [item["item"]["title"] for item in payload["results"]]
         self.assertEqual(titles, sorted(titles, reverse=True))
+
+    def test_list_items_sort_filter_supports_multiword_fields(self):
+        """List items accept a descending multiword Item field sort."""
+        movie, tv, anime = self.items_by_type[MediaTypes.MOVIE.value][0], self.items_by_type[
+            MediaTypes.TV.value
+        ][0], self.items_by_type[MediaTypes.ANIME.value][0]
+        now = timezone.now()
+        for item, release_datetime in (
+            (movie, now - timedelta(days=2)),
+            (tv, now),
+            (anime, now - timedelta(days=1)),
+        ):
+            item.release_datetime = release_datetime
+            item.save(update_fields=["release_datetime"])
+
+        custom_list = self.lists_by_name["favorites"]
+        response = self.call_api(
+            "get",
+            "api_list_add_item",
+            args=(custom_list.id,),
+            params={"sort": "release_datetime_desc"},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [item["item"]["media_id"] for item in response.json()["results"]],
+            [tv.media_id, anime.media_id, movie.media_id],
+        )
 
     def test_list_items_not_found_returns_404(self):
         """List items endpoint with non-existent ID should return 404."""


### PR DESCRIPTION
## Summary
Allows custom-list API endpoints to sort by multiword fields such as `release_datetime_desc`.

**Root cause:** the parser split at the first underscore, turning `release_datetime_desc` into an invalid field and direction. The list sorter also lacked a `release_datetime` ordering key.

**Solution:** parse only a trailing `_asc` or `_desc` suffix and add a null-safe `release_datetime` list sort key.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 Sol)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped helper inspection, targeted Django testing, repository-wide Ruff, Spectacular OpenAPI validation, API contract testing, and domain-vocabulary verification.

## How It Was Tested
- `SECRET=test-only scripts/test.sh api.tests.test_lists` → Passed (51 tests).
- `uv run --no-sync ruff check src` → Passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Failed only on the two current-`latest` list-column expectations for the newly added `synopsis` column; neither failing test is changed by this PR.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified (if API endpoints changed)
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Refs #888.
