### PR TITLE
fix IGDB game backdrop to use artwork_type=2 for Key Art

### DIFF
--- a/src/lists/models.py
+++ b/src/lists/models.py
@@ -12,8 +12,13 @@ from app.providers import services
 from lists import smart_rules
 
 # IGDB artwork_type values used to classify fetched artwork images.
-IGDB_ARTWORK_TYPE_HERO = 7
-IGDB_ARTWORK_TYPE_TOP_BANNER = 4
+# Verified by sampling artwork_type + image dimensions across titles already
+# tracked on this instance (Hades, Big Walk, 007 First Light, and others):
+# type=2 is the one that is consistently a clean widescreen promotional image.
+# type=7 was tried previously on a guess, but its shape is inconsistent across
+# titles (a wide banner for some, a square for others), so it does not hold up
+# as Key Art.
+IGDB_ARTWORK_TYPE_KEY_ART = 2
 
 # Acceptable image aspect ratio range for list artwork: from 3:2 (1.5) up to
 # 16:9 (1.777..., allowing a small rounding margin up to 1.778).
@@ -476,7 +481,7 @@ class CustomList(models.Model):
             # We request both artworks.image_id (to get image_ids) and artworks (to get artwork IDs for fetching image_type)
             # Note: IGDB API doesn't support artworks.image_type as nested field,
             # so we'll fetch artworks separately to get image_type
-            # Key Art is identified by image_type=4 in the artworks endpoint, not a separate field
+            # Key Art is identified by artwork_type=2 in the artworks endpoint, not a separate field
             access_token = igdb.get_access_token()
             url = "https://api.igdb.com/v4/games"
             data = (
@@ -592,7 +597,7 @@ class CustomList(models.Model):
                 )
 
                 # Fetch artwork details to get image_type (to identify Key Art)
-                # Key Art is identified by image_type=4 in the artworks endpoint
+                # Key Art is identified by artwork_type=2 in the artworks endpoint
                 key_arts = []
                 other_artworks = []
 
@@ -617,8 +622,7 @@ class CustomList(models.Model):
                         for i in range(0, len(artwork_ids), batch_size):
                             batch_ids = artwork_ids[i : i + batch_size]
                             artwork_id_list = ",".join(str(aid) for aid in batch_ids)
-                            # IGDB artwork types: 0=Other, 1=Box Art, 2=Screenshot, 3=Clear Logo, 4=Top Banner, 5=Marquee, 6=Steam Grid, 7=Hero, 8=Logo, 9=Icon
-                            # Key Art is typically artwork_type=4 (Top Banner) or artwork_type=7 (Hero)
+                            # Key Art is artwork_type=2, verified against sampled images
                             artworks_data = (
                                 f"fields image_id,artwork_type;"
                                 f"where id = ({artwork_id_list});"
@@ -678,27 +682,10 @@ class CustomList(models.Model):
                                 image_id = artwork.get("image_id")
                                 artwork_type = artwork.get("artwork_type")
                                 if image_id:
-                                    # IGDB artwork types: 0=Other, 1=Box Art, 2=Screenshot, 3=Clear Logo, 4=Top Banner, 5=Marquee, 6=Steam Grid, 7=Hero, 8=Logo, 9=Icon
-                                    # Based on user feedback, artwork_type=4 might be Concept Art, not Key Art
-                                    # Need to identify the correct type for Key Art - possibly type 7 (Hero) or a different value
-                                    # For now, let's try type 7 (Hero) as Key Art, and if that doesn't work, we'll need to check the actual values
-                                    if (
-                                        artwork_type == IGDB_ARTWORK_TYPE_HERO
-                                    ):  # Hero - trying this as Key Art
+                                    if artwork_type == IGDB_ARTWORK_TYPE_KEY_ART:
                                         key_arts.append(image_id)
                                         logger.debug(
-                                            "Identified Key Art (Hero) for game %s: image_id=%s, artwork_type=%s",
-                                            media_id,
-                                            image_id,
-                                            artwork_type,
-                                        )
-                                    elif (
-                                        artwork_type == IGDB_ARTWORK_TYPE_TOP_BANNER
-                                    ):  # Top Banner - might be Concept Art based on user feedback
-                                        # Skip type 4 for now since user says it's showing Concept Art
-                                        other_artworks.append(image_id)
-                                        logger.debug(
-                                            "Skipping Top Banner (might be Concept Art) for game %s: image_id=%s, artwork_type=%s",
+                                            "Identified Key Art for game %s: image_id=%s, artwork_type=%s",
                                             media_id,
                                             image_id,
                                             artwork_type,


### PR DESCRIPTION
## Summary

- Game backdrops pulled from IGDB were meant to prefer Key Art, a clean widescreen promotional image, before falling back to other artwork and then screenshots. The type used to detect Key Art was artwork_type=7, a guess that was never confirmed and left in place with a comment saying so.
- I checked the IGDB images for several of my tracked games (Hades, Big Walk, 007 First Light, and others) and checked both the image dimensions and the images themselves. artwork_type=7 turned out to be inconsistent, a wide banner for some titles and a square image for others, and almost always including the video game's title. artwork_type=2 was the one that consistently produced a clean widescreen promotional image across every title checked.
- This updates _get_igdb_backdrop in src/lists/models.py to key off artwork_type=2 for Key Art, and removes the speculative type=4/type=7 branching and the unverified type-name comment table that came with it.

Closes #994

## AI Assistance

- Claude Sonnet 5 (claude-sonnet-5) helped identify the issue, sample and compare artwork across titles, and make this change.

## How It Was Tested

- SECRET=test-only python src/manage.py test lists --exclude-tag slow --exclude-tag network -> Passed (223 tests)
- Manually queried the IGDB API for artwork_type and image dimensions across the games already tracked on my instance to confirm artwork_type=2 is the consistent widescreen promotional image before making the change.

## Public API & Documentation Handoff

- [ ] Domain terminology is up to date (python -m app.domain_vocabulary --check)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance

- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. /gstack-qa or browser testing)

## Database & Migration Safety (Only if modifying models)

- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (uv run --no-sync python src/manage.py check_migration_hygiene --strict)
- [x] Not applicable (no database changes)