### PR TITLE
Prevent black overlays during media pagination

### DIFF
--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -479,18 +479,16 @@ def build_filter_data_from_items(
         {"value": value, "label": value}
         for value in sorted(providers_set, key=lambda val: val.lower())
     ]
-    all_providers = (
-        [
-            {
-                "value": provider["provider_name"],
-                "label": provider["provider_name"],
+    all_providers_by_name = {}
+    if include_providers:
+        for provider in tmdb.global_watch_provider_catalog():
+            provider_name = provider["provider_name"]
+            all_providers_by_name[provider_name] = {
+                "value": provider_name,
+                "label": provider_name,
                 "image": provider["image"],
             }
-            for provider in tmdb.global_watch_provider_catalog()
-        ]
-        if include_providers
-        else []
-    )
+    all_providers = list(all_providers_by_name.values())
     media_statuses = [
         {"value": value, "label": value}
         for value in sorted(media_statuses_set, key=lambda val: val.lower())

--- a/src/app/tests/views/test_media_list.py
+++ b/src/app/tests/views/test_media_list.py
@@ -2874,6 +2874,38 @@ class MediaListViewTests(TestCase):
         self.assertContains(filtered_response, "Provider Filter Pinned Movie")
         self.assertNotContains(filtered_response, "Provider Filter Other Movie")
 
+    @mock.patch("app.media_list_views.tmdb.global_watch_provider_catalog")
+    def test_global_provider_choices_deduplicate_names(self, mock_catalog):
+        """Provider-name keys must remain unique for Alpine's x-for rendering."""
+        mock_catalog.return_value = [
+            {
+                "provider_id": 1,
+                "provider_name": "Amazon MX Player",
+                "image": "https://example.com/movie-logo.jpg",
+            },
+            {
+                "provider_id": 2,
+                "provider_name": "Amazon MX Player",
+                "image": "https://example.com/tv-logo.jpg",
+            },
+        ]
+
+        response = self.client.get(
+            reverse("medialist", args=[MediaTypes.MOVIE.value]),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["filter_data"]["all_providers"],
+            [
+                {
+                    "value": "Amazon MX Player",
+                    "label": "Amazon MX Player",
+                    "image": "https://example.com/tv-logo.jpg",
+                },
+            ],
+        )
+
     def test_toggle_pinned_provider_requires_authentication(self):
         self.client.logout()
         response = self.client.post(
@@ -3071,6 +3103,9 @@ class MediaListViewTests(TestCase):
             'hx-trigger="revealed threshold:200px once"',
             html=False,
         )
+        grid_html = grid_page.content.decode()
+        self.assertRegex(grid_html, r'x-show="trackOpen"\s+x-cloak')
+        self.assertRegex(grid_html, r'x-show="listsOpen"\s+x-cloak')
 
         first_page = self.client.get(
             reverse("medialist", args=[MediaTypes.MOVIE.value])
@@ -3095,6 +3130,7 @@ class MediaListViewTests(TestCase):
         )
         second_html = second_page.content.decode()
         self.assertNotIn("<thead", second_html)
+        self.assertRegex(second_html, r'x-show="trackOpen"\s+x-cloak')
 
         second_rows = re.findall(r"<tr[^>]*>(.*?)</tr>", second_html, flags=re.DOTALL)
         self.assertGreater(len(second_rows), 0)

--- a/src/templates/app/components/album_list_grid_items.html
+++ b/src/templates/app/components/album_list_grid_items.html
@@ -85,6 +85,7 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"

--- a/src/templates/app/components/artist_grid_items.html
+++ b/src/templates/app/components/artist_grid_items.html
@@ -101,6 +101,7 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"

--- a/src/templates/app/components/cells/album_image_cell.html
+++ b/src/templates/app/components/cells/album_image_cell.html
@@ -20,6 +20,7 @@
 
 {# Track Modal #}
 <div x-show="trackOpen"
+     x-cloak
      @keydown.escape.window="trackOpen = false"
      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
   <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"

--- a/src/templates/app/components/cells/artist_image_cell.html
+++ b/src/templates/app/components/cells/artist_image_cell.html
@@ -19,6 +19,7 @@
 
 {# Track Modal #}
 <div x-show="trackOpen"
+     x-cloak
      @keydown.escape.window="trackOpen = false"
      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
   <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"

--- a/src/templates/app/components/cells/media_image_cell.html
+++ b/src/templates/app/components/cells/media_image_cell.html
@@ -14,6 +14,7 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -730,6 +730,7 @@
 
         {# Track Modal #}
         <div x-show="trackOpen"
+             x-cloak
              @keydown.escape.window="trackOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
@@ -749,6 +750,7 @@
 
         {# Lists Modal #}
         <div x-show="listsOpen"
+             x-cloak
              @keydown.escape.window="listsOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"

--- a/src/templates/app/components/podcast_show_grid_items.html
+++ b/src/templates/app/components/podcast_show_grid_items.html
@@ -99,6 +99,7 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"


### PR DESCRIPTION
## Summary

Media-library pagination no longer leaves a black overlay over newly loaded cards.

TMDB can return separate provider IDs with the same display name. Floppy used that name as an Alpine `x-for` key, so duplicate names such as Amazon MX Player could break Alpine while HTMX appended the next page. Floppy now emits one global provider choice per filter name and cloaks card modal backdrops until Alpine initializes them.

No API, database, migration, CSS, or documentation contract changes are included.

### Bug fix explanation

**Root cause:** The global provider catalog was unique by TMDB provider ID, but the filter and pinning contract is name-based. Two IDs with the same name therefore produced duplicate Alpine keys. If Alpine failed while processing an HTMX page append, the new cards' full-screen modal backdrops could render before `x-show` hid them, covering the page while the cards remained underneath.

**Prevention:** Provider choices are deduplicated at the name-based UI boundary. Paginated grid and table card dialogs also use the repository's existing `x-cloak` rule, so an uninitialized dialog cannot obscure the page.

**Scope:** The cloak is applied only to the existing card dialogs used by media, artist, album, and podcast library pagination. No dialog behavior or layout is changed.

**Screenshots:** The reporter's before screenshot is in [issue #908](https://github.com/dannyvfilms/Floppy/issues/908). The verified after screenshot is attached in [this PR comment](https://github.com/dannyvfilms/Floppy/pull/915#issuecomment-5355495927).

<img width="1710" height="854" alt="Successful two-page pagination with no overlay" src="https://github.com/user-attachments/assets/e6a374f5-7243-4b5f-b62b-a6f7d22a58ba" />

## AI Assistance

OpenAI Codex using the exact model identifier **`gpt-5.6-sol` (Codex 5.6 SOL)** generated and reviewed this change.

Workflows used: repository-guidance review, GitHub duplicate-PR audit, issue log and screenshot inspection, focused Alpine/HTMX root-cause analysis, minimal implementation, regression-test authoring, Django testing, Ruff, template-lint inspection, staged-diff review, and manual browser QA.

## How It Was Tested

Completed:

- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list.MediaListViewTests.test_global_provider_choices_deduplicate_names app.tests.views.test_media_list.MediaListViewTests.test_paginated_media_layouts_render_correctly` -> Passed (2 tests).
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list` -> Passed (91 tests).
- `uv run --no-sync ruff check src` -> Passed.
- `git diff --check upstream/latest...HEAD` -> Passed.
- Manual browser QA: HTMX appended page two (32 → 40 cards), no modal backdrops were visible, and the browser console had no errors.
- GitHub Actions: all 9 required checks passed, including App Tests, Lint, CodeQL, and Docker Image.
- No existing assertion was weakened. The regressions add duplicate-provider coverage and strengthen existing grid/table pagination coverage.

Template-lint note: a scoped `djlint --check` reports existing whole-file formatting differences across these established templates. Applying its suggested rewrite would create a large unrelated diff, so no formatting churn is included.

## Public API & Documentation Handoff

- [x] Not applicable (no API or vocabulary changes)
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)

## Human Review & Quality Assurance

- [ ] Code review completed
- [x] Visual and manual QA verified

## Database & Migration Safety (Only if modifying models)

- [x] Not applicable (no database changes)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)

## Related Issues

Fixes #908.