### PR TITLE
Include parent show names in episode history

### DIFF
--- a/src/api/tests/test_fork_tracking.py
+++ b/src/api/tests/test_fork_tracking.py
@@ -481,6 +481,45 @@ class HistoryTimelineTests(FloppyApiTestCase):
             for entry in day["entries"]:
                 self.assertEqual(entry["media_type"], "game")
 
+    def test_episode_history_includes_parent_show_name(self):
+        """Episode entries identify their parent show on every history path."""
+        episode = self.episode_medias[0]
+        episode.item.title = "Pilot"
+        episode.item.save(update_fields=["title"])
+        episode.end_date = datetime.datetime(2024, 5, 11, tzinfo=datetime.UTC)
+        episode.save(update_fields=["end_date"])
+
+        requests = (
+            {"types": "episodes"},
+            {
+                "types": "tv",
+                "media_id": "1001",
+                "source": Sources.TMDB.value,
+            },
+        )
+        for params in requests:
+            with self.subTest(params=params):
+                response = self.call_api(
+                    "get",
+                    "api_history",
+                    params=params,
+                    headers=self.auth_headers,
+                )
+
+                self.assertEqual(response.status_code, HTTP.OK)
+                entries = [
+                    entry
+                    for day in response.json()["results"]
+                    for entry in day["entries"]
+                ]
+                history_entry = next(
+                    entry
+                    for entry in entries
+                    if entry["instance_id"] == episode.id
+                )
+                self.assertEqual(history_entry["title"], "Pilot")
+                self.assertEqual(history_entry["show"]["title"], "TV Show 1")
+
     def test_history_types_alias_filters_categories_before_querying(self):
         """The issue's plural types parameter excludes unrelated categories."""
         episode = self.episode_medias[0]

--- a/src/app/history_cache_utils.py
+++ b/src/app/history_cache_utils.py
@@ -35,7 +35,7 @@ def _coerce_timedelta(value, default):
         return default
 
 
-HISTORY_CACHE_VERSION = 20
+HISTORY_CACHE_VERSION = 21
 HISTORY_INDEX_PREFIX = f"history_index_v{HISTORY_CACHE_VERSION}"
 HISTORY_DAY_PREFIX = f"history_day_v{HISTORY_CACHE_VERSION}"
 HISTORY_CACHE_PREFIX = HISTORY_INDEX_PREFIX

--- a/src/app/history_entry_builders.py
+++ b/src/app/history_entry_builders.py
@@ -219,6 +219,7 @@ def _build_episode_entry(episode, episode_title_map=None):
     entry = {
         "media_type": MediaTypes.EPISODE.value,
         "item": _serialize_item(entry_item),
+        "show": _serialize_show(tv_item),
         "poster": _get_episode_poster(episode),
         "title": title,
         "display_title": display_title,


### PR DESCRIPTION
## Summary
Episode history responses now identify the parent show through the existing `show` object while preserving the episode title in `title`.

**Root cause:** the shared episode history builder already resolved the parent TV item for poster, runtime, and genre fallbacks, but never projected it into the response.

**Solution:** serialize the resolved parent TV item into `entry.show` and bump the history cache schema from v20 to v21 so cached rows are rebuilt. Regression coverage verifies both cached `types=episodes` and filtered TV-history paths. Existing tests were not weakened.

Screenshots are not applicable. This corrects a backend API payload and cache schema with no rendered UI change.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 SOL)** generated and reviewed the implementation. Workflows used: repository-guidance review, issue/PR duplicate audit, scoped history-builder/cache inspection, regression-test authoring, targeted Django testing, Ruff, OpenAPI validation, contract/domain verification, and domain-vocabulary verification.

## How It Was Tested
- Focused parent-show regression → Passed (1 test).
- `SECRET=test-only scripts/test.sh api.tests.test_fork_tracking.HistoryTimelineTests app.tests.test_history_cache.HistoryMonthCacheTests` → Passed (15 tests).
- `uv run --no-sync ruff check src` → Passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- `git diff --check` → Passed.
- The local fast suite discovered all 4,359 tests but the macOS parallel runner could not serialize an unrelated config/entrypoint worker result after SQLite recovery-path failures. The three changed paths were not implicated; GitHub's Linux App Tests remain the definitive broad gate.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual QA is not applicable; this change only corrects a JSON response

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no model or migration changes)

## Related Issues
Refs #888.
