### PR TITLE
Add copy-between-dates to the track modal date pickers

### DIFF
--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -10,6 +10,7 @@ if (!window.__floppyDateTimePickerBound) {
     suggestionLabel: config.suggestionLabel || "",
     suggestionDate: config.suggestionDate || "",
     suggestionRuntimeMinutes: config.suggestionRuntimeMinutes || "",
+    copyFrom: config.copyFrom || "",
 
     value: config.initialValue || "",
     open: false,
@@ -468,6 +469,67 @@ if (!window.__floppyDateTimePickerBound) {
       this.backfillStartDateIfNeeded();
     },
 
+    copyFromOther() {
+      if (!this.copyFrom) {
+        return;
+      }
+      const form = this.$refs.hiddenInput.closest("form");
+      if (!form) {
+        return;
+      }
+      const sourceInput = form.querySelector(`[name="${this.copyFrom}"]`);
+      if (!sourceInput || !sourceInput.value) {
+        return;
+      }
+      const sourceParts = this.partsFor(sourceInput.value);
+      if (!sourceParts) {
+        return;
+      }
+      // The form's progress-based start-date auto-fill recomputes start_date
+      // from end_date on every end_date change. A copy is an explicit user
+      // intent, so suppress that auto-fill for this commit regardless of which
+      // field we are writing, otherwise the copied value gets overwritten.
+      if (form && window.Alpine) {
+        try {
+          Alpine.$data(form).manualStartDate = true;
+        } catch {
+          // Ignore Alpine lookup failures.
+        }
+      }
+      this.commit(
+        this.formatValueFromParts(
+          sourceParts.y,
+          sourceParts.m,
+          sourceParts.d,
+          sourceParts.h,
+          sourceParts.min,
+          sourceParts.s,
+        ),
+      );
+      this.backfillStartDateIfNeeded();
+    },
+
+    partsFor(value) {
+      if (!value) {
+        return null;
+      }
+      const [datePart, timePart] = value.trim().split(/[T ]/, 2);
+      const [y, m, d] = datePart.split("-").map(Number);
+      if ([y, m, d].some(Number.isNaN)) {
+        return null;
+      }
+      let h = 0;
+      let min = 0;
+      let s = 0;
+      if (timePart) {
+        const segments = timePart.split(":").map(Number);
+        h = segments[0] || 0;
+        min = segments[1] || 0;
+        s = segments[2] || 0;
+      }
+      return { y, m, d, h, min, s };
+    },
+
     backfillStartDateIfNeeded() {
       const runtimeMinutes = Number.parseInt(this.suggestionRuntimeMinutes, 10);
       if (
@@ -483,6 +545,15 @@ if (!window.__floppyDateTimePickerBound) {
       const startInput = form?.querySelector('[name="start_date"]');
       if (!startInput || startInput === this.$refs.hiddenInput) {
         return;
+      }
+      if (form && window.Alpine) {
+        try {
+          if (Alpine.$data(form).manualStartDate) {
+            return;
+          }
+        } catch {
+          // Ignore Alpine lookup failures.
+        }
       }
 
       const parts = this.parts();

--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -7,6 +7,7 @@
        suggestionLabel: '{{ suggestion_label|default:""|escapejs }}',
        suggestionDate: '{{ suggestion_date|default:""|escapejs }}',
        suggestionRuntimeMinutes: '{{ suggestion_runtime_minutes|default:""|escapejs }}',
+       copyFrom: '{{ copy_from|default:""|escapejs }}',
        weekStart: '{{ week_start|default:"monday" }}',
        use12Hour: {{ use_12_hour|yesno:'true,false' }}
      })"
@@ -155,6 +156,12 @@
             <span x-text="resolvedSuggestionLabel()"></span>
           </button>
         </template>
+        {% if copy_from %}
+        <button type="button" @click="copyFromOther()" class="date-picker-common-time-button">
+          {% include "app/icons/copy.svg" with classes="w-3.5 h-3.5" %}
+          Copy from {{ copy_from_label|default:copy_from }}
+        </button>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/src/templates/app/components/fill_track.html
+++ b/src/templates/app/components/fill_track.html
@@ -125,9 +125,9 @@
                       </button>
                     </div>
                   {% elif field.name == "start_date" %}
-                    {% include "app/components/date_time_picker.html" with field_name=field.name field_value=field.value|default_if_none:"" field_id=field.id_for_label field_label=field.label mobile_label="Start:" track_time=TRACK_TIME suggestion_label=date_suggestion.label suggestion_date=date_suggestion.date suggestion_runtime_minutes=date_suggestion.runtime_minutes week_start=user.week_start_day use_12_hour=user|user_uses_12_hour_format only %}
+                    {% include "app/components/date_time_picker.html" with field_name=field.name field_value=field.value|default_if_none:"" field_id=field.id_for_label field_label=field.label mobile_label="Start:" track_time=TRACK_TIME suggestion_label=date_suggestion.label suggestion_date=date_suggestion.date suggestion_runtime_minutes=date_suggestion.runtime_minutes week_start=user.week_start_day use_12_hour=user|user_uses_12_hour_format copy_from="end_date" copy_from_label="End" only %}
                   {% elif field.name == "end_date" %}
-                    {% include "app/components/date_time_picker.html" with field_name=field.name field_value=field.value|default_if_none:"" field_id=field.id_for_label field_label=field.label mobile_label="End:" track_time=TRACK_TIME suggestion_label=date_suggestion.label suggestion_date=date_suggestion.date suggestion_runtime_minutes=date_suggestion.runtime_minutes week_start=user.week_start_day use_12_hour=user|user_uses_12_hour_format only %}
+                    {% include "app/components/date_time_picker.html" with field_name=field.name field_value=field.value|default_if_none:"" field_id=field.id_for_label field_label=field.label mobile_label="End:" track_time=TRACK_TIME suggestion_label=date_suggestion.label suggestion_date=date_suggestion.date suggestion_runtime_minutes=date_suggestion.runtime_minutes week_start=user.week_start_day use_12_hour=user|user_uses_12_hour_format copy_from="start_date" copy_from_label="Start" only %}
                   {% else %}
                     {{ field|add_class:"w-full p-2 bg-[var(--color-surface-strong)] rounded-md text-[var(--color-text)] text-sm border border-gray-600 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]" }}
                   {% endif %}


### PR DESCRIPTION
## Summary
In the track modal, the Start and End date pickers are independent — setting both for a watch that started and ended the same day meant picking the date twice (and the time separately).

This change adds a **"Copy from End"** button to the Start picker and a **"Copy from Start"** button to the End picker, in each picker's footer (after Now / None / the suggestion button). It copies the other field's date **and time** into the current field, so you pick once and then adjust the time if needed.

It also suppresses the progress-based start-date auto-fill during a copy: normally, changing the end date recomputes the start date from the runtime. A copy is explicit user intent, so the copied value is kept as-is rather than being overwritten by that auto-fill.

**Before:** picking Start and End dates required selecting each date and time separately.
**After:** pick one, click "Copy from ..." to reuse it in the other field.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/4866d355-1ed2-41d0-8a18-db76f5d4ced6" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3c295cc5-efc5-46af-9b85-34a9b9468d4d" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/2b6c6e86-4ccf-4d3a-ab64-eb8c23b52f75" />


## AI Assistance
Code generated and reviewed with an AI coding agent using model `deepseek-v4-flash` (opencode agent). Workflow: inspection of the date picker and the track modal's start/end date handling, Node simulation of the copy logic.

## How It Was Tested
- `node --check src/static/js/dateTimePicker.js` → passed
- `node` simulation of `copyFromOther` → copies the source date/time correctly
- `djlint src/templates/app/components/date_time_picker.html fill_track.html` → passed
- Manual browser check (optional): copy Start→End and End→Start, verify the copied value isn't recomputed

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
None.

