### PR TITLE
Guard against a duplicate rewatch start resetting an open pass's cutoff

### DIFF
--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -169,24 +169,32 @@ class TV(Media):
 
         A season already fully covered by plays at or after `started_at`
         is skipped rather than opened and immediately closed again —
-        that's more confusing than just leaving it alone. Raises
-        RewatchAlreadyCompleteError only if every season would be skipped,
-        so the caller can tell the user nothing would happen. Returns the
-        seasons that *were* skipped (empty if none) so a caller can still
-        tell the user about a partial skip, since that succeeds silently
-        otherwise.
+        that's more confusing than just leaving it alone. A season with
+        an already-open pass is left untouched too, so a duplicate
+        submission or retry can't silently push its cutoff later and
+        strand plays logged against the original one as pre-cutoff
+        history. Raises RewatchAlreadyCompleteError only if every season
+        would be skipped, so the caller can tell the user nothing would
+        happen. Returns the seasons that *were* skipped (empty if none)
+        so a caller can still tell the user about a partial skip, since
+        that succeeds silently otherwise.
         """
         from app.models.media import BasicMedia  # avoid a module-load cycle
 
         started_at = started_at or timezone.now()
-        seasons = [
+        all_seasons = [
             season
             for season in self.seasons.filter(item__season_number__gt=0)
             if season.status != Status.DROPPED.value
         ]
-        if not seasons:
+        if not all_seasons:
             no_seasons_msg = "This show has no seasons to rewatch."
             raise RewatchAlreadyCompleteError(no_seasons_msg)
+
+        seasons = [season for season in all_seasons if season.rewatch_started_at is None]
+        if not seasons:
+            already_open_msg = "Every season is already being rewatched."
+            raise RewatchAlreadyCompleteError(already_open_msg)
         BasicMedia.objects.annotate_max_progress(seasons, MediaTypes.SEASON.value)
 
         skipped = [
@@ -1017,13 +1025,18 @@ class Season(Media):
     def start_rewatch(self, started_at=None, max_progress=None):
         """Begin a new pass, keeping every existing play as history.
 
-        Raises RewatchAlreadyCompleteError if the plays already logged at
-        or after `started_at` already cover the season — opening a pass
+        A no-op if a pass is already open, so a duplicate submission or
+        retry can't silently push the cutoff later and strand plays
+        logged against the original one as pre-cutoff history. Raises
+        RewatchAlreadyCompleteError if the plays already logged at or
+        after `started_at` already cover the season — opening a pass
         that would immediately close itself again is more confusing than
         just refusing it. Looks up its own episode count when
         `max_progress` isn't supplied — see `stop_rewatch` for why that
         can't be a shared value.
         """
+        if self.rewatch_started_at is not None:
+            return
         started_at = started_at or timezone.now()
         if max_progress is None:
             from app.models.media import BasicMedia  # avoid a module-load cycle

--- a/src/app/tests/models/test_season_rewatch.py
+++ b/src/app/tests/models/test_season_rewatch.py
@@ -131,6 +131,27 @@ class SeasonRewatch(TestCase):
         self.assertEqual(self.season.next_episode_number(), 1)
         self.assertEqual(self.season.status, Status.IN_PROGRESS.value)
 
+    def test_starting_an_already_open_rewatch_is_a_no_op(
+        self,
+        _mock_metadata,
+    ):
+        """A retried/duplicate start can't push an open pass's cutoff later.
+
+        Without this guard, a retry after the user had already replayed
+        an episode would overwrite rewatch_started_at with the later
+        timestamp, stranding that play as pre-cutoff history and forcing
+        them to replay it again.
+        """
+        original_start = datetime(2026, 8, 1, tzinfo=UTC)
+        self.season.start_rewatch(started_at=original_start)
+        self._watch(self.episode_items[0], datetime(2026, 8, 2, tzinfo=UTC))
+
+        self.season.start_rewatch(started_at=timezone.now())
+
+        self.season.refresh_from_db()
+        self.assertEqual(self.season.rewatch_started_at, original_start)
+        self.assertEqual(self.season.completed_episode_count, 1)
+
     def test_starting_a_rewatch_already_fully_replayed_is_rejected(
         self,
         _mock_metadata,
@@ -233,6 +254,52 @@ class SeasonRewatch(TestCase):
         self.assertIsNotNone(self.season.rewatch_started_at)
         self.assertEqual(self.season.status, Status.IN_PROGRESS.value)
         self.assertTrue(self.tv.is_rewatching)
+
+    def test_show_rewatch_leaves_an_already_open_season_untouched(
+        self,
+        _mock_metadata,
+    ):
+        """A retried show-level start can't push an open season's cutoff later.
+
+        Season 2 is added fresh (never watched, never rewatched) so the
+        retry still has somewhere to legitimately open a pass — proving
+        season 1 is skipped specifically because it's already mid-pass,
+        not because every season happened to be covered.
+        """
+        season_2_item = Item.objects.create(
+            media_id="123",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Show",
+            season_number=2,
+        )
+        season_2 = Season.objects.create(
+            item=season_2_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.PLANNING.value,
+        )
+
+        original_start = datetime(2026, 8, 1, tzinfo=UTC)
+        self.season.start_rewatch(started_at=original_start)
+        self._watch(self.episode_items[0], datetime(2026, 8, 2, tzinfo=UTC))
+
+        self.tv.start_rewatch(started_at=timezone.now())
+
+        self.season.refresh_from_db()
+        season_2.refresh_from_db()
+        self.assertEqual(self.season.rewatch_started_at, original_start)
+        self.assertIsNotNone(season_2.rewatch_started_at)
+
+    def test_show_rewatch_already_open_on_every_season_is_rejected(
+        self,
+        _mock_metadata,
+    ):
+        """A retry once every season is already mid-pass is refused, not silent."""
+        self.tv.start_rewatch(started_at=datetime(2026, 8, 1, tzinfo=UTC))
+
+        with self.assertRaises(RewatchAlreadyCompleteError):
+            self.tv.start_rewatch(started_at=timezone.now())
 
     def test_show_rewatch_already_fully_replayed_is_rejected(
         self,


### PR DESCRIPTION
## Summary

A follow-up to #923 / #925: a retried or double-submitted "Rewatch" request can silently reset an already-open rewatch pass's start date, stranding plays the user already logged against the original cutoff as pre-cutoff history.

#925 added an explicit rewatch pass (`rewatch_started_at`) so reopening a season no longer falsely re-completes it — fixing #923. But `Season.start_rewatch` and `TV.start_rewatch` had no guard against being called while a pass was already open. Concretely:

1. User starts a rewatch (`rewatch_started_at = T0`).
2. User logs a play for episode 1 — it counts towards the pass.
3. The "Start rewatch" request gets resubmitted — a double-click, a slow-network retry, or a second tab still showing the "Rewatch" action before the first request's response landed.
4. `start_rewatch` runs again, unconditionally overwriting `rewatch_started_at` with the new, later timestamp `T1`.
5. Episode 1's play, logged before `T1`, is now *before* the cutoff — it silently drops out of the pass. The user has to replay it again with no error or explanation.

This is exactly the kind of silent, hard-to-diagnose state issue #923 was about — the whole point of the rewatch pass is that its cutoff is a hard boundary users are meant to trust; letting a retry move it out from under them undermines that.

## Fix

Both `Season.start_rewatch` and `TV.start_rewatch` now leave an already-open pass alone instead of overwriting it:

- `Season.start_rewatch` is a no-op when `rewatch_started_at` is already set.
- `TV.start_rewatch` excludes seasons that are already mid-pass from the ones it (re)opens, and only raises `RewatchAlreadyCompleteError` if *every* season is already mid-pass (so the caller still gets a clear "nothing to do" signal instead of silent success).

Found via an adversarial Codex review of #925 after it merged.

## AI Assistance
Generated with Claude (Sonnet 5, `claude-sonnet-5`).

## How It Was Tested
- `uv run python manage.py test app.tests.models.test_season_rewatch` → Passed (23 tests, including 3 new regression tests for this fix)
- `uv run python manage.py test` (full suite) → Passed
- `uv run --no-sync python manage.py check_migration_hygiene --strict --base-ref upstream/latest` → Passed (no migration changes in this PR)
- Confirmed RED against the pre-fix code (reverted the guard locally, all 3 new tests failed reproducing the exact bug), then GREEN with the fix restored.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety
- [x] Not applicable (no database changes)

## Related Issues
Refs dannyvfilms/Floppy#923 (closed by #925). Follow-up to #925.
