### PR TITLE
Keep grouped-anime links on the anime route when served from cache

### DIFF
--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -268,6 +268,25 @@ def _hydrate_media_list_page(user, media_type, order_slice):
         if item is None:
             continue
         entries.append(MediaListEntry(item=item, media=None))
+
+    # Grouped anime (TV items in the anime bucket) are surfaced in the anime
+    # list via the warm-cache hydration path too. _mark_grouped_anime_route is
+    # applied at cache-build time, but hydration rebuilds media objects from
+    # their pks and would otherwise lose the route_media_type annotation, so
+    # grouped-anime rows must be re-marked here to keep their links on the
+    # anime route (e.g. /details/tmdb/anime/...) instead of the TV route.
+    if media_type == MediaTypes.ANIME.value:
+        _mark_grouped_anime_route(
+            [
+                entry.media
+                for entry in entries
+                if entry.media is not None
+                and getattr(entry.media, "item", None) is not None
+                and entry.media.item.library_media_type
+                == MediaTypes.ANIME.value
+            ],
+        )
+
     return entries
 
 


### PR DESCRIPTION
## Summary
Grouped anime shows (TV items stored in the `anime` library bucket) link to the **TV detail route** (`/details/tmdb/tv/...`) instead of the **anime route** (`/details/tmdb/anime/...`) when the anime list is served from its warm cache. Clicking such a card shows "Add to tracker" even though the show is tracked, because the TV route intentionally excludes anime-bucketed items.

**Root cause:** The anime list builds grouped-anime rows by calling `_mark_grouped_anime_route`, which sets `route_media_type = anime` on the media/item objects at **cache-build time**. But when the list is served from the warm order cache, `_hydrate_media_list_page` rebuilds the media objects from their primary keys and **loses that annotation** — so the `media_url` filter falls back to the TV route.

**Fix:** `_hydrate_media_list_page` now re-applies `_mark_grouped_anime_route` to hydrated entries whose items are `library_media_type = anime` (only when the requested media type is `anime`), so grouped-anime links stay on the anime route regardless of cache state.

**Before:** anime list card for a grouped anime links to `/details/tmdb/tv/<id>/...` (shows "Add to tracker") when served from cache.
**After:** always links to `/details/tmdb/anime/<id>/...` (shows the tracked status).

## AI Assistance
Code generated and reviewed with an AI coding agent using model `deepseek-v4-flash` (opencode agent).

## How It Was Tested
- Verified the served anime list link for a grouped anime:
  - Cold cache → `/details/tmdb/anime/209867/frieren-beyond-journeys-end` ✅
  - Warm cache → `/details/tmdb/anime/209867/frieren-beyond-journeys-end` ✅ (was `/tmdb/tv/`)
- `_hydrate_media_list_page` simulation: hydrated grouped-anime entries get `route_media_type = anime` ✅
- `ruff check src/app/media_list_views.py` → passed
- `test_track_modal` → passed
- `test_grouped_anime` → passed

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
None.

