### PR TITLE
Fix podcast progress units

### DIFF
--- a/mcp_server/floppy_mcp/server.py
+++ b/mcp_server/floppy_mcp/server.py
@@ -212,7 +212,7 @@ async def track_media(
     carries progress_scope="entry" for clarity). Its unit depends on
     media_type: minutes for games, episodes for tv/season/anime, plays for
     boardgame/music, percentage/pages/chapters for book/manga/comic
-    depending on the user's preference and format, seconds for podcast.
+    depending on the user's preference and format, minutes for podcast.
     Each response's progress_unit field states the unit actually in use;
     check it rather than assuming from media_type alone.
     """

--- a/src/api/tests/test_fork_podcast.py
+++ b/src/api/tests/test_fork_podcast.py
@@ -132,9 +132,13 @@ class EpisodePlayTests(PodcastApiTestCase):
             headers=self.auth_headers,
         )
         self.assertEqual(response.status_code, HTTP.CREATED)
+        payload = response.json()
+        self.assertEqual(payload["progress"], 30)
+        self.assertEqual(payload["progress_unit"], "minutes")
         podcast = Podcast.objects.get(user=self.user1, episode=self.episode1)
         self.assertEqual(podcast.item.media_id, "ep-uuid-1")
         self.assertEqual(podcast.progress, 30)
+        self.assertEqual(podcast.formatted_progress, "30m")
 
     def test_blank_date_uses_current_server_time(self):
         """A blank date records a completed play at the current server time."""

--- a/src/app/activity_builders.py
+++ b/src/app/activity_builders.py
@@ -329,8 +329,7 @@ def _build_detail_activity_state(
                         },
                     )
             elif media_type == MediaTypes.PODCAST.value:
-                total_progress_seconds = int(aggregated_progress or 0)
-                total_minutes = total_progress_seconds // 60
+                total_minutes = int(aggregated_progress or 0)
                 completed_entries = sum(
                     1
                     for entry in user_medias

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -905,7 +905,7 @@ def media_details(
                 range_start_candidates = []
                 range_end_candidates = []
                 completed_entries = 0
-                total_progress_seconds = 0
+                total_progress_minutes = 0
 
                 for entry in user_podcasts:
                     range_start = entry.start_date or entry.end_date or entry.created_at
@@ -916,9 +916,9 @@ def media_details(
                         range_end_candidates.append(range_end)
                     if entry.end_date or entry.status == Status.COMPLETED.value:
                         completed_entries += 1
-                    total_progress_seconds += int(entry.progress or 0)
+                    total_progress_minutes += int(entry.progress or 0)
 
-                total_listened_minutes = total_progress_seconds // 60
+                total_listened_minutes = total_progress_minutes
                 podcast_play_stats = {
                     "first_played": min(range_start_candidates)
                     if range_start_candidates

--- a/src/app/models/podcast.py
+++ b/src/app/models/podcast.py
@@ -198,13 +198,12 @@ class Podcast(Media):
             minutes = self.played_up_to_seconds // 60
             return f"{minutes}m"
 
-        minutes = (self.progress or 0) // 60
-        return f"{minutes}m"
+        return f"{self.progress or 0}m"
 
     @property
     def progress_unit(self):
         """Return the unit `progress` is measured in."""
-        return "seconds"
+        return "minutes"
 
     @property
     def progress_percentage(self):

--- a/src/app/tests/test_activity_builders.py
+++ b/src/app/tests/test_activity_builders.py
@@ -1,0 +1,55 @@
+from datetime import UTC, datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.activity_builders import _build_detail_activity_state
+from app.models import Item, MediaTypes, Podcast, Sources, Status
+
+
+class PodcastActivityBuilderTests(TestCase):
+    """Test podcast activity totals."""
+
+    def test_progress_is_aggregated_as_minutes(self):
+        """Podcast progress values are already stored in minutes."""
+        user = get_user_model().objects.create_user(username="podcast-activity")
+        first_item = Item.objects.create(
+            media_id="podcast-episode-1",
+            source=Sources.POCKETCASTS.value,
+            media_type=MediaTypes.PODCAST.value,
+            title="Episode One",
+            runtime_minutes=30,
+        )
+        second_item = Item.objects.create(
+            media_id="podcast-episode-2",
+            source=Sources.POCKETCASTS.value,
+            media_type=MediaTypes.PODCAST.value,
+            title="Episode Two",
+            runtime_minutes=45,
+        )
+        first = Podcast.objects.create(
+            item=first_item,
+            user=user,
+            status=Status.COMPLETED.value,
+            progress=30,
+            end_date=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        second = Podcast.objects.create(
+            item=second_item,
+            user=user,
+            status=Status.COMPLETED.value,
+            progress=45,
+            end_date=datetime(2026, 3, 2, tzinfo=UTC),
+        )
+
+        play_stats, subtitle = _build_detail_activity_state(
+            MediaTypes.PODCAST.value,
+            {"max_progress": 2},
+            current_instance=first,
+            user_medias=[first, second],
+        )
+
+        self.assertEqual(play_stats["total_minutes"], 75)
+        self.assertEqual(play_stats["total_hours"], 1)
+        self.assertEqual(play_stats["total_minutes_remainder"], 15)
+        self.assertEqual(subtitle["duration_text"], "1h 15min listened")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -3348,7 +3348,7 @@ class MediaDetailsViewTests(TestCase):
             show=show,
             episode=episode_one,
             status=Status.COMPLETED.value,
-            progress=1800,
+            progress=30,
             start_date=datetime(2026, 3, 1, 12, 0, tzinfo=UTC),
             end_date=datetime(2026, 3, 1, 12, 30, tzinfo=UTC),
         )
@@ -3358,7 +3358,7 @@ class MediaDetailsViewTests(TestCase):
             show=show,
             episode=episode_two,
             status=Status.COMPLETED.value,
-            progress=2700,
+            progress=45,
             start_date=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
             end_date=datetime(2026, 3, 12, 12, 45, tzinfo=UTC),
         )


### PR DESCRIPTION
## Summary
Podcast progress is now reported, formatted, and aggregated consistently in minutes.

**Root cause:** PR #730 inferred the generic progress unit from the separate `played_up_to_seconds` resume-position field. Existing podcast writers, runtime limits, forms, and status processing all store `Podcast.progress` in minutes, while two detail aggregators repeated the stale seconds assumption.

**Solution:** declare `progress_unit` as minutes, format stored progress without dividing again, sum both detail activity totals directly in minutes, and correct MCP guidance. `played_up_to_seconds` remains the precise resume-position field. Regression coverage verifies the API unit/value, formatted progress, and 30+45=75 minute aggregation. Existing tests were corrected to the intended storage contract, not weakened.

Screenshots are not applicable. This is a backend unit-contract correction with no rendered layout change.

## AI Assistance
OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 SOL)** generated and reviewed the implementation. Workflows used: repository-guidance and Pocket Casts playbook review, issue/PR duplicate audit, complete writer/reader path audit, regression-test authoring, targeted Django testing, Ruff, OpenAPI validation, and contract/domain verification.

## How It Was Tested
- Podcast writer/API audit suite → Passed (130 tests).
- Final focused podcast/API/activity suite → Passed (20 tests).
- `uv run --no-sync ruff check src` → Passed; changed `mcp_server/floppy_mcp/server.py` also passed.
- `PYTHONPATH=mcp_server SECRET=test-only uv run --no-sync python src/manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` → Passed; artifact unchanged.
- `PYTHONPATH=mcp_server SECRET=test-only scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary` → Passed (64 tests).
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` → Passed.
- `git diff --check` → Passed.
- The local fast suite reached unrelated startup/SQLite recovery failures; no podcast failures appeared. GitHub's Linux App Tests remain the definitive broad gate.

## Compatibility Note
Clients that followed the stale seconds guidance may have submitted seconds through the generic API. Internally written rows are consistently minutes, and ambiguous externally written legacy values cannot be safely auto-migrated without provenance.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual QA is not applicable; this change corrects unit semantics without changing layout

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no model or migration changes)

## Related Issues
Refs #888.
