### PR TITLE
fix: distinct media types for list status filter

### DIFF
--- a/src/lists/views.py
+++ b/src/lists/views.py
@@ -261,7 +261,7 @@ def list_detail(request, list_reference):
     )
 
     # Get distinct media types for filtering
-    media_types = items.values_list("media_type", flat=True).distinct()
+    media_types = items.order_by().values_list("media_type", flat=True).distinct()
     media_manager = MediaManager()
     media_by_item_id = {}
 


### PR DESCRIPTION
## Summary
- Ensured distinct media type in list query
- Originally, the `media_types` list contains the media type per item in the list
- Calling `.order_by()` clears default ordering and removes the repeated media types from the list
- No UI changes

## How It Was Tested
- `SECRET=test-only test.sh lists.tests.test_views` -> Passed
- Debug panel in UI, for list with >400 items, shows reduction in SQL queries from >1400 to <40
- Reviewing underlying SQL shows the removal of the default order by media_id

from
```
SELECT
    DISTINCT "app_item"."media_type" AS "media_type",
    "app_item"."media_id"
FROM "app_item" INNER JOIN "lists_customlistitem"
    ON ("app_item"."id" = "lists_customlistitem"."item_id")
WHERE "lists_customlistitem"."custom_list_id" = 1
ORDER BY "app_item"."media_id" ASC;
```
to
```
SELECT
    DISTINCT "app_item"."media_type" AS "media_type"
FROM "app_item"
INNER JOIN "lists_customlistitem"
    ON ("app_item"."id" = "lists_customlistitem"."item_id")
WHERE "lists_customlistitem"."custom_list_id" = 1;
```

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [X] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [X] Not applicable (no database changes)

## Related Issues
- None

