### PR TITLE
fix: sort API serializer imports

### DIFF
--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.utils.timezone import now
 from rest_framework import serializers
 
-from app.backdrops import resolve_backdrop  # FORK: horizontal artwork
 from app import helpers as app_helpers
+from app.backdrops import resolve_backdrop  # FORK: horizontal artwork
 from app.helpers import build_provider_ids
 from app.models import (
     TV,


### PR DESCRIPTION
## Summary
- Restore the repository's zero-warning Ruff baseline by sorting one existing import block.
- No runtime behavior changes.

## AI Assistance
- `gpt-5` identified the failing lint gate, applied the one-line import-order fix, and reviewed the final diff.
- Workflow: test-first reproduction with Ruff 0.15.8, targeted verification, then full `src` verification.

## How It Was Tested
- `ruff check src/api/serializers.py` -> Passed.
- `ruff check src` -> Passed.

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (one import-order-only diff reviewed)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- No related issue.
