### PR TITLE
Preserve tracked seasons in TV API details

### DIFF
--- a/src/api/tests/test_media_core.py
+++ b/src/api/tests/test_media_core.py
@@ -652,6 +652,39 @@ class MediaCoreTests(FloppyApiTestCase):
             },
         )
 
+    @patch("api.views.services.get_media_metadata")
+    def test_tv_detail_reports_tracked_season(self, mock_metadata):
+        """TV detail should preserve tracked state for provider seasons."""
+        tv_item = self.items_by_type[MediaTypes.TV.value][0]
+        season_media = self.season_medias[0]
+        mock_metadata.return_value = {
+            "media_id": tv_item.media_id,
+            "source": tv_item.source,
+            "media_type": MediaTypes.TV.value,
+            "related": {
+                "seasons": [
+                    {
+                        "media_id": tv_item.media_id,
+                        "source": tv_item.source,
+                        "media_type": MediaTypes.SEASON.value,
+                        "season_number": season_media.item.season_number,
+                    },
+                ],
+            },
+        }
+
+        response = self.call_api(
+            "get",
+            "api_media_detail",
+            args=(MediaTypes.TV.value, tv_item.source, tv_item.media_id),
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        season = response.json()["related"]["seasons"][0]
+        self.assertTrue(season["tracked"])
+        self.assertEqual(season["id"], season_media.item_id)
+
     def test_media_detail_get_invalid_type_returns_bad_request(self):
         """Media detail endpoint should reject unsupported media types."""
         response = self.call_api(

--- a/src/app/models/manager.py
+++ b/src/app/models/manager.py
@@ -1998,7 +1998,8 @@ class MediaManager(models.Manager):
             params["item__library_media_type"] = MediaTypes.ANIME.value
 
         if media_type == MediaTypes.SEASON.value:
-            params["item__season_number"] = season_number
+            if season_number is not None:
+                params["item__season_number"] = season_number
             params["user"] = user
         elif media_type == MediaTypes.EPISODE.value:
             params["item__season_number"] = season_number


### PR DESCRIPTION
## Summary
TV detail responses now preserve tracked state for seasons that already exist in the user's library.

**Root cause:** the shared season query always added `item__season_number=None` when a caller requested all seasons. Django translated that to `season_number IS NULL`, which excluded every real numbered season and made the API serialize them as untracked.

**Solution:** add the season-number filter only when a specific number is supplied. Exact season lookups keep their existing behavior, and aggregate show-detail lookups can return all tracked seasons.

A focused regression test now proves that a provider season is returned as tracked with the correct Item identity. Existing tests were not weakened.

Screenshots are not applicable. This is a backend query correction with no rendered UI change.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 SOL)** generated and reviewed the implementation. Workflows used: repository-guidance review, issue/comment audit, scoped manager/API inspection, regression-test authoring, targeted Django testing, repository Ruff, OpenAPI validation, contract/domain verification, and the Linux fast suite in Docker.

## How It Was Tested
- `SECRET=test-only scripts/test.sh api.tests.test_media_core` → Passed (73 tests).
- `uv run --no-sync ruff check src` → Passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; generated artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- Linux Docker: `SECRET=test-only scripts/test.sh` → Passed (4,359 tests; 5 skipped).

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual QA is not applicable; this change only corrects a backend query filter

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no model or migration changes)

## Related Issues
Refs #888.
