### PR TITLE
Merge seven duration formatters into one

### DIFF
--- a/src/api/fork_urls.py
+++ b/src/api/fork_urls.py
@@ -169,6 +169,11 @@ urlpatterns = [
         name="api_podcast_shows",
     ),
     re_path(
+        r"^podcasts/lookup/(?P<itunes_id>\d+)/?$",
+        fork_views_podcast.PodcastLookupView.as_view(),
+        name="api_podcast_lookup",
+    ),
+    re_path(
         r"^podcasts/shows/(?P<show_id>\d+)/?$",
         fork_views_podcast.PodcastShowDetailView.as_view(),
         name="api_podcast_show_detail",

--- a/src/api/fork_views_podcast.py
+++ b/src/api/fork_views_podcast.py
@@ -4,14 +4,18 @@ import json
 import logging
 from http import HTTPStatus as HTTP  # noqa: N814
 
+from django.core.cache import cache
 from rest_framework import views as drf_views
 from rest_framework.response import Response
 
 from app import fork_services_podcast
 from app.forms import PodcastShowTrackerForm
+from app.log_safety import safe_url
 from app.models import PodcastEpisode, PodcastShow, PodcastShowTracker, Status
 from app.podcast_views import podcast_episodes_api
+from app.providers import pocketcasts, services
 from app.services import podcast_import
+from integrations import podcast_rss
 
 from .helpers import (
     get_media_status,
@@ -145,6 +149,121 @@ class PodcastShowsView(drf_views.APIView):
         tracker.show = show
         tracker.save()
         return Response(_serialize_show(show, tracker), status=HTTP.CREATED)
+
+
+# /api/v1/podcasts/lookup/[itunes_id]/
+class PodcastLookupView(drf_views.APIView):
+    """Preview an iTunes search result before importing it.
+
+    A read-only counterpart to the itunes_id branch of PodcastShowsView.post:
+    it wraps pocketcasts.lookup_by_itunes_id (a cached iTunes API call) and,
+    when the lookup has a feed, reads the RSS feed directly — the same feed
+    `import_show_from_itunes_id` would import from — for the metadata
+    fallbacks and the episode list. Nothing here creates a PodcastShow or a
+    PodcastEpisode row; that still only happens once the caller adds it.
+    `show_id` reports the show an import would reuse, or null.
+
+    Episodes come back in the standard limit/offset envelope, because a feed
+    can run past a thousand of them.
+    """
+
+    # Both feed reads land in the request/response cycle, and this endpoint
+    # gets hit while paging through search results, so cache what the feed
+    # gave us. A preview never needs to be fresher than the import that
+    # follows it, and the iTunes half of the lookup is already cached for a
+    # week in pocketcasts.lookup_by_itunes_id.
+    _FEED_CACHE_SECONDS = 15 * 60
+
+    @staticmethod
+    def _format_duration(seconds):
+        """Format a duration in seconds as "1h 9m" or "46m".
+
+        Matches the format `podcast_views.py` sends for every already-imported
+        episode, so a preview episode's duration reads the same as a tracked
+        one's.
+        """
+        if not seconds:
+            return ""
+        hours = seconds // 3600
+        minutes = (seconds % 3600) // 60
+        return f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
+
+    def _read_feed(self, itunes_id, itunes_data, rss_feed_url):
+        """Return (metadata, episodes) for a feed, caching the pair briefly."""
+        cache_key = f"podcast_lookup_feed_{itunes_id}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        metadata = podcast_import.resolve_show_metadata(itunes_data, rss_feed_url)
+        episodes = self._feed_episodes(rss_feed_url)
+        cache.set(cache_key, (metadata, episodes), self._FEED_CACHE_SECONDS)
+        return metadata, episodes
+
+    def _feed_episodes(self, rss_feed_url):
+        """Serialize a feed's episodes; an unreadable feed previews as none."""
+        try:
+            episodes = podcast_rss.fetch_episodes_from_rss(rss_feed_url)
+        except Exception:
+            logger.warning(
+                "Failed to preview episodes from %s",
+                safe_url(rss_feed_url),
+            )
+            return []
+
+        return [
+            {
+                "title": episode.get("title", ""),
+                "published": episode.get("published"),
+                "duration": self._format_duration(episode.get("duration")),
+                "duration_seconds": episode.get("duration"),
+                "episode_number": episode.get("episode_number"),
+                "season_number": episode.get("season_number"),
+            }
+            for episode in episodes
+        ]
+
+    def get(self, request, itunes_id):
+        """Return iTunes + RSS metadata for the given collection id."""
+        limit, offset, err = parse_limit_offset(request)
+        if err:
+            return err
+
+        try:
+            itunes_data = pocketcasts.lookup_by_itunes_id(itunes_id)
+        except services.ProviderAPIError as error:
+            if error.status_code == HTTP.NOT_FOUND:
+                return Response({"detail": "Podcast not found."}, status=HTTP.NOT_FOUND)
+            return Response(
+                {
+                    "detail": HTTP.INTERNAL_SERVER_ERROR.phrase,
+                    "errors": str(error),
+                },
+                status=HTTP.INTERNAL_SERVER_ERROR,
+            )
+
+        rss_feed_url = itunes_data.get("feed_url", "")
+        metadata, episodes = itunes_data, []
+        if rss_feed_url:
+            metadata, episodes = self._read_feed(itunes_id, itunes_data, rss_feed_url)
+
+        existing_show = podcast_import.find_existing_show(itunes_id, rss_feed_url)
+
+        return Response(
+            {
+                "itunes_id": itunes_id,
+                "title": metadata.get("title", ""),
+                "author": metadata.get("author", ""),
+                "image": metadata.get("artwork_url", ""),
+                "description": metadata.get("description", ""),
+                "genres": metadata.get("genres", []),
+                "language": metadata.get("language", ""),
+                "rss_feed_url": rss_feed_url,
+                "show_id": existing_show.id if existing_show else None,
+                "episodes": paginate_data(request, episodes, limit, offset),
+            },
+            status=HTTP.OK,
+        )
 
 
 # /api/v1/podcasts/shows/[show_id]/

--- a/src/api/fork_views_podcast.py
+++ b/src/api/fork_views_podcast.py
@@ -234,11 +234,17 @@ class PodcastLookupView(drf_views.APIView):
         except services.ProviderAPIError as error:
             if error.status_code == HTTP.NOT_FOUND:
                 return Response({"detail": "Podcast not found."}, status=HTTP.NOT_FOUND)
+            # Names the provider and nothing else. str(error) is only
+            # sanitised when the provider answered: with no response at all
+            # ProviderAPIError builds "Could not reach X (<exception>)", so
+            # returning it really would put exception text in a response body,
+            # which is what CodeQL's py/stack-trace-exposure flags. The error
+            # is already logged with its status and body shape, and there is
+            # nothing here a caller can act on beyond the status code, so this
+            # follows the provider-search handler in views.py and reports the
+            # label alone.
             return Response(
-                {
-                    "detail": HTTP.INTERNAL_SERVER_ERROR.phrase,
-                    "errors": str(error),
-                },
+                {"detail": f"{error.provider_label} lookup failed."},
                 status=HTTP.INTERNAL_SERVER_ERROR,
             )
 

--- a/src/api/fork_views_podcast.py
+++ b/src/api/fork_views_podcast.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from rest_framework import views as drf_views
 from rest_framework.response import Response
 
-from app import fork_services_podcast
+from app import fork_services_podcast, helpers
 from app.forms import PodcastShowTrackerForm
 from app.log_safety import safe_url
 from app.models import PodcastEpisode, PodcastShow, PodcastShowTracker, Status
@@ -174,20 +174,6 @@ class PodcastLookupView(drf_views.APIView):
     # week in pocketcasts.lookup_by_itunes_id.
     _FEED_CACHE_SECONDS = 15 * 60
 
-    @staticmethod
-    def _format_duration(seconds):
-        """Format a duration in seconds as "1h 9m" or "46m".
-
-        Matches the format `podcast_views.py` sends for every already-imported
-        episode, so a preview episode's duration reads the same as a tracked
-        one's.
-        """
-        if not seconds:
-            return ""
-        hours = seconds // 3600
-        minutes = (seconds % 3600) // 60
-        return f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
-
     def _read_feed(self, itunes_id, itunes_data, rss_feed_url):
         """Return (metadata, episodes) for a feed, caching the pair briefly."""
         cache_key = f"podcast_lookup_feed_{itunes_id}"
@@ -215,7 +201,7 @@ class PodcastLookupView(drf_views.APIView):
             {
                 "title": episode.get("title", ""),
                 "published": episode.get("published"),
-                "duration": self._format_duration(episode.get("duration")),
+                "duration": helpers.seconds_to_hm(episode.get("duration")),
                 "duration_seconds": episode.get("duration"),
                 "episode_number": episode.get("episode_number"),
                 "season_number": episode.get("season_number"),

--- a/src/api/schema_contract.py
+++ b/src/api/schema_contract.py
@@ -410,6 +410,7 @@ EXPECTED_SCHEMA_ERRORS: frozenset[SchemaFinding] = frozenset(
         ("api.fork_views_music.MusicSongPlayView", "serializer-unresolved"),
         ("api.fork_views_music.MusicTrackScoreView", "serializer-unresolved"),
         ("api.fork_views_podcast.PodcastEpisodePlayView", "serializer-unresolved"),
+        ("api.fork_views_podcast.PodcastLookupView", "serializer-unresolved"),
         (
             "api.fork_views_podcast.PodcastMarkAllPlayedView",
             "serializer-unresolved",

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.utils.timezone import now
 from rest_framework import serializers
 
-from app.backdrops import resolve_backdrop  # FORK: horizontal artwork
 from app import helpers as app_helpers
+from app.backdrops import resolve_backdrop  # FORK: horizontal artwork
 from app.helpers import build_provider_ids
 from app.models import (
     TV,

--- a/src/api/tests/fork_endpoints.py
+++ b/src/api/tests/fork_endpoints.py
@@ -46,6 +46,7 @@ def get_fork_endpoint_cases() -> list[EndpointCase]:
             payload={"score": 8},
         ),
         EndpointCase("post", "api_music_bulk_plays", payload={}),
+        EndpointCase("get", "api_podcast_lookup", args=("1",)),
         EndpointCase("get", "api_podcast_shows"),
         EndpointCase("post", "api_podcast_shows", payload={"show_id": 1}),
         EndpointCase("get", "api_podcast_show_detail", args=(1,)),

--- a/src/api/tests/test_fork_podcast.py
+++ b/src/api/tests/test_fork_podcast.py
@@ -356,6 +356,15 @@ class PodcastLookupTests(PodcastApiTestCase):
 
         self.assertEqual(response.status_code, HTTP.INTERNAL_SERVER_ERROR)
 
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_outage_names_the_provider_and_nothing_else(self, mock_lookup):
+        """The failure body carries no exception-derived text."""
+        mock_lookup.side_effect = self._provider_error(HTTP.BAD_GATEWAY)
+
+        payload = self._lookup().json()
+
+        self.assertEqual(payload, {"detail": "Pocket Casts lookup failed."})
+
     @staticmethod
     def _provider_error(status_code):
         """Build the ProviderAPIError a failing provider call would raise."""

--- a/src/api/tests/test_fork_podcast.py
+++ b/src/api/tests/test_fork_podcast.py
@@ -1,9 +1,11 @@
 # FORK: tests for the first-class podcast API endpoints.
 import datetime
 from http import HTTPStatus as HTTP  # noqa: N814
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.messages import get_messages
+from django.core.cache import cache
 from django.urls import reverse
 
 from app import fork_services_podcast
@@ -135,6 +137,234 @@ class ShowTrackerTests(PodcastApiTestCase):
         )
         self.assertEqual(response.status_code, HTTP.BAD_REQUEST)
         mock_import.assert_not_called()
+
+
+class PodcastLookupTests(PodcastApiTestCase):
+    """Read-only iTunes preview, ahead of any import."""
+
+    ITUNES_DATA = {
+        "feed_url": "https://example.com/feed.xml",
+        "title": "Unimported Show",
+        "author": "Some Network",
+        "artwork_url": "https://example.com/art.jpg",
+        "description": "A show nobody's tracked yet.",
+        "genres": ["Comedy"],
+        "language": "en",
+    }
+
+    def setUp(self):
+        """Drop the feed cache so previews don't leak between tests."""
+        super().setUp()
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+    def _lookup(self, itunes_id="999888", **kwargs):
+        return self.call_api(
+            "get",
+            "api_podcast_lookup",
+            args=(itunes_id,),
+            headers=self.auth_headers,
+            **kwargs,
+        )
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_returns_itunes_metadata_without_importing(
+        self,
+        mock_lookup,
+        mock_episodes,
+    ):
+        """A lookup returns the provider's metadata and creates nothing."""
+        mock_lookup.return_value = dict(self.ITUNES_DATA)
+        mock_episodes.return_value = [
+            {
+                "title": "Pilot",
+                "published": datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+                "duration": 4140,
+                "episode_number": 1,
+            },
+        ]
+
+        response = self._lookup()
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        payload = response.json()
+        self.assertEqual(payload["title"], "Unimported Show")
+        self.assertEqual(payload["author"], "Some Network")
+        self.assertEqual(payload["image"], "https://example.com/art.jpg")
+        self.assertEqual(payload["description"], "A show nobody's tracked yet.")
+        self.assertEqual(payload["genres"], ["Comedy"])
+        self.assertEqual(payload["rss_feed_url"], "https://example.com/feed.xml")
+        self.assertIsNone(payload["show_id"], "nothing is imported yet")
+
+        episodes = payload["episodes"]["results"]
+        self.assertEqual(len(episodes), 1)
+        self.assertEqual(episodes[0]["title"], "Pilot")
+        # "1h 9m" — matches the format podcast_views.py sends for a tracked
+        # episode's own duration; see PodcastLookupView._format_duration.
+        self.assertEqual(episodes[0]["duration"], "1h 9m")
+        self.assertEqual(episodes[0]["duration_seconds"], 4140)
+
+        mock_lookup.assert_called_once_with("999888")
+        # The whole feed is read, the way every other RSS caller reads it.
+        mock_episodes.assert_called_once_with("https://example.com/feed.xml")
+        self.assertFalse(
+            PodcastShow.objects.filter(podcast_uuid="itunes:999888").exists(),
+        )
+        self.assertFalse(
+            PodcastEpisode.objects.filter(title="Pilot").exists(),
+            "a preview episode must not be persisted",
+        )
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_paginates_episodes_with_the_standard_envelope(
+        self,
+        mock_lookup,
+        mock_episodes,
+    ):
+        """A feed's episodes page like every other list in the API."""
+        mock_lookup.return_value = dict(self.ITUNES_DATA)
+        mock_episodes.return_value = [
+            {"title": f"Ep {index}", "duration": 60} for index in range(5)
+        ]
+
+        response = self._lookup(params={"limit": 2, "offset": 2})
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        episodes = response.json()["episodes"]
+        self.assertEqual(episodes["pagination"]["total"], 5)
+        self.assertEqual(episodes["pagination"]["limit"], 2)
+        self.assertEqual(episodes["pagination"]["offset"], 2)
+        self.assertEqual(
+            [episode["title"] for episode in episodes["results"]],
+            ["Ep 2", "Ep 3"],
+        )
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_reports_the_show_an_import_would_reuse(
+        self,
+        mock_lookup,
+        mock_episodes,
+    ):
+        """An already-imported feed previews with its existing show id."""
+        mock_lookup.return_value = dict(self.ITUNES_DATA)
+        mock_episodes.return_value = []
+        imported = PodcastShow.objects.create(
+            podcast_uuid="itunes:999888",
+            title="Unimported Show",
+            rss_feed_url="https://example.com/feed.xml",
+        )
+
+        response = self._lookup()
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        self.assertEqual(response.json()["show_id"], imported.id)
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("integrations.podcast_rss.fetch_show_metadata_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_falls_back_to_rss_for_a_blank_itunes_description(
+        self,
+        mock_lookup,
+        mock_rss_metadata,
+        mock_episodes,
+    ):
+        """ITunes' own lookup often has no description; the RSS feed does."""
+        mock_lookup.return_value = {
+            **self.ITUNES_DATA,
+            "author": "",
+            "artwork_url": "",
+            "description": "",
+            "genres": [],
+            "language": "",
+        }
+        mock_rss_metadata.return_value = {
+            "description": "From the feed, not iTunes.",
+            "author": "Feed Author",
+            "language": "en",
+        }
+        mock_episodes.return_value = []
+
+        response = self._lookup()
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        payload = response.json()
+        self.assertEqual(payload["description"], "From the feed, not iTunes.")
+        self.assertEqual(payload["author"], "Feed Author")
+        self.assertEqual(payload["language"], "en")
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_caches_the_feed_read(self, mock_lookup, mock_episodes):
+        """Paging through search results must not re-download a feed."""
+        mock_lookup.return_value = dict(self.ITUNES_DATA)
+        mock_episodes.return_value = []
+
+        self.assertEqual(self._lookup().status_code, HTTP.OK)
+        self.assertEqual(self._lookup().status_code, HTTP.OK)
+
+        mock_episodes.assert_called_once()
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_without_a_feed_previews_no_episodes(
+        self,
+        mock_lookup,
+        mock_episodes,
+    ):
+        """An iTunes result with no feed still previews its own metadata."""
+        mock_lookup.return_value = {**self.ITUNES_DATA, "feed_url": ""}
+
+        response = self._lookup()
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        payload = response.json()
+        self.assertEqual(payload["title"], "Unimported Show")
+        self.assertEqual(payload["rss_feed_url"], "")
+        self.assertEqual(payload["episodes"]["results"], [])
+        mock_episodes.assert_not_called()
+
+    @patch("integrations.podcast_rss.fetch_episodes_from_rss")
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_survives_an_unreadable_feed(self, mock_lookup, mock_episodes):
+        """A feed that won't parse previews as no episodes, not a 500."""
+        mock_lookup.return_value = dict(self.ITUNES_DATA)
+        mock_episodes.side_effect = ValueError("bad feed")
+
+        response = self._lookup()
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        self.assertEqual(response.json()["episodes"]["results"], [])
+
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_of_unknown_id_404s(self, mock_lookup):
+        """An id iTunes doesn't recognise 404s rather than 500ing."""
+        mock_lookup.side_effect = self._provider_error(HTTP.NOT_FOUND)
+
+        response = self._lookup(itunes_id="0")
+
+        self.assertEqual(response.status_code, HTTP.NOT_FOUND)
+
+    @patch("app.providers.pocketcasts.lookup_by_itunes_id")
+    def test_lookup_reports_a_provider_outage_as_a_server_error(self, mock_lookup):
+        """A failing provider is the server's problem, not a missing podcast."""
+        mock_lookup.side_effect = self._provider_error(HTTP.BAD_GATEWAY)
+
+        response = self._lookup()
+
+        self.assertEqual(response.status_code, HTTP.INTERNAL_SERVER_ERROR)
+
+    @staticmethod
+    def _provider_error(status_code):
+        """Build the ProviderAPIError a failing provider call would raise."""
+        from app.providers import services
+
+        return services.ProviderAPIError(
+            "pocketcasts",
+            SimpleNamespace(response=SimpleNamespace(status_code=status_code)),
+        )
 
 
 class ShowEpisodesTests(PodcastApiTestCase):

--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -75,6 +75,18 @@ def minutes_to_hhmm(total_minutes):
     return f"{hours}h {minutes:02d}min"
 
 
+def seconds_to_hm(total_seconds):
+    """Convert a duration in seconds to "1h 9m", or to "46m" under an hour.
+
+    Returns "" for a missing or zero duration.
+    """
+    if not total_seconds:
+        return ""
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    return f"{hours}h {minutes}m" if hours else f"{minutes}m"
+
+
 def has_real_image(image):
     """Return whether the value is a usable artwork URL."""
     return bool(image and image != settings.IMG_NONE)

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -488,15 +488,7 @@ def media_details(
             for episode_obj, enriched in zip(
                 episodes[:initial_limit], enriched_episodes, strict=False
             ):
-                # Format duration
-                duration_str = ""
-                if episode_obj.duration:
-                    hours = episode_obj.duration // 3600
-                    minutes = (episode_obj.duration % 3600) // 60
-                    if hours > 0:
-                        duration_str = f"{hours}h {minutes}m"
-                    else:
-                        duration_str = f"{minutes}m"
+                duration_str = helpers.seconds_to_hm(episode_obj.duration)
 
                 # Get user's podcast media for this episode
                 episode_media = enriched["media"]

--- a/src/app/podcast_views.py
+++ b/src/app/podcast_views.py
@@ -174,11 +174,7 @@ def podcast_episodes_api(request, show_id):
                     enriched = e
                     break
 
-            duration_str = ""
-            if episode_obj.duration:
-                hours = episode_obj.duration // 3600
-                minutes = (episode_obj.duration % 3600) // 60
-                duration_str = f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
+            duration_str = helpers.seconds_to_hm(episode_obj.duration)
 
             user_podcast = episode_podcast_map.get(episode_obj.id)
 
@@ -308,11 +304,7 @@ def podcast_episodes_api(request, show_id):
                 enriched = e
                 break
 
-        duration_str = ""
-        if episode_obj.duration:
-            hours = episode_obj.duration // 3600
-            minutes = (episode_obj.duration % 3600) // 60
-            duration_str = f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
+        duration_str = helpers.seconds_to_hm(episode_obj.duration)
 
         user_podcast = episode_podcast_map.get(episode_obj.id)
         status = user_podcast.status if user_podcast else None
@@ -585,11 +577,7 @@ def podcast_save(request):
             else {"item": {"media_id": episode_obj.episode_uuid}, "media": None}
         )
 
-        duration_str = ""
-        if episode_obj.duration:
-            hours = episode_obj.duration // 3600
-            minutes = (episode_obj.duration % 3600) // 60
-            duration_str = f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
+        duration_str = helpers.seconds_to_hm(episode_obj.duration)
 
         all_history = []
         if user_podcast:

--- a/src/app/services/podcast_import.py
+++ b/src/app/services/podcast_import.py
@@ -19,6 +19,49 @@ class PodcastImportError(Exception):
     """Raised when an iTunes id cannot be resolved into a podcast show."""
 
 
+def resolve_show_metadata(itunes_data: dict, rss_feed_url: str) -> dict:
+    """Return the iTunes lookup data with RSS-feed fallbacks applied.
+
+    iTunes' own lookup frequently omits the description, and when it does it
+    often omits the author and language too; the show's feed carries all
+    three. Returns a new dict instead of mutating `itunes_data`, and creates
+    nothing, so `PodcastLookupView`'s read-only preview can share it with the
+    import below and get the same metadata an import would store.
+    """
+    from integrations import podcast_rss
+
+    resolved = dict(itunes_data)
+    if resolved.get("description"):
+        return resolved
+    try:
+        rss_metadata = podcast_rss.fetch_show_metadata_from_rss(rss_feed_url)
+    except Exception as e:
+        logger.debug(
+            "Failed to fetch show metadata from RSS: %s",
+            exception_summary(e),
+        )
+        return resolved
+
+    for field in ("description", "author", "language"):
+        if not resolved.get(field) and rss_metadata.get(field):
+            resolved[field] = rss_metadata[field]
+    return resolved
+
+
+def find_existing_show(itunes_id: str, rss_feed_url: str) -> PodcastShow | None:
+    """Return the already-imported show for an iTunes result, if there is one.
+
+    Matches on the feed first and then on the iTunes-derived uuid — the same
+    two lookups `import_show_from_itunes_id` uses to avoid importing a show
+    twice, so a preview reports exactly what an import would reuse.
+    """
+    if rss_feed_url:
+        existing = PodcastShow.objects.filter(rss_feed_url=rss_feed_url).first()
+        if existing:
+            return existing
+    return PodcastShow.objects.filter(podcast_uuid=f"itunes:{itunes_id}").first()
+
+
 def import_show_from_itunes_id(itunes_id: str) -> PodcastShow:
     """Return the PodcastShow for an iTunes collection id, importing it if needed.
 
@@ -31,7 +74,6 @@ def import_show_from_itunes_id(itunes_id: str) -> PodcastShow:
             fails.
     """
     from app.providers import pocketcasts
-    from integrations import podcast_rss
 
     try:
         itunes_data = pocketcasts.lookup_by_itunes_id(itunes_id)
@@ -49,38 +91,20 @@ def import_show_from_itunes_id(itunes_id: str) -> PodcastShow:
         no_feed_error = f"Could not find an RSS feed for iTunes id {itunes_id}."
         raise PodcastImportError(no_feed_error)
 
-    existing_show = PodcastShow.objects.filter(rss_feed_url=rss_feed_url).first()
+    existing_show = find_existing_show(itunes_id, rss_feed_url)
     if existing_show:
         return existing_show
 
-    podcast_uuid = f"itunes:{itunes_id}"
-    existing_by_uuid = PodcastShow.objects.filter(podcast_uuid=podcast_uuid).first()
-    if existing_by_uuid:
-        return existing_by_uuid
-
-    description = itunes_data.get("description", "")
-    if not description:
-        try:
-            rss_metadata = podcast_rss.fetch_show_metadata_from_rss(rss_feed_url)
-            description = rss_metadata.get("description", description)
-            if not itunes_data.get("author") and rss_metadata.get("author"):
-                itunes_data["author"] = rss_metadata["author"]
-            if not itunes_data.get("language") and rss_metadata.get("language"):
-                itunes_data["language"] = rss_metadata["language"]
-        except Exception as e:
-            logger.debug(
-                "Failed to fetch show metadata from RSS: %s",
-                exception_summary(e),
-            )
+    metadata = resolve_show_metadata(itunes_data, rss_feed_url)
 
     show = PodcastShow.objects.create(
-        podcast_uuid=podcast_uuid,
-        title=itunes_data.get("title", "Unknown Podcast"),
-        author=itunes_data.get("author", ""),
-        image=itunes_data.get("artwork_url", ""),
-        description=description,
-        genres=itunes_data.get("genres", []),
-        language=itunes_data.get("language", ""),
+        podcast_uuid=f"itunes:{itunes_id}",
+        title=metadata.get("title", "Unknown Podcast"),
+        author=metadata.get("author", ""),
+        image=metadata.get("artwork_url", ""),
+        description=metadata.get("description", ""),
+        genres=metadata.get("genres", []),
+        language=metadata.get("language", ""),
         rss_feed_url=rss_feed_url,
     )
 

--- a/src/app/statistics_aggregator.py
+++ b/src/app/statistics_aggregator.py
@@ -1380,9 +1380,7 @@ def _aggregate_statistics_from_days(
     for item in most_played + most_listened:
         item["formatted_duration"] = helpers.minutes_to_hhmm(item["minutes"])
     for item in longest_episodes:
-        hours = item["duration_seconds"] // 3600
-        minutes = (item["duration_seconds"] % 3600) // 60
-        item["formatted_duration"] = f"{hours}h {minutes}m" if hours else f"{minutes}m"
+        item["formatted_duration"] = helpers.seconds_to_hm(item["duration_seconds"])
     podcast_consumption.update(
         {
             "most_played": most_played,

--- a/src/app/stats_podcast.py
+++ b/src/app/stats_podcast.py
@@ -156,7 +156,7 @@ def _compute_podcast_top_lists(play_details, limit=STATISTICS_TOP_N):
     Returns:
         dict with most_played (by show), most_listened (by show), longest_episodes lists
     """
-    from app.helpers import minutes_to_hhmm
+    from app.helpers import minutes_to_hhmm, seconds_to_hm
 
     # Aggregate by show for most_played and most_listened
     show_stats = defaultdict(
@@ -298,12 +298,7 @@ def _compute_podcast_top_lists(play_details, limit=STATISTICS_TOP_N):
 
     # Format longest episodes duration (from seconds)
     for item in longest_episodes:
-        hours = item["duration_seconds"] // 3600
-        minutes = (item["duration_seconds"] % 3600) // 60
-        if hours > 0:
-            item["formatted_duration"] = f"{hours}h {minutes}m"
-        else:
-            item["formatted_duration"] = f"{minutes}m"
+        item["formatted_duration"] = seconds_to_hm(item["duration_seconds"])
 
     return {
         "most_played": most_played,

--- a/src/app/tests/test_api_contracts.py
+++ b/src/app/tests/test_api_contracts.py
@@ -951,7 +951,7 @@ class SchemaFindingContractTests(SimpleTestCase):
         self.assertIn(SCHEMA_REGENERATION_COMMAND, message)
 
     def test_reviewed_baseline_has_expected_unique_counts(self):
-        self.assertEqual(len(EXPECTED_SCHEMA_ERRORS), 82)
+        self.assertEqual(len(EXPECTED_SCHEMA_ERRORS), 83)
         self.assertEqual(len(EXPECTED_SCHEMA_WARNINGS), 18)
 
     def test_generated_schema_findings_match_reviewed_baseline(self):


### PR DESCRIPTION
**Depends on #987. Merge that one first.** This branch is stacked on it, because the seventh copy of the formatter is introduced there.

## Summary
- Replaces seven hand-rolled copies of the same duration formatter with one shared helper. Three lived in `podcast_views.py`, and one each in `media_details_views.py`, `stats_podcast.py`, `statistics_aggregator.py` and the new podcast lookup API.
- The helper, `helpers.seconds_to_hm`, sits next to the `minutes_to_hhmm` that was already there, so this is filling in a missing sibling rather than introducing a new abstraction.
- Output is identical everywhere with one exception worth a reviewer's eye: a zero-second duration in the statistics "longest episodes" lists now renders blank instead of "0m". That matches what all five view call sites already did for a zero or missing duration, and it is not reachable in practice, since a zero-length episode cannot be a longest episode.
- The `H:MM:SS` formatters in `track_modal_views.py`, `models/podcast.py` and the media detail adapters are a different format and were deliberately left alone.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
Local `uv` is pinned to a version this machine does not have, so these ran through the venv interpreter directly.

- `SECRET=test-only PYTHONPATH=mcp_server .venv/bin/python src/manage.py test app users integrations lists events api --parallel --buffer --exclude-tag slow --exclude-tag network` -> 4412 tests. Seven did not pass, and all seven were confirmed to fail identically on `latest` with these changes stashed:
  - 2 x `ModuleNotFoundError: pyld` in `app.tests.test_api_contracts`, a stale local venv.
  - 3 x `app.tests.test_data_paths.EntrypointDataPathTests`, which assert on entrypoint output and fail on macOS only, because macOS resolves `/var/...` to `/private/var/...`.
  - 2 x `events.tests.test_views.DownloadCalendarViewTests`, the known calendar date-drift flake, already fixed upstream in `fb78c9e0`, which this base predates.
- `.venv/bin/ruff check src` -> All checks passed.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues

#987