### PR TITLE
test: fix CI App Test (3.12) stale provider mocks

### DIFF
--- a/src/api/tests/test_calendar.py
+++ b/src/api/tests/test_calendar.py
@@ -104,9 +104,7 @@ class CalendarTests(FloppyApiTestCase):
             "api_calendar",
             headers=self.auth_headers,
             params={
-                "start_date": (
-                    future_event_date - timezone.timedelta(days=5)
-                ).isoformat()
+                "start_date": future_event_date.isoformat()
             },
         )
         self.assertEqual(response.status_code, 200)

--- a/src/app/tests/providers/test_search.py
+++ b/src/app/tests/providers/test_search.py
@@ -379,7 +379,7 @@ class SearchById(TestCase):
         )
         self.assertIsNotNone(result)
         self.assertEqual(result["results"][0]["title"], "Dune")
-        mock_book.assert_called_once_with(42)
+        mock_book.assert_called_once_with(42, user=None)
 
     def test_non_id_title_query_returns_none(self):
         """search_by_id returns None for a plain-text (non-ID) query."""

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -2170,6 +2170,7 @@ class MediaDetailsViewTests(TestCase):
             "377938",
             Sources.HARDCOVER.value,
             language="en",
+            user=self.user,
         )
 
     @patch("app.providers.services.get_media_metadata")
@@ -2238,6 +2239,7 @@ class MediaDetailsViewTests(TestCase):
             "10193",
             Sources.TMDB.value,
             language="en",
+            user=self.user,
         )
         self.assertContains(response, "media-grid-row-detail-cast", html=False)
         self.assertContains(response, "Tom Hanks")
@@ -2499,6 +2501,8 @@ class MediaDetailsViewTests(TestCase):
             season_numbers=None,
             episode_number=None,
             language=None,
+            edition_id=None,
+            user=None,
         ):
             del media_type, media_id, season_numbers, episode_number, language
             if source == Sources.TMDB.value:
@@ -4103,6 +4107,8 @@ class MediaDetailsViewTests(TestCase):
             season_numbers=None,
             episode_number=None,
             language=None,
+            edition_id=None,
+            user=None,
         ):
             del media_id, episode_number, language
             if media_type == MediaTypes.ANIME.value and source == Sources.TVDB.value:
@@ -4381,6 +4387,8 @@ class MediaDetailsViewTests(TestCase):
             season_numbers=None,
             episode_number=None,
             language=None,
+            edition_id=None,
+            user=None,
         ):
             del media_id, episode_number, language
             if media_type == MediaTypes.ANIME.value and source == Sources.TVDB.value:
@@ -7833,6 +7841,8 @@ class MediaDetailsViewTests(TestCase):
             season_numbers=None,
             episode_number=None,
             language=None,
+            edition_id=None,
+            user=None,
         ):
             del episode_number, language
             self.assertEqual(media_id, "114410")
@@ -8117,6 +8127,8 @@ class MediaDetailsViewTests(TestCase):
             season_numbers=None,
             episode_number=None,
             language=None,
+            edition_id=None,
+            user=None,
         ):
             del episode_number, language
             self.assertEqual(media_id, "76703")
@@ -8509,7 +8521,7 @@ class MediaDetailsViewTests(TestCase):
                 (MediaTypes.TV.value, "1396", Sources.TMDB.value),
             )
             self.assertFalse(args)
-            self.assertEqual(set(kwargs) - {"language"}, set())
+            self.assertEqual(set(kwargs), {"language", "user"})
             detail_call_count["count"] += 1
             if detail_call_count["count"] == 1:
                 return stale_metadata

--- a/src/app/tests/views/test_media_search.py
+++ b/src/app/tests/views/test_media_search.py
@@ -61,6 +61,7 @@ class MediaSearchViewTests(TestCase):
             1,
             Sources.TMDB.value,
             language="en",
+            user=self.user,
         )
 
     @patch("app.providers.services.search")
@@ -176,6 +177,7 @@ class MediaSearchViewTests(TestCase):
             1,
             Sources.MUSICBRAINZ.value,
             language="en",
+            user=self.user,
         )
 
     @patch("app.providers.services.search")
@@ -227,4 +229,5 @@ class MediaSearchViewTests(TestCase):
             1,
             Sources.TVDB.value,
             language="en",
+            user=self.user,
         )


### PR DESCRIPTION
## Summary

CI App Test (3.12) has been red since upstream #937 threaded `user=` through `services.search`, `services.get_media_metadata`, and `hardcover.book|search|editions`, with views now passing `user=request.user`. The test mocks/assertions were not updated, so every run since #937 failed identically. This PR stabilizes the suite by updating those stale expectations, fixing a calendar flake, and repairing five additional base failures that surfaced once the run could get far enough to reach them.

## Changes

### Mock expectations for per-user provider calls (#937)
- **`test_search.py`**: `hardcover.book(42)` → `hardcover.book(42, user=None)`.
- **`test_media_details.py`**: 3 `assert_called_once_with(...)` on `get_media_metadata` gained `user=self.user`; 5 `metadata_side_effect` signatures gained `edition_id=None` and `user=None` to match the real signature; tightened the kwargs guard from `set(kwargs) - {"language"} == set()` to `set(kwargs) == {"language", "user"}`.
- **`test_media_search.py`**: 3 `assert_called_once_with(...)` on `services.search` gained `user=self.user`.

### Calendar date-filtering flake
- **`test_calendar.py`**: `start_date` changed from `future_event_date - 5d` to `future_event_date` directly. `resolve_calendar_date_range` caps a start-only range at the last day of the start month; the old `-5d` could cross a month boundary and exclude the event, flaking `assertIn`.

### Base failures repaired (independent of #937)
- **`test_changes_history.py`**: `MediaEpisodeChangesHistoryView` now resolves episode coordinates via `services.get_media_metadata` (upstream #956). The shared base fixture's empty episode map made the episode route 404. Added a `setUp` overriding the metadata patch to an authoritative `{1,2,3}` episode list, mirroring `MediaEpisodeTests`. Movie and season changes-history routes never call `get_media_metadata`, so the broader patch is inert for them.
- **`schema_contract.py` / `test_api_contracts.py`**: removed the now-stale `("api.views.MediaEpisodeChangesHistoryView", "serializer-unresolved")` baseline entry. Upstream 380fbc added `responses={404: DetailErrorSerializer}` to that view's `@extend_schema`, so drf-spectacular no longer emits the finding. Reviewed-baseline count 83 → 82. The movie/season equivalents remain unresolved and stay in the baseline. The `assert_schema_findings` frozenset comparison is the real contract; the count is a tripwire against forgetting to update the baseline.
- **`test_settings.py`**: added `TVDB_API_KEY = "test_tvdb_api_key"`. `test_flat_anime_search_falls_back_to_verified_grouped_provider` asserts TVDB as the migration fallback, but TVDB is filtered out when the key is empty, so the test could never pass. Matches the STEAM/TRAKT key pattern.
- **`test_query_counts.py`**: pinned `CUSTOM_LIST_DETAIL_MAX_QUERIES` 30 → 33. Server-side external image caching (#941) added an `image_url` filter whose first call per request does a cached `ApplicationSettings` lookup (`get_or_create`). Bounded, not an N+1.

## Validation

- `test_services.py` `user=None` mock expectations already landed upstream in `f318c632`.
- Targeted run of the four affected files: **Ran 90 tests ... OK** (covers `test_changes_history`, `test_api_contracts`, `test_query_counts`, `test_library_migration`).
- TVDB blast-radius check (`test_metadata_resolution` + `test_sidebar`): **Ran 32 tests ... OK** — all TVDB-sensitive tests use `override_settings`, so the default test key is inert for them.
- Ruff clean on all changed files.
- Remaining errors on affected paths are pre-existing `network`-tagged tests excluded from the CI fast suite.
- **Known limitation**: the full fast suite was not run locally (memory/time). The `TVDB_API_KEY` test-setting change has suite-wide reach; all 13 files that reference TVDB either override it explicitly or mock the provider, and the two most TVDB-sensitive files passed, but any untested test that depends on TVDB being disabled without an explicit override would surface as a CI failure in the next run. Worst case is a still-red CI for a different reason, not production impact — the change is test-only.