### PR TITLE
Cache compact media list order to fix page-2+ scroll perf

### DIFF
--- a/src/app/cache_utils.py
+++ b/src/app/cache_utils.py
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 TIME_LEFT_CACHE_PREFIX = "time_left_sorted_v19"
 _REGISTRY_TEMPLATE = f"{TIME_LEFT_CACHE_PREFIX}_registry_{{user_id}}"
 
-MEDIA_LIST_CACHE_PREFIX = "media_list_v1"
+# v2: payload changed from a pickled full MediaListEntry list to a compact
+# {media_pk, model, item_pk} order hydrated per page (issue #865). Bumped so a
+# rolling deploy can't hand the new code an old pickled entry (or vice versa).
+MEDIA_LIST_CACHE_PREFIX = "media_list_v2"
 MEDIA_LIST_CACHE_TTL = 60  # seconds — enough for "navigate away and back" use case
 # v2: filter payloads include per-tag media-list usage counts.
 MEDIA_LIST_FILTER_CACHE_PREFIX = "media_list_filters_v2"

--- a/src/app/management/commands/benchmark_perf.py
+++ b/src/app/management/commands/benchmark_perf.py
@@ -21,6 +21,12 @@ ENDPOINTS = [
     ("GET", "/medialist/tv"),
     ("GET", "/medialist/season"),
     ("GET", "/medialist/anime"),
+    ("GET", "/medialist/movie"),
+    ("GET", "/medialist/game"),
+    ("GET", "/medialist/book"),
+    ("GET", "/medialist/manga"),
+    ("GET", "/medialist/music"),
+    ("GET", "/medialist/podcast"),
     ("GET", "/statistics"),
     ("GET", "/history"),
     ("GET", "/discover"),
@@ -28,6 +34,16 @@ ENDPOINTS = [
     ("GET", "/lists"),
     ("GET", "/health/"),
 ]
+
+# medialist paths whose "scroll" (pagination) requests we also benchmark
+# separately from first-load, matching how issue #865 was reported: a slow
+# first render followed by additional slow requests while scrolling further
+# pages of the same list.
+MEDIALIST_SCROLL_PATHS = [
+    "/medialist/tv",
+    "/medialist/movie",
+]
+SCROLL_PAGES = 3
 
 RUNS = 3
 
@@ -135,6 +151,29 @@ class Command(BaseCommand):
             f"(median of {runs} runs per endpoint; first run warms Django caches)"
         )
         self.stdout.write("")
+
+        # Reproduce the issue #865 report: a cold first load followed by
+        # scrolling through several more pages of the same list. Each row
+        # here is ONE request (not a median), in request order, so a
+        # regression that only shows up after the cache warms (or only on
+        # page >= 2) is visible instead of averaged away.
+        if MEDIALIST_SCROLL_PATHS:
+            self.stdout.write("Scroll reproduction (issue #865): cold load + N page requests")
+            self.stdout.write(divider)
+            for path in MEDIALIST_SCROLL_PATHS:
+                for page in range(1, SCROLL_PAGES + 2):
+                    reset_queries()
+                    t0 = time.perf_counter()
+                    client.get(path, {"page": page} if page > 1 else {})
+                    wall_ms = (time.perf_counter() - t0) * 1000
+                    n_queries = len(connection.queries)
+                    label = f"{path} page={page}" + (" (first load)" if page == 1 else "")
+                    self.stdout.write(
+                        f"{label:<{col_w[0]}} | {n_queries:>{col_w[1]}} | "
+                        f"{'':>{col_w[2]}} | {wall_ms:>{col_w[3]}.1f}"
+                    )
+            self.stdout.write(divider)
+            self.stdout.write("")
 
         conf.settings.DEBUG = original_debug
         conf.settings.ALLOWED_HOSTS = original_allowed_hosts

--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -192,34 +192,58 @@ def _hydrate_time_left_page(user, order_slice):
 def _serialize_media_list_order(entries):
     """Compact, cache-friendly representation of a fully filtered/sorted list.
 
-    Stores only primary keys; a cache hit hydrates one page from the DB
-    instead of unpickling the whole per-user library on every request (see
-    issue #865 — this was the dominant cost even when few SQL queries ran).
+    Stores only primary keys (plus the concrete model backing each row, since
+    a grouped-anime list mixes Anime and TV rows under one route media_type);
+    a cache hit hydrates one page from the DB instead of unpickling the whole
+    per-user library on every request (see issue #865 — this was the
+    dominant cost even when few SQL queries ran).
     """
-    return [
-        {"media_pk": getattr(getattr(entry, "media", None), "pk", None), "item_pk": entry.item_id}
-        for entry in entries
-    ]
+    result = []
+    for entry in entries:
+        media = getattr(entry, "media", None)
+        result.append(
+            {
+                "media_pk": getattr(media, "pk", None),
+                "model": type(media).__name__.lower() if media is not None else None,
+                "item_pk": entry.item_id,
+            }
+        )
+    return result
 
 
 def _hydrate_media_list_page(user, media_type, order_slice):
     """Rebuild MediaListEntry objects for a slice of a cached compact order."""
-    model = django_apps.get_model(app_label="app", model_name=media_type)
-    media_pks = [o["media_pk"] for o in order_slice if o.get("media_pk")]
-    item_pks = [
-        o["item_pk"] for o in order_slice if not o.get("media_pk") and o.get("item_pk")
-    ]
-    media_queryset = model.objects.filter(user=user, pk__in=media_pks).select_related(
-        "item",
-    )
-    # Same prefetch profile as get_media_list, so per-page progress/runtime
-    # annotation doesn't devolve into per-item queries.
-    media_queryset = BasicMedia.objects._apply_prefetch_related(
-        media_queryset,
-        media_type,
-        list_mode=True,
-    )
-    media_by_pk = {media.pk: media for media in media_queryset}
+    pks_by_model: dict[str, list] = {}
+    item_pks = []
+    for order_entry in order_slice:
+        media_pk = order_entry.get("media_pk")
+        if media_pk:
+            model_name = order_entry.get("model") or media_type
+            pks_by_model.setdefault(model_name, []).append(media_pk)
+        elif order_entry.get("item_pk"):
+            item_pks.append(order_entry["item_pk"])
+
+    media_by_key = {}
+    for model_name, media_pks in pks_by_model.items():
+        model = django_apps.get_model(app_label="app", model_name=model_name)
+        media_queryset = model.objects.filter(
+            user=user, pk__in=media_pks
+        ).select_related("item")
+        # Same prefetch profile as get_media_list, so per-page progress/runtime
+        # annotation doesn't devolve into per-item queries.
+        media_queryset = BasicMedia.objects._apply_prefetch_related(
+            media_queryset,
+            model_name,
+            list_mode=True,
+        )
+        media_list = list(media_queryset)
+        # Restore duplicate-tracking aggregates (aggregated_progress/status/
+        # score, dates, repeats) that get_media_list() would have attached —
+        # a raw pk lookup bypasses that window/aggregation pass entirely.
+        BasicMedia.objects._aggregate_duplicate_data(media_list, user, model_name)
+        for media in media_list:
+            media_by_key[(model_name, media.pk)] = media
+
     items_by_pk = (
         {item.pk: item for item in Item.objects.filter(pk__in=item_pks)}
         if item_pks
@@ -228,14 +252,17 @@ def _hydrate_media_list_page(user, media_type, order_slice):
 
     entries = []
     for order_entry in order_slice:
-        media = media_by_pk.get(order_entry.get("media_pk"))
-        if media is not None:
-            entries.append(MediaListEntry.from_media(media))
+        media_pk = order_entry.get("media_pk")
+        if media_pk:
+            model_name = order_entry.get("model") or media_type
+            media = media_by_key.get((model_name, media_pk))
+            if media is not None:
+                entries.append(MediaListEntry.from_media(media))
+            # Row deleted since the order was cached; skip until the
+            # invalidation signal refreshes the cache.
             continue
         item = items_by_pk.get(order_entry.get("item_pk"))
         if item is None:
-            # Row deleted since the order was cached; skip until the
-            # invalidation signal refreshes the cache.
             continue
         entries.append(MediaListEntry(item=item, media=None))
     return entries

--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -189,6 +189,58 @@ def _hydrate_time_left_page(user, order_slice):
     return entries
 
 
+def _serialize_media_list_order(entries):
+    """Compact, cache-friendly representation of a fully filtered/sorted list.
+
+    Stores only primary keys; a cache hit hydrates one page from the DB
+    instead of unpickling the whole per-user library on every request (see
+    issue #865 — this was the dominant cost even when few SQL queries ran).
+    """
+    return [
+        {"media_pk": getattr(getattr(entry, "media", None), "pk", None), "item_pk": entry.item_id}
+        for entry in entries
+    ]
+
+
+def _hydrate_media_list_page(user, media_type, order_slice):
+    """Rebuild MediaListEntry objects for a slice of a cached compact order."""
+    model = django_apps.get_model(app_label="app", model_name=media_type)
+    media_pks = [o["media_pk"] for o in order_slice if o.get("media_pk")]
+    item_pks = [
+        o["item_pk"] for o in order_slice if not o.get("media_pk") and o.get("item_pk")
+    ]
+    media_queryset = model.objects.filter(user=user, pk__in=media_pks).select_related(
+        "item",
+    )
+    # Same prefetch profile as get_media_list, so per-page progress/runtime
+    # annotation doesn't devolve into per-item queries.
+    media_queryset = BasicMedia.objects._apply_prefetch_related(
+        media_queryset,
+        media_type,
+        list_mode=True,
+    )
+    media_by_pk = {media.pk: media for media in media_queryset}
+    items_by_pk = (
+        {item.pk: item for item in Item.objects.filter(pk__in=item_pks)}
+        if item_pks
+        else {}
+    )
+
+    entries = []
+    for order_entry in order_slice:
+        media = media_by_pk.get(order_entry.get("media_pk"))
+        if media is not None:
+            entries.append(MediaListEntry.from_media(media))
+            continue
+        item = items_by_pk.get(order_entry.get("item_pk"))
+        if item is None:
+            # Row deleted since the order was cached; skip until the
+            # invalidation signal refreshes the cache.
+            continue
+        entries.append(MediaListEntry(item=item, media=None))
+    return entries
+
+
 def _collect_reading_activity_day_keys(entries):
     """Return history/statistics day keys touched by reading entries."""
     day_keys = set()
@@ -1514,6 +1566,16 @@ def media_list(request, media_type):
             # from _time_left_cached_order in the time_left branch.
             _media_list_cached = []
 
+    # `_media_list_cached`, when present, holds a compact ordered list of
+    # {media_pk, item_pk} rows (see `_serialize_media_list_order`), not full
+    # objects — unpickling thousands of hydrated model instances per request
+    # was the dominant cost behind issue #865, even on a cache hit. Only take
+    # the fast (page-only-hydrate) path when filter_data is ALSO cached: the
+    # two caches are written together on every rebuild, so a filter_data miss
+    # here means the order cache is stale relative to it and both should be
+    # rebuilt together rather than drifting apart.
+    _media_list_full = None
+    _cached_media_list_order = None
     if _media_list_cached is None:
         media_queryset = BasicMedia.objects.get_media_list(
             user=request.user,
@@ -1835,17 +1897,28 @@ def media_list(request, media_type):
             _sort_reverse = direction == "desc"
             media_list = sorted(media_list, key=_mixed_sort_key, reverse=_sort_reverse)
 
+        _media_list_full = media_list
         if _media_list_cache_key:
             cache.set(
                 _media_list_cache_key,
-                media_list,
+                _serialize_media_list_order(media_list),
                 cache_utils.MEDIA_LIST_CACHE_TTL,
             )
             cache_utils.register_media_list_cache_key(
                 request.user.id, _media_list_cache_key
             )
+    elif filter_data is None:
+        # Order cache hit but filter_data cache missed: hydrate every cached
+        # row (one bulk query) instead of the full filter/sort pipeline, then
+        # fall through to the normal filter_data build below.
+        media_list = _hydrate_media_list_page(
+            request.user, media_type, _media_list_cached
+        )
+        _media_list_full = media_list
     else:
-        media_list = _media_list_cached
+        # Fast path: both caches are warm. Defer hydration to just the
+        # current page instead of rebuilding or unpickling the full library.
+        _cached_media_list_order = _media_list_cached
 
     if filter_data is None:
         tracked_item_ids = {
@@ -2013,8 +2086,17 @@ def media_list(request, media_type):
     else:
         # Paginate results normally
         items_per_page = 32
-        paginator = Paginator(media_list, items_per_page)
-        media_page = paginator.get_page(page)
+        if _cached_media_list_order is not None:
+            # Fast path: paginate the compact cached order and hydrate only
+            # this page's rows from the DB — no library-wide materialization.
+            paginator = Paginator(_cached_media_list_order, items_per_page)
+            media_page = paginator.get_page(page)
+            media_page.object_list = _hydrate_media_list_page(
+                request.user, media_type, media_page.object_list
+            )
+        else:
+            paginator = Paginator(_media_list_full, items_per_page)
+            media_page = paginator.get_page(page)
 
         BasicMedia.objects.annotate_max_progress(
             _tracked_media_entries(media_page.object_list),

--- a/src/app/tests/test_media_list_performance.py
+++ b/src/app/tests/test_media_list_performance.py
@@ -416,3 +416,73 @@ class MaterializationWasteTests(TestCase):
         print("  All 1000 items go through: build_filter_data_from_items,")
         print("  apply_latest_status_filter, and all Python filter functions")
         print("  before pagination reduces to 32.")
+
+
+@tag("slow", "benchmark")
+class CachedPageScalingTests(TestCase):
+    """Issue #865: a warm-cache page-2+ request must not scale with library size.
+
+    Production logs showed /medialist/movie scroll requests taking 2.6-3.4s
+    on only 4 SQL queries — the cost was unpickling the ENTIRE cached library
+    just to slice out one page. The fix caches a compact {media_pk, item_pk}
+    order instead of full objects and hydrates only the requested page.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = get_user_model().objects.create_user(
+            username="scalepage", password="12345"
+        )
+        cls.user.movie_enabled = True
+        cls.user.save()
+        cls.factory = RequestFactory()
+
+    def _second_page_ms(self, count):
+        cache.clear()
+        Movie.objects.filter(user=self.user).delete()
+        Item.objects.filter(
+            media_id__startswith="perf_",
+            media_type=MediaTypes.MOVIE.value,
+        ).delete()
+        _bulk_create_movie_items_and_entries(self.user, count)
+
+        from app.views import media_list
+
+        # Warm both the order cache and the filter_data cache with page 1.
+        first_request = self.factory.get("/medialist/movie")
+        first_request.user = self.user
+        media_list(first_request, MediaTypes.MOVIE.value)
+
+        second_request = self.factory.get("/medialist/movie", {"page": 2})
+        second_request.user = self.user
+        with override_settings(DEBUG=True):
+            reset_queries()
+            start = time.perf_counter()
+            response = media_list(second_request, MediaTypes.MOVIE.value)
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            n_queries = len(connection.queries)
+        self.assertEqual(response.status_code, 200)
+        return elapsed_ms, n_queries
+
+    def test_cached_second_page_does_not_scale_with_library_size(self):
+        """A warm-cache page-2 request should cost roughly the same at 100 vs 2000 items."""
+        print()
+        small_ms, small_queries = self._second_page_ms(100)
+        large_ms, large_queries = self._second_page_ms(2000)
+
+        print("[PERF] Cached page-2 request:")
+        print(f"  100 items:  {small_ms:.0f}ms, {small_queries} queries")
+        print(f"  2000 items: {large_ms:.0f}ms, {large_queries} queries")
+
+        # A generous bound: even accounting for noise, a page-2 request that
+        # only ever touches ~32 rows should not take meaningfully longer as
+        # the underlying library grows 20x. Before the fix this scaled
+        # roughly linearly with library size because the whole cached
+        # library was unpickled every request.
+        self.assertLess(
+            large_ms,
+            small_ms * 5 + 200,
+            "page-2 request time scaled with library size; the media_list "
+            "cache is likely storing/hydrating full objects instead of a "
+            "compact per-page order",
+        )

--- a/src/app/tests/test_query_counts.py
+++ b/src/app/tests/test_query_counts.py
@@ -358,6 +358,34 @@ class QueryCountTests(TestCase):
         self.client.get("/medialist/tv")  # warm the cache
         self._assert_query_budget("/medialist/tv", 20, "TV list cache hit")
 
+    def test_tv_list_cache_hit_page_two_query_budget(self):
+        """A cache-hit page-2 request stays within budget (issue #865).
+
+        Before the fix, a cache hit still unpickled the ENTIRE per-user
+        library just to slice out page 2 — invisible to a query-count pin
+        but very visible in wall time. The fix hydrates only the 32 rows on
+        the requested page, so this budget should track the plain cache-hit
+        budget above, not the library size.
+        """
+        self.client.get("/medialist/tv")  # warm the order + filter_data caches
+        self._assert_query_budget(
+            "/medialist/tv?page=2", 20, "TV list cache hit page 2"
+        )
+
+    def test_movie_list_cache_hit_query_budget(self):
+        """Second movie list request hits the media-list cache (issue #865)."""
+        self.client.get("/medialist/movie")  # warm the cache
+        self._assert_query_budget(
+            "/medialist/movie", 12, "movie list cache hit"
+        )
+
+    def test_movie_list_cache_hit_page_two_query_budget(self):
+        """A cache-hit page-2 movie request hydrates only its own page."""
+        self.client.get("/medialist/movie")  # warm the order + filter_data caches
+        self._assert_query_budget(
+            "/medialist/movie?page=2", 12, "movie list cache hit page 2"
+        )
+
     def test_movie_list_default_sort_query_budget(self):
         self._assert_query_budget(
             "/medialist/movie",


### PR DESCRIPTION
## Summary

Fixes issue #865: warm-cache requests for media list page 2+ were taking 2.6-3.4s despite only 4 SQL queries. The root cause was unpickling the entire cached per-user library (thousands of hydrated model instances) just to slice out one page.

**The fix:** Instead of caching full `MediaListEntry` objects, cache a compact `{media_pk, item_pk}` order. On a cache hit, hydrate only the 32 rows needed for the requested page via a single bulk query, rather than materializing the entire library.

### Changes

1. **New serialization functions** (`_serialize_media_list_order`, `_hydrate_media_list_page`):
   - `_serialize_media_list_order`: Converts a filtered/sorted list to compact `{media_pk, item_pk}` dicts for caching
   - `_hydrate_media_list_page`: Rebuilds `MediaListEntry` objects for a slice of the cached compact order via bulk queries

2. **Cache strategy refinement**:
   - When both order cache and `filter_data` cache are warm, defer full library hydration until pagination
   - Paginate the compact order first, then hydrate only the current page's rows
   - If order cache hits but `filter_data` misses, hydrate the full order (one bulk query) to rebuild filters

3. **Pagination optimization**:
   - Fast path: paginate compact cached order, hydrate only the page slice
   - Fallback: paginate full hydrated list (when cache is cold or partially warm)

4. **Test coverage**:
   - Added `CachedPageScalingTests` to verify page-2+ requests don't scale with library size
   - Added query budget tests for movie list and TV list page-2 requests
   - Extended benchmark script to measure scroll scenarios (cold load + multiple page requests)

## How It Was Tested

- `test_media_list_performance.py::CachedPageScalingTests::test_cached_second_page_does_not_scale_with_library_size` — Verifies a warm-cache page-2 request costs ~the same at 100 vs 2000 items (generous 5x bound + 200ms)
- `test_query_counts.py::test_tv_list_cache_hit_page_two_query_budget` — Ensures page-2 TV list stays within 20-query budget
- `test_query_counts.py::test_movie_list_cache_hit_page_two_query_budget` — Ensures page-2 movie list stays within 12-query budget
- `benchmark_perf.py` extended with scroll reproduction scenario (cold load + pages 2–4) to catch regressions in pagination performance

## Database & Migration Safety

- Not applicable (no database changes)

## Related Issues

- Fixes #865

https://claude.ai/code/session_01QQwYFGW8fKGQUpFQYff4PN