### PR TITLE
Close the date picker on outside mousedown on desktop

### DIFF
--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -12,7 +12,8 @@
      })"
      x-init="init"
      {% if suggestion_date_expr %}x-effect="suggestionDate = ({{ suggestion_date_expr }}) || ''"{% endif %}
-     @keydown.escape.window="open && closePicker()">
+     @keydown.escape.window="open && closePicker()"
+     @mousedown.outside="open && !isMobile && closePicker()">
 
   <div class="flex-1 flex items-stretch border border-gray-600 rounded-md bg-[var(--color-surface-strong)] focus-within:ring-2 focus-within:ring-[var(--color-accent)]">
     {% if mobile_label %}
@@ -56,7 +57,6 @@
        :aria-modal="isMobile ? 'true' : 'false'"
        aria-label="{{ field_label|default:'Date' }} picker"
        @keydown.tab="trapFocus($event)"
-       @click.outside="!isMobile && !$refs.trigger.contains($event.target) && closePicker()"
        :style="popoverStyle"
        class="date-picker-popover fixed inset-x-0 bottom-0 rounded-t-xl max-h-[85dvh] overflow-y-auto overscroll-contain bg-[var(--color-surface)] border-t border-[var(--color-border)] shadow-2xl p-4 sm:inset-x-auto sm:bottom-auto sm:w-[22rem] sm:rounded-lg sm:border"
        x-transition:enter="transition ease-out duration-150"


### PR DESCRIPTION
## Summary
The date picker's outside-click dismissal was broken — clicking outside the picker never closed it, on any platform. The old `@click.outside` handler lived on the popover panel and failed to fire reliably for this fixed-position element.

The picker now closes on `@mousedown.outside` on its **root**: pressing outside closes it immediately, and a press inside (e.g. to select text) never dismisses it.

The **original mobile behavior is preserved**: outside-click dismissal stays desktop-only (`!isMobile`); narrow viewports still use the bottom-sheet overlay to close.

## AI Assistance
Code generated and reviewed with an AI coding agent using model `deepseek-v4-flash` (opencode agent).

## How It Was Tested
- `node --check src/static/js/dateTimePicker.js` → passed
- `djlint src/templates/app/components/date_time_picker.html` → passed
- Manual browser check: press outside closes on mousedown (desktop)

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
None.
