### PR TITLE
Fix regressions related to season/episode thumbnails and IMDb season aggregation

### DIFF
--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -232,13 +232,23 @@ class CompleteMediaSerializer(serializers.Serializer):
         # FORK: look up already-synced season Items (e.g. IMDb ratings) for
         # untracked seasons instead of always building an ephemeral in-memory
         # Item, one batched query for the whole show rather than per-season.
+        existing_items = Item.objects.filter(
+            media_id=str(media_metadata.get("media_id") or ""),
+            source=media_metadata.get("source"),
+            media_type=MediaTypes.SEASON.value,
+        )
+        library_media_type = media_metadata.get("library_media_type")
+        if library_media_type:
+            existing_items = existing_items.filter(
+                library_media_type=library_media_type,
+            )
+        else:
+            existing_items = existing_items.exclude(
+                library_media_type=MediaTypes.ANIME.value,
+            )
         existing_items_by_season = {
             existing_item.season_number: existing_item
-            for existing_item in Item.objects.filter(
-                media_id=str(media_metadata.get("media_id") or ""),
-                source=media_metadata.get("source"),
-                media_type=MediaTypes.SEASON.value,
-            )
+            for existing_item in existing_items
         }
 
         processed_seasons = []
@@ -262,6 +272,10 @@ class CompleteMediaSerializer(serializers.Serializer):
                     image=season.get("image") or settings.IMG_NONE,
                     season_number=season_number,
                 )
+            elif not app_helpers.has_real_image(item.image):
+                image = app_helpers.first_real_image(season.get("image"), default=None)
+                if image:
+                    item.image = image
 
             if tracked_season is None:
                 tracked_season = type(
@@ -301,14 +315,24 @@ class CompleteMediaSerializer(serializers.Serializer):
         # FORK: look up already-synced episode Items (e.g. IMDb ratings) for
         # untracked episodes instead of always building an ephemeral in-memory
         # Item, one batched query for the whole season rather than per-episode.
+        existing_items = Item.objects.filter(
+            media_id=str(media_metadata.get("media_id") or ""),
+            source=media_metadata.get("source"),
+            media_type=MediaTypes.EPISODE.value,
+            season_number=media_metadata.get("season_number"),
+        )
+        library_media_type = media_metadata.get("library_media_type")
+        if library_media_type:
+            existing_items = existing_items.filter(
+                library_media_type=library_media_type,
+            )
+        else:
+            existing_items = existing_items.exclude(
+                library_media_type=MediaTypes.ANIME.value,
+            )
         existing_items_by_episode = {
             existing_item.episode_number: existing_item
-            for existing_item in Item.objects.filter(
-                media_id=str(media_metadata.get("media_id") or ""),
-                source=media_metadata.get("source"),
-                media_type=MediaTypes.EPISODE.value,
-                season_number=media_metadata.get("season_number"),
-            )
+            for existing_item in existing_items
         }
         serializer = EpisodeSerializer(
             context={
@@ -470,16 +494,20 @@ class EpisodeSerializer(serializers.ModelSerializer):
         if hasattr(episode, "item"):
             item = getattr(episode, "item", None)
         else:
+            image = app_helpers.first_real_image(
+                (
+                    "https://image.tmdb.org/t/p/original" + instance["still_path"]
+                    if instance.get("still_path")
+                    else None
+                ),
+                instance.get("image"),
+                default=None,
+            )
             # FORK: reuse an already-synced episode Item (e.g. IMDb ratings)
             # instead of always building an ephemeral in-memory Item.
             existing_items_by_episode = context.get("existing_items_by_episode", {})
             item = existing_items_by_episode.get(episode_number)
             if item is None:
-                image = (
-                    "https://image.tmdb.org/t/p/original" + instance.get("still_path")
-                    if instance.get("still_path")
-                    else None
-                )
                 item = Item(
                     media_id=media_id,
                     source=context.get("source"),
@@ -492,6 +520,9 @@ class EpisodeSerializer(serializers.ModelSerializer):
                         {"release_date": instance.get("air_date")},
                     ),
                 )
+            elif not app_helpers.has_real_image(item.image) and image:
+                # Enrich the response without saving provider metadata here.
+                item.image = image
 
         if hasattr(episode, "lists"):
             lists = episode.lists

--- a/src/api/tests/test_media_season.py
+++ b/src/api/tests/test_media_season.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.db.utils import OperationalError
 
-from api.serializers import EpisodeSerializer
+from api.serializers import CompleteMediaSerializer, EpisodeSerializer
 from app.models import TV, Episode, Item, MediaTypes, Season, Sources
 
 from .base import FloppyApiTestCase
@@ -1877,3 +1877,176 @@ class EpisodeSerializerAirDateTests(FloppyApiTestCase):
         self.assertTrue(
             str(result["item"]["release_datetime"]).startswith("2023-01-22"),
         )
+
+    def test_existing_untracked_item_uses_provider_still_without_losing_rating(self):
+        """An existing image-less Item keeps its ratings and gets a response-only still."""
+        item = Item.objects.create(
+            media_id="air-date-show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Provider title",
+            season_number=1,
+            episode_number=2,
+            imdb_rating=8.7,
+            imdb_rating_count=123,
+        )
+        instance = {
+            "show_id": "air-date-show-1",
+            "season_number": 1,
+            "episode_number": 2,
+            "name": "Provider title",
+            "still_path": "/episode-still.jpg",
+        }
+
+        result = EpisodeSerializer(
+            context={
+                "source": Sources.TMDB.value,
+                "existing_items_by_episode": {2: item},
+            },
+        ).to_representation(instance)
+
+        self.assertEqual(result["item"]["imdb_rating"], 8.7)
+        self.assertEqual(result["item"]["imdb_rating_count"], 123)
+        self.assertEqual(
+            result["item"]["image"],
+            "https://image.tmdb.org/t/p/original/episode-still.jpg",
+        )
+        item.refresh_from_db()
+        self.assertIsNone(item.image)
+
+    def test_existing_untracked_item_image_takes_precedence_over_provider_still(self):
+        """Stored episode artwork remains authoritative over provider metadata."""
+        item = Item.objects.create(
+            media_id="air-date-show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Stored title",
+            image="https://example.test/stored-still.jpg",
+            season_number=1,
+            episode_number=2,
+        )
+        instance = {
+            "show_id": "air-date-show-1",
+            "season_number": 1,
+            "episode_number": 2,
+            "name": "Provider title",
+            "still_path": "/provider-still.jpg",
+        }
+
+        result = EpisodeSerializer(
+            context={
+                "source": Sources.TMDB.value,
+                "existing_items_by_episode": {2: item},
+            },
+        ).to_representation(instance)
+
+        self.assertEqual(result["item"]["image"], "https://example.test/stored-still.jpg")
+
+    def test_existing_untracked_tvdb_item_uses_provider_image(self):
+        """TVDB episode images are already normalized instead of a still path."""
+        item = Item.objects.create(
+            media_id="air-date-show-1",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Provider title",
+            season_number=1,
+            episode_number=2,
+        )
+        instance = {
+            "show_id": "air-date-show-1",
+            "season_number": 1,
+            "episode_number": 2,
+            "name": "Provider title",
+            "still_path": None,
+            "image": "https://artworks.thetvdb.com/episode-still.jpg",
+        }
+
+        result = EpisodeSerializer(
+            context={
+                "source": Sources.TVDB.value,
+                "existing_items_by_episode": {2: item},
+            },
+        ).to_representation(instance)
+
+        self.assertEqual(
+            result["item"]["image"],
+            "https://artworks.thetvdb.com/episode-still.jpg",
+        )
+
+    def test_untracked_episode_lookup_excludes_anime_bucket_by_default(self):
+        """TV detail must not reuse a same-coordinate grouped-anime Item."""
+        Item.objects.create(
+            media_id="air-date-show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.ANIME.value,
+            title="Anime episode",
+            image="https://example.test/anime.jpg",
+            season_number=1,
+            episode_number=2,
+            imdb_rating=1.0,
+        )
+        Item.objects.create(
+            media_id="air-date-show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="TV episode",
+            season_number=1,
+            episode_number=2,
+            imdb_rating=8.5,
+        )
+        metadata = {
+            "media_id": "air-date-show-1",
+            "source": Sources.TMDB.value,
+            "season_number": 1,
+            "episodes": [
+                {
+                    "show_id": "air-date-show-1",
+                    "season_number": 1,
+                    "episode_number": 2,
+                    "name": "TV episode",
+                    "still_path": "/tv.jpg",
+                },
+            ],
+        }
+
+        CompleteMediaSerializer()._process_episodes(metadata)
+
+        episode = metadata["related"]["episodes"][0]
+        self.assertEqual(episode["item"]["imdb_rating"], 8.5)
+        self.assertEqual(
+            episode["item"]["image"],
+            "https://image.tmdb.org/t/p/original/tv.jpg",
+        )
+
+    def test_existing_untracked_season_uses_provider_image(self):
+        """Existing image-less season Items keep ratings and get response artwork."""
+        item = Item.objects.create(
+            media_id="air-date-show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Season 2",
+            season_number=2,
+            imdb_rating=8.2,
+        )
+        metadata = {
+            "media_id": "air-date-show-1",
+            "source": Sources.TMDB.value,
+            "related": {
+                "seasons": [
+                    {
+                        "season_number": 2,
+                        "title": "Season 2",
+                        "image": "https://example.test/season-2.jpg",
+                    },
+                ],
+            },
+        }
+
+        CompleteMediaSerializer()._process_seasons(metadata)
+
+        season = metadata["related"]["seasons"][0]
+        self.assertEqual(season["item"]["imdb_rating"], 8.2)
+        self.assertEqual(season["item"]["image"], "https://example.test/season-2.jpg")
+        item.refresh_from_db()
+        self.assertIsNone(item.image)

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1211,6 +1211,8 @@ class MediaDetailView(drf_views.APIView):
             )
 
         library_media_type = request.query_params.get("library_media_type")
+        if library_media_type:
+            media_metadata["library_media_type"] = library_media_type
         try:
             user_medias = BasicMedia.objects.filter_media_prefetch(
                 user,
@@ -1269,7 +1271,12 @@ class MediaDetailView(drf_views.APIView):
             game_length_item = (
                 user_medias[0].item
                 if user_medias
-                else resolve_item_queryset(media_id, source, media_type).first()
+                else resolve_item_queryset(
+                    media_id,
+                    source,
+                    media_type,
+                    library_media_type=library_media_type,
+                ).first()
             )
             if game_length_item is None and source == Sources.IGDB.value:
                 try:
@@ -1315,7 +1322,12 @@ class MediaDetailView(drf_views.APIView):
             top_level_item = (
                 user_medias[0].item
                 if user_medias
-                else resolve_item_queryset(media_id, source, media_type).first()
+                else resolve_item_queryset(
+                    media_id,
+                    source,
+                    media_type,
+                    library_media_type=library_media_type,
+                ).first()
             )
 
         data = {
@@ -2424,6 +2436,8 @@ class MediaSeasonDetailView(drf_views.APIView):
             )
 
         library_media_type = request.query_params.get("library_media_type")
+        if library_media_type:
+            media_metadata["library_media_type"] = library_media_type
         try:
             user_medias = BasicMedia.objects.filter_media_prefetch(
                 user,
@@ -2485,6 +2499,7 @@ class MediaSeasonDetailView(drf_views.APIView):
                 source,
                 MediaTypes.SEASON.value,
                 season_number=season_number,
+                library_media_type=library_media_type,
             ).first()
         )
 
@@ -2694,6 +2709,7 @@ class MediaSeasonEpisodesView(drf_views.APIView):
     def get(self, request, media_type, source, media_id, season_number):
         """Retrieve the episodes for a specific season of a tv serie."""
         user = request.user
+        library_media_type = request.query_params.get("library_media_type")
         limit, offset, err = parse_limit_offset(request)
         if err:
             return err
@@ -2773,7 +2789,7 @@ class MediaSeasonEpisodesView(drf_views.APIView):
                 source,
                 season_number=season_number,
                 episode_numbers=episode_numbers,
-                library_media_type=request.query_params.get("library_media_type"),
+                library_media_type=library_media_type,
             )
             for tracked in tracked_episodes:
                 item = getattr(tracked, "item", None)
@@ -3565,6 +3581,7 @@ class MediaEpisodeDetailView(drf_views.APIView):
         """Retrieve details of a specific episode for the authenticated user."""
         user = request.user
         episode = None
+        library_media_type = request.query_params.get("library_media_type")
 
         if not check_valid_type(media_type):
             return Response(
@@ -3594,7 +3611,7 @@ class MediaEpisodeDetailView(drf_views.APIView):
             source,
             season_number,
             episode_number,
-            library_media_type=request.query_params.get("library_media_type"),
+            library_media_type=library_media_type,
         )
         if coordinate_error:
             return coordinate_error
@@ -3609,7 +3626,7 @@ class MediaEpisodeDetailView(drf_views.APIView):
                 source,
                 season_number=season_number,
                 episode_number=episode_number,
-                library_media_type=request.query_params.get("library_media_type"),
+                library_media_type=library_media_type,
             )
         except Exception:
             logger.exception("An error occurred while fetching user media.")
@@ -3642,6 +3659,7 @@ class MediaEpisodeDetailView(drf_views.APIView):
                 MediaTypes.EPISODE.value,
                 season_number=season_number,
                 episode_number=episode_number,
+                library_media_type=library_media_type,
             ).first()
         )
 

--- a/src/app/services/imdb_ratings.py
+++ b/src/app/services/imdb_ratings.py
@@ -171,21 +171,29 @@ def sync_season_ratings() -> int:
 
     Returns the number of Items updated.
     """
-    show_keys = set(
+    show_keys = (
         Item.objects.filter(
             media_type=MediaTypes.EPISODE.value,
             imdb_rating_count__isnull=False,
-        ).values_list("media_id", "source"),
+        )
+        .values_list("media_id", "source", "library_media_type")
+        .distinct()
     )
     if not show_keys:
         return 0
 
     updated = []
-    for media_id, source in show_keys:
+    for media_id, source, library_media_type in show_keys:
+        season_library_media_type = (
+            MediaTypes.SEASON.value
+            if library_media_type == MediaTypes.EPISODE.value
+            else library_media_type
+        )
         episode_ratings = Item.objects.filter(
             media_id=media_id,
             source=source,
             media_type=MediaTypes.EPISODE.value,
+            library_media_type=library_media_type,
             season_number__isnull=False,
             imdb_rating__isnull=False,
             imdb_rating_count__isnull=False,
@@ -210,6 +218,7 @@ def sync_season_ratings() -> int:
                 media_id=media_id,
                 source=source,
                 media_type=MediaTypes.SEASON.value,
+                library_media_type=season_library_media_type,
                 season_number__in=totals_by_season.keys(),
             )
         }

--- a/src/app/tests/test_tasks_imdb.py
+++ b/src/app/tests/test_tasks_imdb.py
@@ -12,6 +12,7 @@ from app.models import (
     Person,
     Sources,
 )
+from app.services.imdb_ratings import sync_season_ratings
 from app.tasks_backfill_state import _record_backfill_success
 from app.tasks_imdb import (
     backfill_imdb_game_person_profiles,
@@ -182,3 +183,48 @@ class SyncImdbRatingsTaskTests(TestCase):
                 "seasons_updated": 1,
             },
         )
+
+    def test_season_ratings_stay_within_their_library_bucket(self):
+        """TV and grouped-anime rows with shared IDs must not be combined."""
+        common = {
+            "media_id": "tmdb-shared",
+            "source": Sources.TMDB.value,
+            "season_number": 1,
+        }
+        tv_episode = Item.objects.create(
+            **common,
+            media_type=MediaTypes.EPISODE.value,
+            title="TV episode",
+            episode_number=1,
+            imdb_rating=8.0,
+            imdb_rating_count=100,
+        )
+        tv_season = Item.objects.create(
+            **common,
+            media_type=MediaTypes.SEASON.value,
+            title="TV season",
+        )
+        anime_episode = Item.objects.create(
+            **common,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.ANIME.value,
+            title="Anime episode",
+            episode_number=1,
+            imdb_rating=6.0,
+            imdb_rating_count=10,
+        )
+        anime_season = Item.objects.create(
+            **common,
+            media_type=MediaTypes.SEASON.value,
+            library_media_type=MediaTypes.ANIME.value,
+            title="Anime season",
+        )
+
+        self.assertEqual(sync_season_ratings(), 2)
+
+        for item in (tv_episode, tv_season, anime_episode, anime_season):
+            item.refresh_from_db()
+        self.assertEqual(tv_season.imdb_rating, 8.0)
+        self.assertEqual(tv_season.imdb_rating_count, 100)
+        self.assertEqual(anime_season.imdb_rating, 6.0)
+        self.assertEqual(anime_season.imdb_rating_count, 10)


### PR DESCRIPTION
## Summary

- Restored missing episode and season artwork when an existing synced Item has no real image.
- Uses provider-normalized artwork for TVDB episodes and preserves stored artwork when present.
- Keeps IMDb ratings and episode/season data isolated between TV and grouped-anime library buckets.

## AI Assistance

- Generated with `gpt-5.6`.

## How It Was Tested

- `SECRET=test-only .venv/bin/python src/manage.py test api.tests.test_media_season.EpisodeSerializerAirDateTests app.tests.test_tasks_imdb.SyncImdbRatingsTaskTests --buffer` → Passed
- `.venv/bin/ruff check src/api/serializers.py src/api/views.py src/app/services/imdb_ratings.py src/api/tests/test_media_season.py src/app/tests/test_tasks_imdb.py` → Passed
- `git diff --check` → Passed

## Public API & Documentation Handoff

- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance

- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety

- [x] Not applicable (no database changes)

## Related Issues

- #984