### PR TITLE
Expose podcast show metadata through API

### DIFF
--- a/src/api/fork_views_podcast.py
+++ b/src/api/fork_views_podcast.py
@@ -39,6 +39,9 @@ def _serialize_show(show, tracker=None):
         "title": show.title,
         "author": show.author,
         "image": show.image,
+        "description": show.description,
+        "genres": show.genres,
+        "language": show.language,
         "rss_feed_url": show.rss_feed_url,
         "tracker": tracker_payload,
     }

--- a/src/api/tests/test_fork_podcast.py
+++ b/src/api/tests/test_fork_podcast.py
@@ -28,6 +28,9 @@ class PodcastApiTestCase(FloppyApiTestCase):
             podcast_uuid="show-uuid-1",
             title="Test Show",
             image="https://example.com/show.jpg",
+            description="A test podcast description.",
+            genres=["Technology", "News"],
+            language="en",
         )
         self.episode1 = PodcastEpisode.objects.create(
             show=self.show,
@@ -47,6 +50,21 @@ class PodcastApiTestCase(FloppyApiTestCase):
 
 class ShowTrackerTests(PodcastApiTestCase):
     """Show tracker CRUD."""
+
+    def test_detail_includes_show_metadata(self):
+        """Show detail exposes the stored discovery metadata."""
+        response = self.call_api(
+            "get",
+            "api_podcast_show_detail",
+            args=(self.show.id,),
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        payload = response.json()
+        self.assertEqual(payload["description"], "A test podcast description.")
+        self.assertEqual(payload["genres"], ["Technology", "News"])
+        self.assertEqual(payload["language"], "en")
 
     def test_track_list_patch_delete(self):
         """Full tracker lifecycle."""


### PR DESCRIPTION
## Summary
Podcast show API responses now include the description, genres, and language already stored for each show.

**Root cause:** podcast show responses are assembled by one explicit dictionary, and those three persisted metadata fields were omitted. The web page could use them, but API clients could not.

**Solution:** add `description`, `genres`, and `language` to the shared show payload. The list, detail, create, and patch responses all use that same serializer, so the fields stay consistent without duplicate logic.

A focused regression test now proves that show detail returns all three stored metadata fields. Existing tests were not weakened.

Screenshots are not applicable. This is an additive backend API response change with no rendered UI change.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 SOL)** generated and reviewed the implementation. Workflows used: repository-guidance review, Pocket Casts playbook review, issue/PR duplicate audit, scoped serializer/model inspection, regression-test authoring, targeted Django testing, repository Ruff, OpenAPI validation, contract/domain verification, and the Linux fast suite in Docker.

## How It Was Tested
- `SECRET=test-only scripts/test.sh api.tests.test_fork_podcast` → Passed (19 tests).
- `uv run --no-sync ruff check src` → Passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; generated artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- Linux Docker: `SECRET=test-only scripts/test.sh` → Passed (4,359 tests; 5 skipped).

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual QA is not applicable; this change only adds fields to JSON responses

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no model or migration changes)

## Related Issues
Refs #888.
