### PR TITLE
List and edit every watch note on media detail pages

### DIFF
--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -1756,18 +1756,12 @@ def media_details(
         music_album = getattr(current_instance, "album", None)
 
     notes_entry = None
+    notes_entries = []
     if render_secondary_only and not public_view and user_medias:
-        if (
-            current_instance
-            and current_instance.notes
-            and current_instance.notes.strip()
-        ):
-            notes_entry = current_instance
-        else:
-            for entry in user_medias:
-                if entry.notes and entry.notes.strip():
-                    notes_entry = entry
-                    break
+        notes_entries = [
+            entry for entry in user_medias if entry.notes and entry.notes.strip()
+        ]
+        notes_entry = notes_entries[0] if notes_entries else None
     elif render_secondary_only and public_notes_view and list_owner:
         public_user_medias = list(
             BasicMedia.objects.filter_media_prefetch(
@@ -1777,14 +1771,10 @@ def media_details(
                 source,
             ),
         )
-        notes_entry = next(
-            (
-                entry
-                for entry in public_user_medias
-                if entry.notes and entry.notes.strip()
-            ),
-            None,
-        )
+        notes_entries = [
+            entry for entry in public_user_medias if entry.notes and entry.notes.strip()
+        ]
+        notes_entry = notes_entries[0] if notes_entries else None
 
     if (
         render_secondary_only
@@ -2051,6 +2041,7 @@ def media_details(
         "game_lengths_pending": game_lengths_refresh_pending
         and not (game_lengths and game_lengths.get("available")),
         "notes_entry": notes_entry,
+        "notes_entries": notes_entries,
         "collection_entry": collection_entry,
         "collection_entries": collection_entries,
         "collection_stats": collection_stats,

--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -369,6 +369,20 @@ def media_save(request):
                                 media_url(tv.item),
                             ),
                         )
+                if media_type in (
+                    MediaTypes.MOVIE.value,
+                    MediaTypes.TV.value,
+                    MediaTypes.SEASON.value,
+                    MediaTypes.ANIME.value,
+                ):
+                    response.write(
+                        _render_notes_section_oob(
+                            request,
+                            request.user,
+                            media.item,
+                            media,
+                        ),
+                    )
             except Exception:
                 logger.exception(
                     "Post-save enrichment failed for %s save "
@@ -672,6 +686,36 @@ def _render_season_progress_oob(related_season):
             f"Progress: {progress}</span>"
         )
     return spans
+
+
+def _render_notes_section_oob(request, user, item, instance):
+    """Render the detail notes section as an OOB swap after a watch save.
+
+    The notes section lists one block per watch (see detail_notes_section),
+    so a note edited in the track modal must be pushed back into the page
+    without a full reload.
+    """
+    return render_to_string(
+        "app/components/detail_notes_section.html",
+        {
+            "notes_entries": [
+                entry
+                for entry in instance.__class__.objects.filter(
+                    user=user, item=item
+                )
+                if entry.notes and entry.notes.strip()
+            ],
+            "media": item,
+            "user": user,
+            "public_notes_view": False,
+            "public_view": False,
+            "detail_return_url": "",
+            "detail_notes_modal_url": "",
+            "detail_notes_target_id": "",
+            "notes_section_oob": True,
+        },
+        request=request,
+    )
 
 
 def _render_track_action_oob(request, instance, return_url):

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -926,17 +926,16 @@ def episode_details(
     )
 
     # Surface the note from the most recent watch that has one, the same way
-    # the movie/season pages do (issue #377).
+    # the movie/season pages do (issue #377). Keep all notes-holding watches
+    # so the notes section can list every watch (see notes_entries).
     notes_entry = None
+    notes_entries = []
     if not public_view:
-        notes_entry = next(
-            (
-                watch
-                for watch in (episode_data or {}).get("history", [])
-                if watch.notes and watch.notes.strip()
-            ),
-            None,
-        )
+        history = (episode_data or {}).get("history", [])
+        notes_entries = [
+            watch for watch in history if watch.notes and watch.notes.strip()
+        ]
+        notes_entry = notes_entries[0] if notes_entries else None
     elif public_notes_view and list_owner:
         public_user_medias = list(
             BasicMedia.objects.filter_media_prefetch(
@@ -951,19 +950,18 @@ def episode_details(
                 ),
             ),
         )
-        notes_entry = next(
-            (
-                entry
-                for entry in public_user_medias
-                if entry.notes and entry.notes.strip()
-            ),
-            None,
-        )
+        notes_entries = [
+            entry
+            for entry in public_user_medias
+            if entry.notes and entry.notes.strip()
+        ]
+        notes_entry = notes_entries[0] if notes_entries else None
 
     context = {
         "user": request.user,
         "episode": episode_data,
         "notes_entry": notes_entry,
+        "notes_entries": notes_entries,
         "episode_notes_modal_target_id": (
             f"episode-notes-modal-{source}-{media_id}-{season_number}-{episode_number}"
         ),

--- a/src/templates/app/components/detail_notes_block.html
+++ b/src/templates/app/components/detail_notes_block.html
@@ -1,0 +1,58 @@
+{% load app_tags %}
+{% load user_tags %}
+
+<div class="mb-2"
+     x-data="{ hovered: false, trackOpen: false }"
+     @mouseenter="hovered = true"
+     @mouseleave="hovered = false">
+  <div x-show="trackOpen"
+       @keydown.escape.window="trackOpen = false"
+       class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+       style="display: none;">
+    <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
+         style="width: min(96vw, 72rem);"
+         @click.outside="trackOpen = false">
+      <div id="{{ notes_modal_target_id }}"></div>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between mb-1">
+    <span class="text-xs text-[var(--color-text-muted)]">{{ entry.end_date|user_date_format:user }}</span>
+  </div>
+
+  <div class="relative"
+       x-data="{ isExpanded: false, isClamped: false, checkClamp() { const element = this.$refs.notesPreview; this.isClamped = element.scrollHeight > element.clientHeight; } }"
+       x-init="$nextTick(() => checkClamp())">
+    {% if not public_notes_view|default:False %}
+    <div class="absolute top-2 right-2 z-10"
+         x-show="hovered"
+         x-transition.opacity.duration.150ms
+         style="display: none;">
+      <button type="button"
+              class="inline-flex items-center justify-center rounded-md p-1.5 text-[var(--color-text-secondary)] transition-colors duration-200 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] cursor-pointer"
+              title="Edit notes"
+              aria-label="Edit notes"
+              hx-get="{% if detail_notes_modal_url %}{{ detail_notes_modal_url }}{% else %}{% media_view_url 'track_modal' media %}{% endif %}?instance_id={{ entry.id }}&return_url={{ detail_return_url|urlencode }}"
+              hx-target="#{{ notes_modal_target_id }}"
+              hx-trigger="click"
+              @click="trackOpen = true">
+        {% include "app/icons/edit.svg" with classes="w-4 h-4" %}
+      </button>
+    </div>
+    {% endif %}
+
+    <div x-ref="notesPreview"
+         data-markdown-preview
+         data-markdown-source="{{ notes_content_id }}"
+         style="max-height: 12rem; overflow: hidden;"
+         :style="isExpanded ? 'max-height: none; overflow: visible;' : 'max-height: 12rem; overflow: hidden;'"
+         class="rounded-lg border border-gray-700 bg-[var(--color-surface)] p-4 text-sm text-[var(--color-text-secondary)]"></div>
+    <div class="mt-3 flex items-center gap-2">
+      <button x-show="isClamped"
+              @click="isExpanded = !isExpanded"
+              class="text-sm text-[var(--color-link)] transition-colors hover:text-[var(--color-link-hover)] focus:outline-none cursor-pointer">
+        <span x-text="isExpanded ? 'Show less' : 'Show more'"></span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/templates/app/components/detail_notes_block.html
+++ b/src/templates/app/components/detail_notes_block.html
@@ -6,12 +6,12 @@
      @mouseenter="hovered = true"
      @mouseleave="hovered = false">
   <div x-show="trackOpen"
+       @mousedown.self="trackOpen = false"
        @keydown.escape.window="trackOpen = false"
        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
        style="display: none;">
     <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-         style="width: min(96vw, 72rem);"
-         @click.outside="trackOpen = false">
+         style="width: min(96vw, 72rem);">
       <div id="{{ notes_modal_target_id }}"></div>
     </div>
   </div>

--- a/src/templates/app/components/detail_notes_section.html
+++ b/src/templates/app/components/detail_notes_section.html
@@ -1,104 +1,36 @@
 {% load app_tags %}
+{% load user_tags %}
 
-{% with notes_modal_id=notes_entry.id|stringformat:"s"|add:"-notes" notes_content_id=notes_entry.id|stringformat:"s"|add:"-notes-content" %}
-  {% if detail_notes_target_id %}
-    {% with notes_modal_target_id=detail_notes_target_id %}
-  {{ notes_entry.notes|json_script:notes_content_id }}
-  <section class="mb-8">
-    <div class="mb-4 flex items-center gap-2">
-      <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
-      {% if not public_notes_view|default:False %}
-      <div x-data="{ trackOpen: false }" class="shrink-0">
-        <button type="button"
-                class="inline-flex items-center justify-center rounded-md p-1.5 text-[var(--color-text-secondary)] transition-colors duration-200 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] cursor-pointer"
-                title="Edit notes"
-                aria-label="Edit notes"
-                hx-get="{% if detail_notes_modal_url %}{{ detail_notes_modal_url }}{% else %}{% media_view_url 'track_modal' media %}{% endif %}?instance_id={{ notes_entry.id }}&return_url={{ detail_return_url|urlencode }}"
-                hx-target="#{{ notes_modal_target_id }}"
-                hx-trigger="click"
-                @click="trackOpen = true">
-          {% include "app/icons/edit.svg" with classes="w-4 h-4" %}
-        </button>
+<section id="detail-notes-section" class="mb-8" {% if notes_section_oob %}hx-swap-oob="outerHTML"{% endif %}>
+  <div class="mb-4 flex items-center gap-2">
+    <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
+  </div>
 
-        <div x-show="trackOpen"
-             @keydown.escape.window="trackOpen = false"
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-               style="width: min(96vw, 72rem);"
-               @click.outside="trackOpen = false">
-            <div id="{{ notes_modal_target_id }}"></div>
-          </div>
-        </div>
-      </div>
+  {% for entry in notes_entries %}
+    {% with notes_modal_id=entry.id|stringformat:"s"|add:"-notes" notes_content_id=entry.id|stringformat:"s"|add:"-notes-content" %}
+      {{ entry.notes|json_script:notes_content_id }}
+      {% if detail_notes_target_id %}
+        {% with notes_modal_target_id=detail_notes_target_id|add:"-"|add:entry.id %}
+          {% include "app/components/detail_notes_block.html" with entry=entry notes_modal_target_id=notes_modal_target_id %}
+        {% endwith %}
+      {% else %}
+        {% component_id 'track' media notes_modal_id as notes_modal_target_id %}
+        {% include "app/components/detail_notes_block.html" with entry=entry notes_modal_target_id=notes_modal_target_id %}
       {% endif %}
-    </div>
-
-    <div x-data="{ isExpanded: false, isClamped: false, checkClamp() { const element = this.$refs.notesPreview; this.isClamped = element.scrollHeight > element.clientHeight; } }"
-         x-init="$nextTick(() => checkClamp())">
-      <div x-ref="notesPreview"
-           data-markdown-preview
-           data-markdown-source="{{ notes_content_id }}"
-           style="max-height: 12rem; overflow: hidden;"
-           :style="isExpanded ? 'max-height: none; overflow: visible;' : 'max-height: 12rem; overflow: hidden;'"
-           class="rounded-lg border border-gray-700 bg-[var(--color-surface)] p-4 text-sm text-[var(--color-text-secondary)]"></div>
-      <div class="mt-3 flex items-center gap-2">
-        <button x-show="isClamped"
-                @click="isExpanded = !isExpanded"
-                class="text-sm text-[var(--color-link)] transition-colors hover:text-[var(--color-link-hover)] focus:outline-none cursor-pointer">
-          <span x-text="isExpanded ? 'Show less' : 'Show more'"></span>
-        </button>
-      </div>
-    </div>
-  </section>
     {% endwith %}
-  {% else %}
-    {% component_id 'track' media notes_modal_id as notes_modal_target_id %}
-  {{ notes_entry.notes|json_script:notes_content_id }}
-  <section class="mb-8">
-    <div class="mb-4 flex items-center gap-2">
-      <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
-      {% if not public_notes_view|default:False %}
-      <div x-data="{ trackOpen: false }" class="shrink-0">
-        <button type="button"
-                class="inline-flex items-center justify-center rounded-md p-1.5 text-[var(--color-text-secondary)] transition-colors duration-200 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] cursor-pointer"
-                title="Edit notes"
-                aria-label="Edit notes"
-                hx-get="{% media_view_url 'track_modal' media %}?instance_id={{ notes_entry.id }}&return_url={{ detail_return_url|urlencode }}"
-                hx-target="#{{ notes_modal_target_id }}"
-                hx-trigger="click"
-                @click="trackOpen = true">
-          {% include "app/icons/edit.svg" with classes="w-4 h-4" %}
-        </button>
-
-        <div x-show="trackOpen"
-             @keydown.escape.window="trackOpen = false"
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-               style="width: min(96vw, 72rem);"
-               @click.outside="trackOpen = false">
-            <div id="{{ notes_modal_target_id }}"></div>
-          </div>
-        </div>
-      </div>
-      {% endif %}
-    </div>
-
-    <div x-data="{ isExpanded: false, isClamped: false, checkClamp() { const element = this.$refs.notesPreview; this.isClamped = element.scrollHeight > element.clientHeight; } }"
-         x-init="$nextTick(() => checkClamp())">
-      <div x-ref="notesPreview"
-           data-markdown-preview
-           data-markdown-source="{{ notes_content_id }}"
-           style="max-height: 12rem; overflow: hidden;"
-           :style="isExpanded ? 'max-height: none; overflow: visible;' : 'max-height: 12rem; overflow: hidden;'"
-           class="rounded-lg border border-gray-700 bg-[var(--color-surface)] p-4 text-sm text-[var(--color-text-secondary)]"></div>
-      <div class="mt-3 flex items-center gap-2">
-        <button x-show="isClamped"
-                @click="isExpanded = !isExpanded"
-                class="text-sm text-[var(--color-link)] transition-colors hover:text-[var(--color-link-hover)] focus:outline-none cursor-pointer">
-          <span x-text="isExpanded ? 'Show less' : 'Show more'"></span>
-        </button>
-      </div>
-    </div>
-  </section>
-  {% endif %}
-{% endwith %}
+  {% empty %}
+    {% if notes_entry %}
+      {% with notes_modal_id=notes_entry.id|stringformat:"s"|add:"-notes" notes_content_id=notes_entry.id|stringformat:"s"|add:"-notes-content" %}
+        {{ notes_entry.notes|json_script:notes_content_id }}
+        {% if detail_notes_target_id %}
+          {% with notes_modal_target_id=detail_notes_target_id %}
+            {% include "app/components/detail_notes_block.html" with entry=notes_entry notes_modal_target_id=notes_modal_target_id %}
+          {% endwith %}
+        {% else %}
+          {% component_id 'track' media notes_modal_id as notes_modal_target_id %}
+          {% include "app/components/detail_notes_block.html" with entry=notes_entry notes_modal_target_id=notes_modal_target_id %}
+        {% endif %}
+      {% endwith %}
+    {% endif %}
+  {% endfor %}
+</section>

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -297,7 +297,7 @@
 
 {# Your Notes — same component the movie/season pages use, pointed at the watch that carries the note. #}
 {% if show_notes and notes_entry %}
-  {% include "app/components/detail_notes_section.html" with notes_entry=notes_entry detail_notes_target_id=episode_notes_modal_target_id detail_notes_modal_url=episode_notes_modal_url detail_return_url=detail_return_url public_notes_view=public_notes_view %}
+  {% include "app/components/detail_notes_section.html" with notes_entries=notes_entries notes_entry=notes_entry detail_notes_target_id=episode_notes_modal_target_id detail_notes_modal_url=episode_notes_modal_url detail_return_url=detail_return_url public_notes_view=public_notes_view %}
 {% endif %}
 
 {# Cast & Crew — same grid pattern as detail_secondary_content.html #}


### PR DESCRIPTION
## Summary
Movie, TV, anime, and season detail pages only showed **one** note — the latest watch's — even when an item was watched multiple times with different notes. The earlier watches' notes were invisible and could not be edited from the UI.

This change:
- **Lists one note block per watch** under "Your Notes", each labeled with its watch date, ordered newest-first.
- Adds a **hover-reveal edit (pencil) button** on each note that opens the existing track modal scoped to that watch (`?instance_id=<id>`), so any watch's note/date can be edited individually.
- **Refreshes the section in place** after saving via an `hx-swap-oob="outerHTML"` push from `media_save`, so no page reload is needed.
- **Dismisses the notes modal on backdrop mousedown** (`@mousedown.self`) instead of click-outside, so pressing outside closes it immediately and dragging a text selection out of the modal never dismisses it.
- Extracts the per-note markup into a small partial and preserves the single-note layout for callers that only pass `notes_entry` (episode details, music artist/album, podcasts).

**Before:** "Your Notes" shows only the latest watch's note; earlier notes are hidden and uneditable for movies.

<img width="608" height="209" alt="image" src="https://github.com/user-attachments/assets/39dcc521-5784-4952-9de5-54bf3e8ebadf" />

**After:** every watch's note is listed; hovering a note reveals its edit button.

<img width="608" height="333" alt="image" src="https://github.com/user-attachments/assets/94cdeedf-8731-452d-b960-3f02fa6854df" />


## AI Assistance
Code generated and reviewed with an AI coding agent using model `deepseek-v4-flash` (opencode agent). Workflow: direct code inspection of the Django views/templates, targeted Django template render checks, and the `test_track_modal` test suite.

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_track_modal` → 33 passed
- `SECRET=test-only scripts/test.sh app.tests.views.test_crud` → 5 failures, **confirmed preexisting** on the unmodified `latest` baseline (create tests require live provider metadata/network); no new failures introduced
- `uv run --no-sync ruff check src/app/save_views.py src/app/media_details_views.py` → passed
- `djlint src/templates/app/components/detail_notes_section.html detail_notes_block.html` → passed
- Template render smoke test: OOB output contains `hx-swap-oob="outerHTML"` + `id="detail-notes-section"` with both watch notes
- Manual: browser QA on a movie with two watches — notes listed, hover-edit opens correct watch, save updates in place
- Manual: notes modal closes on backdrop mousedown; drag-selecting text inside stays open

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
None. (The backdrop-dismiss pattern is also applied more broadly in the separate `modal-dismiss` PR #1016.)

