### PR TITLE
Fix integration test hangs from unmocked tmdb.metadata_languages() call

### DIFF
--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -84,6 +84,10 @@ class IntegrationTest(StaticLiveServerTestCase):
             ),
             patch("app.providers.tmdb.get_tvdb_episode_image_map", return_value={}),
             patch(
+                "app.providers.tmdb.metadata_languages",
+                return_value=[("", "Server Default (en)"), ("en", "English")],
+            ),
+            patch(
                 "app.tasks_trakt.populate_trakt_episode_ratings_for_season.delay",
             ),
         ):

--- a/src/app/tests/test_integration.py
+++ b/src/app/tests/test_integration.py
@@ -88,6 +88,10 @@ class IntegrationTest(StaticLiveServerTestCase):
                 return_value=[("", "Server Default (en)"), ("en", "English")],
             ),
             patch(
+                "app.providers.tmdb.carousel_media",
+                return_value={"video": None, "photos": []},
+            ),
+            patch(
                 "app.tasks_trakt.populate_trakt_episode_ratings_for_season.delay",
             ),
         ):


### PR DESCRIPTION
## Summary
- App Tests run #1138 failed 4 integration tests: `test_movie_split_track_modal_close_button_and_release_date`, `test_season_completed`, `test_season_progress_edit`, `test_tv_completed` — each timing out after 30s on unrelated actions (a "More tracking actions" click, a status `<select>`, a `/season/1` link).
- First fix attempt targeted `tmdb.metadata_languages()` (added by commit 560e00d, the PR's head commit at the time #1138 ran) since it looked like the newest unmocked TMDB call. That mock alone didn't turn CI green (confirmed against run #1142 on this PR — identical failures).
- Bisecting the App Tests history (every run from #1112 through #1142 failed) shows this exact 4-test signature was actually introduced by **9b5f7a2** (run #1122, "Add media details carousel with trailer/photo gallery and lightbox", fixes #850): run #1121 has no such failures, and every run since #1122 does, regardless of what each commit actually changed. `media_details_views.py` lazily loads the details-page carousel via a separate htmx fragment request that calls the live `tmdb.carousel_media()` for any TMDB movie/TV/season page. That call was never mocked in `IntegrationTest.setUp()`, so Playwright's real browser triggers a real, unmocked network request whenever a test opens one of these detail pages, blocking well past the 30s Playwright action timeout.
- Fix: mock both `tmdb.metadata_languages` and `tmdb.carousel_media` in the existing `provider_patch` tuple in `IntegrationTest.setUp()`, following the same pattern already used for `tmdb.search`, `tmdb.tv`, `tmdb.tv_with_seasons`, etc.

## AI Assistance
- Generated with Claude Sonnet 5.

## How It Was Tested
- `uv run --no-sync python src/manage.py test app.tests.test_integration.IntegrationTest.test_tv_completed app.tests.test_integration.IntegrationTest.test_season_completed app.tests.test_integration.IntegrationTest.test_season_progress_edit app.tests.test_integration.IntegrationTest.test_movie_split_track_modal_close_button_and_release_date` — all 4 previously-failing tests now pass (`Ran 4 tests in 37.219s / OK`).

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Fixes the App Tests failure first reported at run #1138; actual regression traced to #850 (run #1122).
