### PR TITLE
Add list filter support to smart list rules

### DIFF
--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -47,6 +47,7 @@ from app.models import (
     Season,
     Sources,
 )
+from lists.models import CustomListItem
 from lists.smart_rules import sync_smart_lists_for_item
 
 logger = logging.getLogger(__name__)
@@ -391,6 +392,27 @@ def sync_smart_lists_on_item_tag_change(sender, instance, **kwargs):
     if not owner or not item:
         return
     _sync_owner_smart_lists_for_items(owner, [item])
+
+
+@receiver([post_save, post_delete], sender=CustomListItem)
+def sync_smart_lists_on_list_membership_change(sender, instance, **kwargs):
+    """Re-evaluate referencing smart lists when a manual list's membership changes.
+
+    A smart list's "List" filter includes the full contents of any linked
+    (non-smart) list. Membership changes on that manual list happen outside
+    the normal media-tracking signals below, so they need their own hook.
+    """
+    if kwargs.get("raw"):
+        return
+    custom_list = getattr(instance, "custom_list", None)
+    item = getattr(instance, "item", None)
+    if not custom_list or not item or custom_list.is_smart:
+        return
+
+    owners = {custom_list.owner}
+    owners.update(custom_list.collaborators.all())
+    for owner in owners:
+        _sync_owner_smart_lists_for_items(owner, [item])
 
 
 @receiver(post_save, sender=Item)

--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -8,7 +8,7 @@ from celery.signals import before_task_publish, task_failure, task_success
 from django.apps import apps
 from django.conf import settings
 from django.db import transaction
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_save
 from django.db.utils import OperationalError
 from django.dispatch import receiver
 from django.utils import timezone
@@ -47,7 +47,7 @@ from app.models import (
     Season,
     Sources,
 )
-from lists.models import CustomListItem
+from lists.models import CustomList, CustomListItem
 from lists.smart_rules import sync_smart_lists_for_item
 
 logger = logging.getLogger(__name__)
@@ -413,6 +413,27 @@ def sync_smart_lists_on_list_membership_change(sender, instance, **kwargs):
     owners.update(custom_list.collaborators.all())
     for owner in owners:
         _sync_owner_smart_lists_for_items(owner, [item])
+
+
+@receiver(m2m_changed, sender=CustomList.items.through)
+def sync_smart_lists_on_list_items_m2m_change(
+    sender, instance, action, reverse, pk_set, **kwargs
+):
+    """Catch list-membership writes that bypass CustomListItem's save/delete.
+
+    `CustomList.items.add()` creates `CustomListItem` rows via the m2m
+    manager's `bulk_create()`, which doesn't call `save()`, so
+    `sync_smart_lists_on_list_membership_change` above never fires for it.
+    `m2m_changed` fires regardless of how the through rows were written.
+    """
+    if action != "post_add" or reverse or instance.is_smart or not pk_set:
+        return
+
+    items = list(Item.objects.filter(id__in=pk_set))
+    owners = {instance.owner}
+    owners.update(instance.collaborators.all())
+    for owner in owners:
+        _sync_owner_smart_lists_for_items(owner, items)
 
 
 @receiver(post_save, sender=Item)

--- a/src/lists/imports/mdblist.py
+++ b/src/lists/imports/mdblist.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from app.models import Item, MediaTypes, Sources
 from app.providers import services
 from integrations.imports import helpers
+from lists.smart_rules import sync_smart_lists_for_item
 
 # Shared MDBList client helpers live with the full-account importer; keep the
 # old private names so existing call sites and test patch targets still work.
@@ -173,6 +174,8 @@ def _sync_list(user, api_key, list_info):
             continue
         desired_item_ids.add(item.id)
 
+    changed_item_ids = set()
+
     def _apply():
         with transaction.atomic():
             custom_list, _ = CustomList.objects.update_or_create(
@@ -184,22 +187,41 @@ def _sync_list(user, api_key, list_info):
                     "description": list_info.get("description") or "",
                 },
             )
-            custom_list.customlistitem_set.exclude(
-                item_id__in=desired_item_ids,
+            removed_item_ids = set(
+                custom_list.customlistitem_set.exclude(
+                    item_id__in=desired_item_ids,
+                ).values_list("item_id", flat=True),
+            )
+            custom_list.customlistitem_set.filter(
+                item_id__in=removed_item_ids,
             ).delete()
             existing_item_ids = set(
                 custom_list.customlistitem_set.values_list("item_id", flat=True),
             )
+            added_item_ids = desired_item_ids - existing_item_ids
             CustomListItem.objects.bulk_create(
                 CustomListItem(
                     custom_list=custom_list,
                     item_id=item_id,
                     added_by=user,
                 )
-                for item_id in desired_item_ids - existing_item_ids
+                for item_id in added_item_ids
             )
+            changed_item_ids.update(removed_item_ids, added_item_ids)
 
     helpers.retry_on_lock(_apply)
+
+    # bulk_create() and the bulk .delete() above bypass CustomListItem's
+    # save()/delete(), so the smart-list membership signal never fires for
+    # them; resync explicitly for whatever actually changed.
+    for item_id in changed_item_ids:
+        try:
+            sync_smart_lists_for_item(owner=user, item=Item(id=item_id))
+        except Exception:
+            logger.exception(
+                "Failed to sync smart lists for item %s after MDBList list sync",
+                item_id,
+            )
     logger.info(
         "Synced MDBList list %s (%s) for %s: %s items, %s skipped",
         list_id,

--- a/src/lists/smart_rules.py
+++ b/src/lists/smart_rules.py
@@ -1199,6 +1199,7 @@ def build_rule_filter_data(
     *,
     include_collection_only_untracked: bool = False,
     precomputed_tags: list[str] | None = None,
+    include_list_options: bool = True,
 ):
     """Build menu options for smart-rule filters from matched candidate media."""
     target_media_types = _target_media_types(owner, media_types)
@@ -1393,13 +1394,15 @@ def build_rule_filter_data(
             .order_by("name")
         )
 
-    from lists.models import CustomList
+    filter_data["lists"] = []
+    if include_list_options:
+        from lists.models import CustomList
 
-    filter_data["lists"] = [
-        {"id": custom_list.id, "label": custom_list.name}
-        for custom_list in CustomList.objects.get_user_lists(owner)
-        .filter(is_smart=False)
-        .order_by("name")
-    ]
+        filter_data["lists"] = [
+            {"id": custom_list.id, "label": custom_list.name}
+            for custom_list in CustomList.objects.get_user_lists(owner)
+            .filter(is_smart=False)
+            .order_by("name")
+        ]
 
     return filter_data

--- a/src/lists/smart_rules.py
+++ b/src/lists/smart_rules.py
@@ -41,6 +41,7 @@ SMART_FILTER_KEYS = (
     "provider",
     "tag",
     "tag_mode",
+    "list",
 )
 
 TAG_MODE_CHOICES = {"and", "or", "not"}
@@ -72,6 +73,7 @@ SMART_FILTER_DEFAULTS = {
     "provider": "",
     "tag": [],
     "tag_mode": "or",
+    "list": [],
 }
 
 MAX_RATING = 10.0
@@ -242,6 +244,22 @@ def _payload_getlist(payload, key: str) -> list[str]:
     return []
 
 
+def _valid_linked_list_ids(owner, raw_values: list[str]) -> list[int]:
+    """Return ids from raw_values that are non-smart lists owner can access."""
+    candidate_ids = {int(value) for value in raw_values if str(value).strip().isdigit()}
+    if not candidate_ids or not owner:
+        return []
+
+    from lists.models import CustomList
+
+    return list(
+        CustomList.objects.filter(id__in=candidate_ids, is_smart=False)
+        .filter(Q(owner=owner) | Q(collaborators=owner))
+        .distinct()
+        .values_list("id", flat=True),
+    )
+
+
 def get_available_media_types(owner) -> list[str]:
     """Return enabled media types that can participate in smart rules."""
     if owner and hasattr(owner, "get_enabled_media_types"):
@@ -368,6 +386,8 @@ def normalize_rule_payload(payload, owner):
         seen_tags.add(key)
         deduped_tags.append(value)
 
+    list_ids = _valid_linked_list_ids(owner, _payload_getlist(payload, "list"))
+
     return {
         "media_types": normalized_media_types,
         "status": normalized_statuses,
@@ -396,6 +416,7 @@ def normalize_rule_payload(payload, owner):
         "provider": str(_payload_get(payload, "provider", "") or "").strip(),
         "tag": deduped_tags,
         "tag_mode": tag_mode,
+        "list": list_ids,
     }
 
 
@@ -836,6 +857,21 @@ def _resolve_tag_id_sets(
     return set().union(*per_tag_id_sets), None
 
 
+def _resolve_list_membership_item_ids(list_ids: list[int]) -> set[int]:
+    """Return the union of item ids belonging to the given linked lists."""
+    if not list_ids:
+        return set()
+
+    from lists.models import CustomListItem
+
+    return set(
+        CustomListItem.objects.filter(custom_list_id__in=list_ids).values_list(
+            "item_id",
+            flat=True,
+        ),
+    )
+
+
 def collect_matching_item_ids(
     owner,
     normalized_rules: dict,
@@ -981,6 +1017,8 @@ def collect_matching_item_ids(
                             continue
                         matched_ids.add(item.id)
 
+    matched_ids |= _resolve_list_membership_item_ids(normalized_rules.get("list") or [])
+
     return matched_ids
 
 
@@ -994,6 +1032,16 @@ def item_matches_rules(
     """Return whether a single item currently matches a normalized rule set for an owner."""
     if not owner or not item:
         return False
+
+    list_ids = normalized_rules.get("list") or []
+    if list_ids:
+        from lists.models import CustomListItem
+
+        if CustomListItem.objects.filter(
+            custom_list_id__in=list_ids,
+            item_id=item.id,
+        ).exists():
+            return True
 
     target_media_types = _target_media_types(
         owner, normalized_rules.get("media_types", [])
@@ -1344,5 +1392,14 @@ def build_rule_filter_data(
             .values_list("name", flat=True)
             .order_by("name")
         )
+
+    from lists.models import CustomList
+
+    filter_data["lists"] = [
+        {"id": custom_list.id, "label": custom_list.name}
+        for custom_list in CustomList.objects.get_user_lists(owner)
+        .filter(is_smart=False)
+        .order_by("name")
+    ]
 
     return filter_data

--- a/src/lists/tests/test_models.py
+++ b/src/lists/tests/test_models.py
@@ -304,6 +304,119 @@ class CustomListManagerTest(TestCase):
                 expected_ids,
             )
 
+    def test_normalize_rule_payload_restricts_list_filter_to_accessible_manual_lists(
+        self,
+    ):
+        """The list filter should only accept non-smart lists owner can access."""
+        inaccessible_list = CustomList.objects.create(
+            name="Not Mine",
+            owner=self.other_user,
+        )
+        smart_target = CustomList.objects.create(
+            name="Smart Target",
+            owner=self.user,
+            is_smart=True,
+        )
+
+        rules = smart_rules.normalize_rule_payload(
+            {
+                "list": [
+                    self.list1.id,
+                    self.list2.id,
+                    inaccessible_list.id,
+                    smart_target.id,
+                ],
+            },
+            self.user,
+        )
+
+        self.assertCountEqual(rules["list"], [self.list1.id, self.list2.id])
+
+    def test_collect_matching_item_ids_unions_linked_list_contents(self):
+        """List filter should include linked lists' items even if other filters fail."""
+        linked_item = Item.objects.create(
+            title="Untracked Linked Game",
+            media_id="link-1",
+            media_type=MediaTypes.GAME.value,
+            source=Sources.IGDB.value,
+        )
+        CustomListItem.objects.create(
+            custom_list=self.list1,
+            item=linked_item,
+            added_by=self.user,
+        )
+        other_item = Item.objects.create(
+            title="Unrelated Movie",
+            media_id="link-2",
+            media_type=MediaTypes.MOVIE.value,
+            source=Sources.TMDB.value,
+        )
+        Movie.objects.create(
+            item=other_item, user=self.user, status=Status.COMPLETED.value
+        )
+
+        rules = smart_rules.normalize_rule_payload(
+            {
+                "media_types": [MediaTypes.MOVIE.value],
+                "genre": "Nonexistent Genre",
+                "list": [self.list1.id],
+            },
+            self.user,
+        )
+
+        matched_ids = smart_rules.collect_matching_item_ids(self.user, rules)
+
+        self.assertIn(linked_item.id, matched_ids)
+        self.assertNotIn(other_item.id, matched_ids)
+
+    def test_item_matches_rules_short_circuits_for_linked_list_membership(self):
+        """A linked list's item should match regardless of other active filters."""
+        linked_item = Item.objects.create(
+            title="Linked Game",
+            media_id="link-3",
+            media_type=MediaTypes.GAME.value,
+            source=Sources.IGDB.value,
+        )
+        CustomListItem.objects.create(
+            custom_list=self.list1,
+            item=linked_item,
+            added_by=self.user,
+        )
+
+        rules = smart_rules.normalize_rule_payload(
+            {"genre": "Nonexistent Genre", "list": [self.list1.id]},
+            self.user,
+        )
+
+        self.assertTrue(smart_rules.item_matches_rules(self.user, linked_item, rules))
+
+    def test_manual_list_membership_change_syncs_referencing_smart_lists(self):
+        """Adding/removing an item on a linked manual list should resync smart lists."""
+        linked_item = Item.objects.create(
+            title="Freshly Linked Game",
+            media_id="link-4",
+            media_type=MediaTypes.GAME.value,
+            source=Sources.IGDB.value,
+        )
+        smart_list = CustomList.objects.create(
+            name="All Owned Games",
+            owner=self.user,
+            is_smart=True,
+            smart_filters={"list": [self.list1.id]},
+        )
+
+        membership = CustomListItem.objects.create(
+            custom_list=self.list1,
+            item=linked_item,
+            added_by=self.user,
+        )
+
+        self.assertTrue(smart_list.items.filter(id=linked_item.id).exists())
+
+        membership.delete()
+
+        self.assertFalse(smart_list.items.filter(id=linked_item.id).exists())
+
     def test_smart_list_collection_filter_uses_episode_collection_for_tv(self):
         """Collected TV rules should match when related episodes are collected."""
         tv_item = Item.objects.create(

--- a/src/lists/views_smart_list.py
+++ b/src/lists/views_smart_list.py
@@ -161,8 +161,12 @@ def _smart_list_detail_response(
                 else saved_rules["tag"],
                 "tag_exclude": request.GET.get("tag_exclude", ""),
                 "tag_mode": request.GET.get("tag_mode", saved_rules["tag_mode"]),
+                # Only an editor may override which manual lists are linked in:
+                # this can union in the full contents of any non-smart list the
+                # owner can access, so a public (non-editor) viewer must not be
+                # able to pass arbitrary list ids via the query string.
                 "list": request.GET.getlist("list")
-                if "list" in request.GET
+                if can_edit and "list" in request.GET
                 else saved_rules["list"],
                 "search": request.GET.get("q", saved_rules["search"]),
                 "sort": request.GET.get("sort", saved_rules["sort"]),
@@ -322,6 +326,9 @@ def _smart_list_detail_response(
         media_types=active_rules["media_types"],
         status=active_rules["status"],
         search=active_rules["search"],
+        # Never hand a non-editor the owner's full catalog of manual lists
+        # (names/ids of private lists), only editors get the picker's options.
+        include_list_options=can_edit,
     )
     available_media_types = sorted(
         smart_rules.get_available_media_types(custom_list.owner),

--- a/src/lists/views_smart_list.py
+++ b/src/lists/views_smart_list.py
@@ -161,6 +161,9 @@ def _smart_list_detail_response(
                 else saved_rules["tag"],
                 "tag_exclude": request.GET.get("tag_exclude", ""),
                 "tag_mode": request.GET.get("tag_mode", saved_rules["tag_mode"]),
+                "list": request.GET.getlist("list")
+                if "list" in request.GET
+                else saved_rules["list"],
                 "search": request.GET.get("q", saved_rules["search"]),
                 "sort": request.GET.get("sort", saved_rules["sort"]),
                 "sort_direction": request.GET.get(
@@ -334,6 +337,7 @@ def _smart_list_detail_response(
         [
             bool(active_rules.get("status")),
             bool(active_rules.get("tag")),
+            bool(active_rules.get("list")),
             active_rules.get("rating") not in {"", "all"},
             active_rules.get("rating_min"),
             active_rules.get("rating_max"),

--- a/src/templates/lists/components/list_form.html
+++ b/src/templates/lists/components/list_form.html
@@ -112,7 +112,7 @@
                   <p class="text-xs text-[var(--color-text-muted)] ml-7">{{ form.is_smart.help_text }}</p>
                 </div>
                 <label class="relative inline-flex items-center cursor-pointer ml-4">
-                  <input class="sr-only peer" type="checkbox" name="{{ form.is_smart.name }}" x-model="isSmart" :checked="listMode === 'smart'" {% if form.instance.is_smart %}checked{% endif %}>
+                  <input class="sr-only peer" type="checkbox" name="{{ form.is_smart.name }}" x-model="isSmart" :checked="typeof listMode !== 'undefined' && listMode === 'smart'" {% if form.instance.is_smart %}checked{% endif %}>
                   <div class="w-9 h-5 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-px after:left-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4.5 after:w-4.5 after:transition-all peer-checked:bg-indigo-600"></div>
                 </label>
               </div>

--- a/src/templates/lists/components/smart_rules_builder.html
+++ b/src/templates/lists/components/smart_rules_builder.html
@@ -30,6 +30,10 @@
   </template>
   <input type="hidden" name="tag" value="" :disabled="selectedTags.length > 0">
   <input type="hidden" name="tag_mode" x-model="tagMode">
+  <template x-for="id in selectedLists" :key="`smart-list-${id}`">
+    <input type="hidden" name="list" :value="id">
+  </template>
+  <input type="hidden" name="list" value="" :disabled="selectedLists.length > 0">
   <input type="hidden" name="q" x-model="query">
   <input type="hidden" name="type_mode" :value="allTypesSelected() ? 'all' : 'subset'">
   {% if can_edit %}
@@ -295,6 +299,17 @@
                     type="button">
               <span class="flex-shrink-0 mr-3">Tag</span>
               <span class="ml-auto text-xs text-[var(--color-text-muted)] block min-w-0 truncate max-w-[8rem]" x-text="selectedTags.length ? selectedTags.join(', ') : 'Any'"></span>
+              <span class="ml-2">{% include "app/icons/chevron-right.svg" with classes="w-3.5 h-3.5" %}</span>
+            </button>
+          {% endif %}
+
+          {% if smart_filter_data.lists %}
+            <div class="border-t border-gray-700 my-1"></div>
+            <button class="flex items-center w-full px-4 py-2 text-left text-sm transition-colors cursor-pointer text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                    @click="view = 'list'; resetSearch()"
+                    type="button">
+              <span class="flex-shrink-0 mr-3">List</span>
+              <span class="ml-auto text-xs text-[var(--color-text-muted)] block min-w-0 truncate max-w-[8rem]" x-text="selectedLists.length ? selectedLists.length + ' selected' : 'Any'"></span>
               <span class="ml-2">{% include "app/icons/chevron-right.svg" with classes="w-3.5 h-3.5" %}</span>
             </button>
           {% endif %}
@@ -1042,6 +1057,51 @@
                       type="button">
                 <span class="block min-w-0 truncate max-w-[11rem]" x-text="option"></span>
                 <span class="ml-auto" x-show="isTagSelected(option)">
+                  {% include "app/icons/checkmark.svg" with classes="w-4 h-4 text-green-400" %}
+                </span>
+              </button>
+            </template>
+          </div>
+        </div>
+
+        <div x-show="view === 'list'" x-cloak class="p-2">
+          <div class="flex items-center gap-2 px-2 py-1">
+            <button class="p-1 rounded hover:bg-[var(--color-surface-hover)] transition-colors cursor-pointer"
+                    @click="view = 'root'"
+                    type="button">
+              {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
+            </button>
+            <div class="text-xs uppercase tracking-wide text-[var(--color-text-secondary)]">List</div>
+          </div>
+          <div class="px-2 py-2">
+            <input type="text"
+                   x-model="listSearch"
+                   placeholder="Filter Lists"
+                   class="w-full px-3 py-2 rounded-md bg-[var(--color-surface)] text-sm text-[var(--color-text-secondary)] placeholder-[var(--color-text-muted)] border border-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+          </div>
+          <div class="max-h-64 overflow-y-auto">
+            <button hx-get="{% url 'list_detail' custom_list.public_reference %}"
+                    hx-target="#items-view"
+                    hx-include="#smart-filter-form"
+                    hx-indicator="#loading-indicator"
+                    class="flex items-center w-full px-4 py-2 text-left text-sm transition-colors cursor-pointer text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                    @click="selectedLists = []; onRuleChange()"
+                    type="button">
+              <span>Clear Lists</span>
+              <span class="ml-auto" x-show="selectedLists.length === 0">
+                {% include "app/icons/checkmark.svg" with classes="w-4 h-4 text-green-400" %}
+              </span>
+            </button>
+            <template x-for="option in filteredLists()" :key="option.id">
+              <button hx-get="{% url 'list_detail' custom_list.public_reference %}"
+                      hx-target="#items-view"
+                      hx-include="#smart-filter-form"
+                      hx-indicator="#loading-indicator"
+                      class="flex items-center w-full px-4 py-2 text-left text-sm transition-colors cursor-pointer text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                      @click="toggleList(option.id); onRuleChange()"
+                      type="button">
+                <span class="block min-w-0 truncate max-w-[11rem]" x-text="option.label"></span>
+                <span class="ml-auto" x-show="isListSelected(option.id)">
                   {% include "app/icons/checkmark.svg" with classes="w-4 h-4 text-green-400" %}
                 </span>
               </button>

--- a/src/templates/lists/smart_list_detail.html
+++ b/src/templates/lists/smart_list_detail.html
@@ -60,6 +60,11 @@
       {% endfor %}
     ],
     tagMode: '{{ active_smart_rules.tag_mode|default:'or'|escapejs }}',
+    selectedLists: [
+      {% for id in active_smart_rules.list %}
+        {{ id }}{% if not forloop.last %},{% endif %}
+      {% endfor %}
+    ],
     showLanguages: {{ smart_filter_data.show_languages|yesno:'true,false' }},
     showCountries: {{ smart_filter_data.show_countries|yesno:'true,false' }},
     showPlatforms: {{ smart_filter_data.show_platforms|yesno:'true,false' }},
@@ -208,6 +213,20 @@
     cycleTagMode() {
       this.tagMode = this.tagMode === 'and' ? 'or' : (this.tagMode === 'or' ? 'not' : 'and');
     },
+    isListSelected(id) { return this.selectedLists.includes(id); },
+    toggleList(id) {
+      if (this.selectedLists.includes(id)) {
+        this.selectedLists = this.selectedLists.filter((l) => l !== id);
+      } else {
+        this.selectedLists = [...this.selectedLists, id];
+      }
+    },
+    listLabelFor(id) {
+      const dataEl = document.getElementById('smart-filter-data');
+      const data = dataEl ? JSON.parse(dataEl.textContent) : {};
+      const match = (data.lists || []).find((option) => option.id === id);
+      return match ? match.label : `List ${id}`;
+    },
     filterLabel() {
       const labels = [];
       if (!this.allTypesSelected()) {
@@ -268,6 +287,9 @@
         const prefix = this.tagMode === 'not' ? '-' : '+';
         labels.push(prefix + this.selectedTags.join(this.tagMode === 'and' ? ' & ' : ', '));
       }
+      if (this.selectedLists.length) {
+        labels.push(this.selectedLists.map((id) => this.listLabelFor(id)).join(', '));
+      }
       if (labels.length === 0) {
         return 'All';
       }
@@ -298,6 +320,7 @@
       this.provider = '';
       this.selectedTags = [];
       this.tagMode = 'or';
+      this.selectedLists = [];
     },
     itemsCountLabel() {
       return `${this.itemsCount} item${this.itemsCount === 1 ? '' : 's'}`;
@@ -336,6 +359,7 @@
         provider: this.provider,
         tag: this.selectedTags,
         tag_mode: this.tagMode,
+        list: this.selectedLists,
         search: this.query,
         sort: this.sort,
         sort_direction: this.direction,
@@ -733,6 +757,7 @@
         formatSearch: '',
         providerSearch: '',
         tagSearch: '',
+        listSearch: '',
         genres: data.genres || [],
         impliedGenres: data.implied_genres || [],
         years: data.years || [],
@@ -744,6 +769,7 @@
         formats: data.formats || [],
         providers: data.providers || [],
         tags: data.tags || [],
+        lists: data.lists || [],
         resetSearch() {
           this.genreSearch = '';
           this.impliedGenreSearch = '';
@@ -756,6 +782,7 @@
           this.formatSearch = '';
           this.providerSearch = '';
           this.tagSearch = '';
+          this.listSearch = '';
         },
         filteredGenres() {
           const term = this.genreSearch.toLowerCase();
@@ -833,6 +860,13 @@
             return this.tags;
           }
           return this.tags.filter((t) => t.toLowerCase().includes(term));
+        },
+        filteredLists() {
+          const term = this.listSearch.toLowerCase();
+          if (!term) {
+            return this.lists;
+          }
+          return this.lists.filter((option) => option.label.toLowerCase().includes(term));
         },
       };
     }


### PR DESCRIPTION
## Summary

This change adds support for filtering smart lists by manual list membership. Users can now create smart lists that include all items from one or more linked manual lists, with the filter respecting access control (only accessible non-smart lists are available).

**Key features:**
- New "List" filter in the smart rules builder UI that allows selecting manual lists
- Smart lists automatically include all items from linked lists, even if other filters would exclude them
- List membership changes on manual lists automatically resync referencing smart lists
- Access control: only non-smart lists the user owns or collaborates on are available as filter options
- Comprehensive test coverage for validation, filtering, and sync behavior

## Changes

### Backend (`src/lists/smart_rules.py`)
- Added `"list"` to `ALLOWED_RULE_KEYS` and default rules
- New `_valid_linked_list_ids()` function validates and filters list IDs by ownership/collaboration and excludes smart lists
- New `_resolve_list_membership_item_ids()` function resolves items belonging to linked lists
- Updated `normalize_rule_payload()` to validate and include list filter
- Updated `collect_matching_item_ids()` to union items from linked lists
- Updated `item_matches_rules()` to short-circuit matching for items in linked lists (items in a linked list match regardless of other filters)
- Updated `build_rule_filter_data()` to include available manual lists

### Frontend (`src/templates/lists/smart_rules_builder.html` & `src/templates/lists/smart_list_detail.html`)
- Added list filter UI section with search/filter capability
- Added hidden form inputs for list selection
- Added Alpine.js methods: `isListSelected()`, `toggleList()`, `listLabelFor()`, `filteredLists()`
- Updated filter label display to show selected lists
- Updated reset functionality to clear list selections

### Signals (`src/app/signals.py`)
- New signal handler `sync_smart_lists_on_list_membership_change()` that re-evaluates smart lists when items are added/removed from manual lists
- Handles both the list owner and collaborators

### Views (`src/lists/views_smart_list.py`)
- Updated `_smart_list_detail_response()` to handle list filter in query parameters and saved rules

## How It Was Tested

Added comprehensive test coverage:
- `test_normalize_rule_payload_restricts_list_filter_to_accessible_manual_lists`: Validates that only accessible non-smart lists are included
- `test_collect_matching_item_ids_unions_linked_list_contents`: Verifies items from linked lists are included in results
- `test_item_matches_rules_short_circuits_for_linked_list_membership`: Confirms items in linked lists match even when other filters fail
- `test_manual_list_membership_change_syncs_referencing_smart_lists`: Ensures smart lists update when manual list membership changes

All existing tests continue to pass.

## Database & Migration Safety

- Not applicable (no database model changes)

## Related Issues

- Implements list filtering capability for smart lists as part of smart rules enhancement

https://claude.ai/code/session_01F7AjQboiiRtbWi9bdJZQCa