### PR TITLE
Support API sorting by user score

### DIFF
--- a/src/api/helpers.py
+++ b/src/api/helpers.py
@@ -124,6 +124,7 @@ MAX_RESULT_LIMIT = 200
 
 
 MEDIA_EXISTING_SORTS = [
+    "score",
     "start_date",
     "end_date",
 ] + [f.name for f in Item._meta.fields]
@@ -724,6 +725,9 @@ _AGGREGATED_SORT_KEYS = {
     "itemid": itemid_key_compare,
     "mediaid": _sort_mediaid,
     "progress": lambda media: int(getattr(media, "progress", 0) or 0),
+    "score": lambda media: _sort_nullable(
+        getattr(media, "aggregated_score", getattr(media, "score", None)),
+    ),
     "source": _sort_source,
     "started": lambda media: _sort_nullable(getattr(media, "start_date", None)),
     "title": _sort_title,

--- a/src/api/tests/test_media_core.py
+++ b/src/api/tests/test_media_core.py
@@ -153,6 +153,38 @@ class MediaCoreTests(FloppyApiTestCase):
         titles = [item["item"]["title"] for item in payload["results"]]
         self.assertEqual(titles, sorted(titles, reverse=True))
 
+    def test_media_list_get_sorts_by_user_score(self):
+        """Media list accepts score as a tracked-media sort field."""
+        for media, score in zip(self.movie_medias, (7, 9, 8), strict=True):
+            media.score = score
+            media.save(update_fields=["score"])
+
+        response = self.call_api(
+            "get",
+            "api_media_list",
+            params={"media_type": MediaTypes.MOVIE.value, "sort": "score_desc"},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [item["score"] for item in response.json()["results"]],
+            [9, 8, 7],
+        )
+
+        response = self.call_api(
+            "get",
+            "api_media_list",
+            params={"sort": "score_desc"},
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [item["score"] for item in response.json()["results"][:3]],
+            [9, 8, 7],
+        )
+
     def test_media_list_get_with_exclude_filter_excludes_type(self):
         """Media list endpoint should exclude requested media types."""
         response = self.call_api(


### PR DESCRIPTION
## Summary
Allows existing-media API lists to sort by the user's tracked-media score.

**Root cause:** the API exposed the value as `score` but omitted it from valid sort fields and aggregate ordering keys.

**Solution:** accept `score` as an existing-media sort and use a null-safe aggregate key for media-type and all-media API lists.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 SOL)** generated or shaped the implementation and regression coverage. Workflows used: repository-guidance review, scoped helper inspection, targeted Django testing, repository-wide Ruff, Spectacular OpenAPI validation, API contract testing, and domain-vocabulary verification.

## How It Was Tested
- `SECRET=test-only scripts/test.sh api.tests.test_media_core` → Passed (73 tests).
- `uv run --no-sync ruff check src` → Passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- GitHub Actions `Lint`, `CodeQL`, and `Docker Image` → Passed.
- GitHub Actions `App Tests` → Passed.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified (if API endpoints changed)
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
Refs #888.
