### PR TITLE
Add month and year selectors to the date picker

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -490,6 +490,33 @@ html.light .theme-toggle-icon-moon {
   gap: 0.125rem;
 }
 
+.date-picker-month-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.125rem;
+}
+
+.date-picker-year-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.125rem;
+}
+
+.date-picker-month-cell {
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+}
+
+.date-picker-year-input {
+  -moz-appearance: textfield;
+}
+
+.date-picker-year-input::-webkit-outer-spin-button,
+.date-picker-year-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .date-picker-day-cell {
   min-width: 2.25rem;
   min-height: 2.25rem;

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -5965,6 +5965,27 @@ html.light .theme-toggle-icon-moon {
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 0.125rem;
 }
+.date-picker-month-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.125rem;
+}
+.date-picker-year-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.125rem;
+}
+.date-picker-month-cell {
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+}
+.date-picker-year-input {
+  -moz-appearance: textfield;
+}
+.date-picker-year-input::-webkit-outer-spin-button, .date-picker-year-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
 .date-picker-day-cell {
   min-width: 2.25rem;
   min-height: 2.25rem;

--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -15,11 +15,13 @@ if (!window.__floppyDateTimePickerBound) {
     open: false,
     isMobile: false,
     popoverStyle: "",
+    pickerView: "days", // "days" | "months" | "years"
     viewYear: 0,
     viewMonth: 0,
     focusYear: 0,
     focusMonth: 0,
     focusDay: 1,
+    yearInput: "",
     hour24: 0,
     minute: 0,
     second: 0,
@@ -344,6 +346,63 @@ if (!window.__floppyDateTimePickerBound) {
       }
     },
 
+    showMonthsView() {
+      this.pickerView = "months";
+    },
+
+    showYearsView() {
+      this.yearInput = String(this.viewYear);
+      this.pickerView = "years";
+    },
+
+    showDaysView() {
+      this.pickerView = "days";
+    },
+
+    gotoMonth(monthIndex) {
+      this.viewMonth = monthIndex;
+      this.pickerView = "days";
+    },
+
+    gotoPrevYear() {
+      this.viewYear -= 1;
+      this.yearInput = String(this.viewYear);
+    },
+
+    gotoNextYear() {
+      this.viewYear += 1;
+      this.yearInput = String(this.viewYear);
+    },
+
+    onYearInput(event) {
+      const digits = event.target.value.replace(/\D/g, "").slice(0, 4);
+      this.yearInput = digits;
+      if (digits.length === 4) {
+        this.viewYear = Number(digits);
+      }
+    },
+
+    applyYearInput() {
+      const year = Number(this.yearInput);
+      if (Number.isInteger(year) && year >= 1000 && year <= 9999) {
+        this.viewYear = year;
+      } else {
+        this.yearInput = String(this.viewYear);
+      }
+      this.pickerView = "months";
+    },
+
+    monthShortLabel(monthIndex) {
+      return new Date(this.viewYear, monthIndex, 1).toLocaleDateString(undefined, {
+        month: "short",
+      });
+    },
+
+    yearRange() {
+      const start = Math.floor(this.viewYear / 20) * 20;
+      return Array.from({ length: 20 }, (_, i) => start + i);
+    },
+
     selectDay(cell) {
       if (!cell) {
         return;
@@ -564,6 +623,7 @@ if (!window.__floppyDateTimePickerBound) {
 
     openPicker() {
       this.open = true;
+      this.pickerView = "days";
       this.positionPopover();
       this.$nextTick(() => {
         this.positionPopover();

--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -71,15 +71,86 @@
     </div>
 
     <div class="flex items-center justify-between mb-2">
-      <button type="button" @click="gotoPrevMonth()" aria-label="Previous month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+      <button type="button" @click="gotoPrevMonth()" aria-label="Previous month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer" x-show="pickerView === 'days'">
         {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
       </button>
-      <span class="text-sm font-semibold text-[var(--color-text)]" x-text="monthLabel()"></span>
-      <button type="button" @click="gotoNextMonth()" aria-label="Next month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+      <button type="button"
+              @click="showMonthsView()"
+              aria-label="Select month"
+              class="text-sm font-semibold text-[var(--color-text)] hover:bg-[var(--color-surface-muted)] rounded-md px-2 py-1 cursor-pointer"
+              x-text="monthLabel()"></button>
+      <button type="button" @click="gotoNextMonth()" aria-label="Next month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer" x-show="pickerView === 'days'">
         {% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}
       </button>
     </div>
 
+    {% comment %} Month picker {% endcomment %}
+    <template x-if="pickerView === 'months'">
+      <div>
+        <div class="flex items-center justify-between mb-2">
+          <button type="button" @click="gotoPrevYear()" aria-label="Previous year" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+            {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
+          </button>
+          <button type="button"
+                  @click="showYearsView()"
+                  aria-label="Select year"
+                  class="text-sm font-semibold text-[var(--color-text)] hover:bg-[var(--color-surface-muted)] rounded-md px-2 py-1 cursor-pointer"
+                  x-text="viewYear"></button>
+          <button type="button" @click="gotoNextYear()" aria-label="Next year" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+            {% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}
+          </button>
+        </div>
+        <div class="date-picker-month-grid mb-1">
+          <template x-for="monthIndex in 12" :key="monthIndex">
+            <button type="button"
+                    @click="gotoMonth(monthIndex - 1)"
+                    :class="monthIndex - 1 === viewMonth ? 'bg-[var(--color-accent)] text-white' : 'text-[var(--color-text)] hover:bg-[var(--color-surface-muted)]'"
+                    class="date-picker-month-cell flex items-center justify-center rounded-md text-sm cursor-pointer transition-colors"
+                    x-text="monthShortLabel(monthIndex - 1)"></button>
+          </template>
+        </div>
+        <div class="mt-2 text-right">
+          <button type="button" @click="showDaysView()" class="text-sm text-[var(--color-link)] hover:text-[var(--color-link-hover)] underline cursor-pointer">Back</button>
+        </div>
+      </div>
+    </template>
+
+    {% comment %} Year picker {% endcomment %}
+    <template x-if="pickerView === 'years'">
+      <div>
+        <div class="flex items-center justify-between mb-2">
+          <button type="button" @click="gotoPrevYear()" aria-label="Previous year" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+            {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
+          </button>
+          <input type="text"
+                 inputmode="numeric"
+                 x-model="yearInput"
+                 @input="onYearInput($event)"
+                 @keydown.enter.prevent="applyYearInput()"
+                 @keydown.escape.prevent="showDaysView()"
+                 class="date-picker-year-input w-20 text-center text-sm font-semibold text-[var(--color-text)] bg-[var(--color-surface-strong)] border border-gray-600 rounded-md px-2 py-1 outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+                 aria-label="Year">
+          <button type="button" @click="gotoNextYear()" aria-label="Next year" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+            {% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}
+          </button>
+        </div>
+        <div class="date-picker-year-grid mb-1">
+          <template x-for="year in yearRange()" :key="year">
+            <button type="button"
+                    @click="viewYear = year; showMonthsView()"
+                    :class="year === viewYear ? 'bg-[var(--color-accent)] text-white' : 'text-[var(--color-text)] hover:bg-[var(--color-surface-muted)]'"
+                    class="date-picker-month-cell flex items-center justify-center rounded-md text-sm cursor-pointer transition-colors"
+                    x-text="year"></button>
+          </template>
+        </div>
+        <div class="mt-2 text-right">
+          <button type="button" @click="showMonthsView()" class="text-sm text-[var(--color-link)] hover:text-[var(--color-link-hover)] underline cursor-pointer">Back</button>
+        </div>
+      </div>
+    </template>
+
+    <template x-if="pickerView === 'days'">
+    <div>
     <div class="date-picker-calendar-grid mb-1">
       <template x-for="label in weekdayLabels()" :key="label">
         <div class="text-center text-xs text-[var(--color-text-muted)] py-1" x-text="label"></div>
@@ -157,6 +228,8 @@
         </template>
       </div>
     </div>
+    </div>
+    </template>
   </div>
 </div>
 {# djlint:on #}


### PR DESCRIPTION
## Summary
The date picker only let you step between months with the prev/next arrows — one month at a time. Jumping to a specific month or year meant many clicks, and there was no way to type a date.

This change adds month and year selectors to the picker:
- Clicking the **month label** (e.g. "May 2023") opens a **month grid** (all 12 months), then a **year grid** (a 20-year window).
- The year grid has **prev/next year arrows** plus a **text input** so you can jump straight to a year (Enter applies; digits only, 1000–9999).
- Selecting a month returns to the day view; the picker always **reopens on the day view**.
- Month/year grids reuse the picker's existing surface tokens and cell sizing.

**Before:** month label was static text; only arrows navigated one month at a time.
**After:** click the month label to pick month/year directly.

<img width="250" alt="day" src="https://github.com/user-attachments/assets/0d8dbb8a-2bd9-4d04-99a8-9077676a2af1" />

<img width="250" alt="month" src="https://github.com/user-attachments/assets/04a88882-1d52-404b-89e3-ee82e8e596a9" />

<img width="250" alt="year" src="https://github.com/user-attachments/assets/88675de9-cac6-435f-86a7-4800ab5f15cc" />

## AI Assistance

Code generated and reviewed with an AI coding agent using model `deepseek-v4-flash` (opencode agent). Workflow: inspection of the Alpine date picker, Node simulation of the month/year navigation logic, and render checks.

## How It Was Tested
- `node --check src/static/js/dateTimePicker.js` → passed
- `node` simulation of `gotoMonth`, `gotoPrevYear`/`gotoNextYear`, `onYearInput`, `applyYearInput`, and `yearRange` → correct
- `djlint src/templates/app/components/date_time_picker.html` → passed
- Tailwind rebuilt `src/static/css/main.css` (only the new grid/input classes added)
- Manual browser check of the picker month/year grids

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
None.
