### PR TITLE
Fix watch notes not reaching the page after a save

### DIFF
--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime
 from django.views.decorators.http import require_GET, require_POST
@@ -378,9 +379,11 @@ def media_save(request):
                     response.write(
                         _render_notes_section_oob(
                             request,
-                            request.user,
-                            media.item,
-                            media,
+                            media.__class__.objects.filter(
+                                user=request.user,
+                                item=media.item,
+                            ),
+                            media=media.item,
                         ),
                     )
             except Exception:
@@ -688,30 +691,41 @@ def _render_season_progress_oob(related_season):
     return spans
 
 
-def _render_notes_section_oob(request, user, item, instance):
+def _render_notes_section_oob(
+    request,
+    entries,
+    *,
+    media=None,
+    detail_notes_target_id="",
+    detail_notes_modal_url="",
+    detail_return_url="",
+):
     """Render the detail notes section as an OOB swap after a watch save.
 
     The notes section lists one block per watch (see detail_notes_section),
     so a note edited in the track modal must be pushed back into the page
     without a full reload.
+
+    The caller supplies the watches rather than this building the queryset:
+    Episode has no `user` field (it is scoped through related_season), so a
+    single `filter(user=...)` here cannot serve both the media and episode
+    save paths. The modal ids are caller-supplied for the same reason — the
+    episode page namespaces its modal targets differently from the movie,
+    season and show pages.
     """
     return render_to_string(
         "app/components/detail_notes_section.html",
         {
             "notes_entries": [
-                entry
-                for entry in instance.__class__.objects.filter(
-                    user=user, item=item
-                )
-                if entry.notes and entry.notes.strip()
+                entry for entry in entries if entry.notes and entry.notes.strip()
             ],
-            "media": item,
-            "user": user,
+            "media": media,
+            "user": request.user,
             "public_notes_view": False,
             "public_view": False,
-            "detail_return_url": "",
-            "detail_notes_modal_url": "",
-            "detail_notes_target_id": "",
+            "detail_return_url": detail_return_url,
+            "detail_notes_modal_url": detail_notes_modal_url,
+            "detail_notes_target_id": detail_notes_target_id,
             "notes_section_oob": True,
         },
         request=request,
@@ -810,6 +824,35 @@ def _write_episode_save_oob(
         response.write(
             _render_track_action_oob(request, related_season, parsed_next),
         )
+        # The episode page lists every watch note, same as the movie/season
+        # pages, so an edited note has to be pushed back the same way. Episode
+        # rows are scoped by season rather than by user, and the page namespaces
+        # its modal targets per episode, so both are passed in explicitly.
+        if episode.item_id:
+            response.write(
+                _render_notes_section_oob(
+                    request,
+                    Episode.objects.filter(
+                        related_season=related_season,
+                        item=episode.item,
+                    ).select_related("item"),
+                    media=episode.item,
+                    detail_notes_target_id=(
+                        f"episode-notes-modal-{source}-{media_id}"
+                        f"-{season_number}-{episode_number}"
+                    ),
+                    detail_notes_modal_url=reverse(
+                        "track_modal",
+                        kwargs={
+                            "source": source,
+                            "media_type": MediaTypes.EPISODE.value,
+                            "media_id": media_id,
+                            "season_number": season_number,
+                        },
+                    ),
+                    detail_return_url=parsed_next,
+                ),
+            )
         # Season-progress spans only exist on the season page — nothing to target here.
         return
 

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 from urllib.parse import urlparse
@@ -6273,6 +6274,361 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["notes_entry"].notes, "Public episode note")
         self.assertContains(response, "Public episode note")
+
+    @patch("integrations.tasks.fetch_collection_metadata_for_item.delay")
+    @patch("app.views.credits.sync_item_credits_from_metadata")
+    @patch("app.views.metadata_utils.apply_item_metadata", return_value=[])
+    @patch("app.providers.services.get_media_metadata")
+    def test_first_saved_note_swaps_into_a_pre_existing_section(
+        self,
+        mock_get_metadata,
+        _mock_apply_item_metadata,
+        _mock_sync_credits,
+        _mock_fetch_delay,
+    ):
+        """The notes section anchor exists before there is any note to show.
+
+        media_save returns the section as an hx-swap-oob fragment. htmx drops an
+        OOB fragment whose target is not already in the DOM, so gating the
+        section on having a note meant the *first* note saved never appeared
+        until a reload.
+        """
+        mock_get_metadata.return_value = {
+            "media_id": "238",
+            "title": "Test Movie",
+            "media_type": MediaTypes.MOVIE.value,
+            "source": Sources.TMDB.value,
+            "image": "http://example.com/image.jpg",
+            "synopsis": "Test overview",
+            "max_progress": 1,
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        item = Item.objects.create(
+            media_id="238",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Test Movie",
+            image="http://example.com/image.jpg",
+        )
+        Movie.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+        )
+
+        fragment = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_type": MediaTypes.MOVIE.value,
+                    "media_id": item.media_id,
+                    "title": "test-movie",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(fragment.status_code, 200)
+        # The anchor is present with no notes yet, and carries no stray heading.
+        self.assertContains(fragment, 'id="detail-notes-section"', html=False)
+        self.assertNotContains(
+            fragment, '<h2 class="text-xl font-bold">Your Notes</h2>', html=False
+        )
+
+        saved = self.client.post(
+            reverse("media_save"),
+            {
+                "media_id": item.media_id,
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.MOVIE.value,
+                "status": Status.COMPLETED.value,
+                "progress": 1,
+                "repeats": 0,
+                "notes": "First note ever",
+            },
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(saved.status_code, 200)
+        body = saved.content.decode()
+        section = body[body.index('id="detail-notes-section"') :]
+        self.assertIn('hx-swap-oob="outerHTML"', section)
+        self.assertIn('<h2 class="text-xl font-bold">Your Notes</h2>', section)
+        self.assertIn("First note ever", section)
+
+    @patch("integrations.tasks.fetch_collection_metadata_for_item.delay")
+    @patch("app.views.credits.sync_item_credits_from_metadata")
+    @patch("app.views.metadata_utils.apply_item_metadata", return_value=[])
+    @patch("app.providers.services.get_media_metadata")
+    def test_clearing_the_last_note_leaves_no_bare_heading(
+        self,
+        mock_get_metadata,
+        _mock_apply_item_metadata,
+        _mock_sync_credits,
+        _mock_fetch_delay,
+    ):
+        """The mirror case: an emptied section must not keep its heading."""
+        mock_get_metadata.return_value = {
+            "media_id": "238",
+            "title": "Test Movie",
+            "media_type": MediaTypes.MOVIE.value,
+            "source": Sources.TMDB.value,
+            "image": "http://example.com/image.jpg",
+            "synopsis": "Test overview",
+            "max_progress": 1,
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        item = Item.objects.create(
+            media_id="238",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Test Movie",
+            image="http://example.com/image.jpg",
+        )
+        movie = Movie.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+            notes="Soon to be cleared",
+        )
+
+        saved = self.client.post(
+            reverse("media_save"),
+            {
+                "media_id": item.media_id,
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.MOVIE.value,
+                "status": Status.COMPLETED.value,
+                "progress": 1,
+                "repeats": 0,
+                "instance_id": movie.id,
+                "notes": "",
+            },
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(saved.status_code, 200)
+        body = saved.content.decode()
+        section = body[body.index('id="detail-notes-section"') :]
+        self.assertIn('hx-swap-oob="outerHTML"', section)
+        self.assertNotIn('<h2 class="text-xl font-bold">Your Notes</h2>', section)
+
+    def test_editing_an_episode_note_swaps_the_section_back(self):
+        """Episode saves push the notes section back like movie saves do.
+
+        Episode rows are scoped through related_season rather than a `user`
+        field, so the notes OOB helper cannot build its own `filter(user=...)`
+        queryset — episodes were left out entirely and an edited note only
+        showed up after a reload.
+        """
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test TV Show",
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Season 1",
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="Episode 1",
+        )
+        episode = Episode.objects.create(
+            item=episode_item,
+            related_season=season,
+            notes="note before the edit",
+            end_date=datetime(2026, 8, 1, tzinfo=UTC),
+        )
+
+        next_path = reverse(
+            "episode_details",
+            kwargs={
+                "source": Sources.TMDB.value,
+                "media_id": "1668",
+                "title": "test-tv-show",
+                "season_number": 1,
+                "episode_number": 1,
+            },
+        )
+        response = self.client.post(
+            f"{reverse('episode_save')}?next={next_path}",
+            {
+                "media_id": "1668",
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.EPISODE.value,
+                "season_number": 1,
+                "episode_number": 1,
+                "instance_id": episode.id,
+                "status": Status.COMPLETED.value,
+                "end_date": "2026-08-01T00:00",
+                "notes": "note after the edit",
+            },
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('id="detail-notes-section"', body)
+        section = body[body.index('id="detail-notes-section"') :]
+        self.assertIn('hx-swap-oob="outerHTML"', section)
+        self.assertIn("note after the edit", section)
+        self.assertNotIn("note before the edit", section)
+        # The swapped-in blocks must keep the episode page's own modal
+        # namespace, not fall back to the movie/season component ids.
+        self.assertIn(
+            f"episode-notes-modal-tmdb-1668-1-1-{episode.id}",
+            section,
+        )
+
+    @patch("app.views.tmdb.episode", return_value={})
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
+    def test_episode_notes_blocks_get_distinct_modal_targets(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+        _mock_episode,
+    ):
+        """Every watch note renders its own edit-modal target.
+
+        The target id is built by concatenating the episode's modal id with the
+        watch's pk. Django's `add` filter returns "" for str + int, so an
+        unstringified pk silently emptied every id and left the edit buttons
+        pointing at "#".
+        """
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test TV Show",
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Season 1",
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="Episode 1",
+        )
+        watches = [
+            Episode.objects.create(
+                item=episode_item,
+                related_season=season,
+                notes=f"Watch note {index}",
+                end_date=datetime(2026, 8, index, tzinfo=UTC),
+            )
+            for index in (1, 2)
+        ]
+
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Test TV Show",
+            "media_id": "1668",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Season 1",
+                "season_title": "Season 1",
+                "media_id": "1668",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TMDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [{"episode_number": 1}],
+            },
+        }
+        mock_process_episodes.return_value = [
+            {
+                "media_id": "1668",
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.EPISODE.value,
+                "season_number": 1,
+                "episode_number": 1,
+                "title": "Episode 1",
+                "air_date": "2023-01-01",
+                "watched": True,
+                "history": watches,
+            },
+        ]
+
+        response = self.client.get(
+            reverse(
+                "episode_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "test-tv-show",
+                    "season_number": 1,
+                    "episode_number": 1,
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [entry.notes for entry in response.context["notes_entries"]],
+            ["Watch note 1", "Watch note 2"],
+        )
+
+        html = response.content.decode()
+        section = html[html.index('id="detail-notes-section"') :]
+        targets = re.findall(r'hx-target="#([^"]*)"', section)
+        anchors = re.findall(r'<div id="([^"]*)"></div>', section)
+
+        expected = [
+            f"{response.context['episode_notes_modal_target_id']}-{watch.pk}"
+            for watch in watches
+        ]
+        self.assertEqual(targets, expected)
+        self.assertEqual(anchors, expected)
 
     @patch("app.providers.services.get_media_metadata")
     @patch("app.providers.tmdb.process_episodes")

--- a/src/templates/app/components/detail_notes_block.html
+++ b/src/templates/app/components/detail_notes_block.html
@@ -1,10 +1,18 @@
 {% load app_tags %}
 {% load user_tags %}
 
+{% comment %}
+  canHover keys the edit affordance off the pointer's actual capability rather
+  than a width breakpoint: a touch device never fires mouseenter, so a
+  hover-only button is unreachable there, and a large tablet would defeat a
+  min-width proxy. focusin/focusout keep it reachable by keyboard too.
+{% endcomment %}
 <div class="mb-2"
-     x-data="{ hovered: false, trackOpen: false }"
+     x-data="{ hovered: false, trackOpen: false, canHover: window.matchMedia('(hover: hover)').matches }"
      @mouseenter="hovered = true"
-     @mouseleave="hovered = false">
+     @mouseleave="hovered = false"
+     @focusin="hovered = true"
+     @focusout="if (!$el.contains($event.relatedTarget)) hovered = false">
   <div x-show="trackOpen"
        @mousedown.self="trackOpen = false"
        @keydown.escape.window="trackOpen = false"
@@ -25,7 +33,7 @@
        x-init="$nextTick(() => checkClamp())">
     {% if not public_notes_view|default:False %}
     <div class="absolute top-2 right-2 z-10"
-         x-show="hovered"
+         x-show="!canHover || hovered"
          x-transition.opacity.duration.150ms
          style="display: none;">
       <button type="button"

--- a/src/templates/app/components/detail_notes_section.html
+++ b/src/templates/app/components/detail_notes_section.html
@@ -1,22 +1,39 @@
 {% load app_tags %}
 {% load user_tags %}
 
-<section id="detail-notes-section" class="mb-8" {% if notes_section_oob %}hx-swap-oob="outerHTML"{% endif %}>
-  <div class="mb-4 flex items-center gap-2">
-    <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
-  </div>
+{% comment %}
+  The section element renders even with no notes, and is deliberately inert when
+  empty: it is the OOB target media_save swaps into, so it has to already exist
+  in the DOM the first time a note is saved. Gating it on having a note meant
+  htmx found no target and dropped the fragment, and the note only appeared on a
+  reload. The heading is inside the emptiness check for the mirror case — the
+  last note being cleared must not leave a bare "Your Notes" behind.
+{% endcomment %}
+<section id="detail-notes-section" class="{% if notes_entries or notes_entry %}mb-8{% endif %}" {% if notes_section_oob %}hx-swap-oob="outerHTML"{% endif %}>
+  {% if notes_entries or notes_entry %}
+    <div class="mb-4 flex items-center gap-2">
+      <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
+    </div>
+  {% endif %}
 
   {% for entry in notes_entries %}
-    {% with notes_modal_id=entry.id|stringformat:"s"|add:"-notes" notes_content_id=entry.id|stringformat:"s"|add:"-notes-content" %}
+    {% comment %}
+      entry_id must be stringified before it is concatenated below: Django's
+      `add` filter returns "" for str + int, which silently emptied the modal
+      target id and left the edit button pointing at "#".
+    {% endcomment %}
+    {% with entry_id=entry.id|stringformat:"s" %}
+    {% with notes_modal_id=entry_id|add:"-notes" notes_content_id=entry_id|add:"-notes-content" %}
       {{ entry.notes|json_script:notes_content_id }}
       {% if detail_notes_target_id %}
-        {% with notes_modal_target_id=detail_notes_target_id|add:"-"|add:entry.id %}
+        {% with notes_modal_target_id=detail_notes_target_id|add:"-"|add:entry_id %}
           {% include "app/components/detail_notes_block.html" with entry=entry notes_modal_target_id=notes_modal_target_id %}
         {% endwith %}
       {% else %}
         {% component_id 'track' media notes_modal_id as notes_modal_target_id %}
         {% include "app/components/detail_notes_block.html" with entry=entry notes_modal_target_id=notes_modal_target_id %}
       {% endif %}
+    {% endwith %}
     {% endwith %}
   {% empty %}
     {% if notes_entry %}

--- a/src/templates/app/components/detail_secondary_content.html
+++ b/src/templates/app/components/detail_secondary_content.html
@@ -327,9 +327,11 @@
 
     {# Related Media #}
     {% if media_type != MediaTypes.PODCAST.value %}
-      {% if notes_entry or media.related or media.cast or media.crew or media_type == MediaTypes.GAME.value or media.episodes %}
+      {% if show_notes|default:False or media.related or media.cast or media.crew or media_type == MediaTypes.GAME.value or media.episodes %}
         <div class="w-full md:w-3/4">
-        {% if show_notes|default:False and notes_entry %}
+        {# Rendered even with no notes yet: the empty section is the anchor the #}
+        {# post-save OOB swap replaces, so it must pre-exist in the DOM. #}
+        {% if show_notes|default:False %}
           {% include "app/components/detail_notes_section.html" %}
         {% endif %}
         {% if media.related %}

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -295,8 +295,9 @@
   </div>
 </div>
 
-{# Your Notes — same component the movie/season pages use, pointed at the watch that carries the note. #}
-{% if show_notes and notes_entry %}
+{# Your Notes — same component the movie/season pages use, listing every watch that carries a note. #}
+{# Rendered even with no notes yet: the empty section is the anchor episode_save's OOB swap replaces. #}
+{% if show_notes %}
   {% include "app/components/detail_notes_section.html" with notes_entries=notes_entries notes_entry=notes_entry detail_notes_target_id=episode_notes_modal_target_id detail_notes_modal_url=episode_notes_modal_url detail_return_url=detail_return_url public_notes_view=public_notes_view %}
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Follow-up to #1012. Three defects in the multi-watch notes section, each found by review after that PR merged.
- At the episodes notes, **the per-note edit button pointed at `#`.** The modal target id was built with `detail_notes_target_id|add:"-"|add:entry.id`, and Django's `add` filter returns `""` for `str + int` (it tries `int()`, hits `ValueError`, then the concatenation raises `TypeError`, and the filter swallows both). Every note block on an episode page rendered `hx-target="#"` plus a duplicate empty `id`, so the button did nothing. The pk is now stringified before it is concatenated.
- **The first note saved never appeared.** `media_save` returns the section as an `hx-swap-oob` fragment, but htmx drops an OOB fragment whose target is not already in the DOM — and the section was only rendered once a note existed. The section element is now always rendered, inert when empty, so it can serve as the anchor. The heading moved inside the emptiness check, which also stops a cleared last note from leaving a bare "Your Notes" behind.
- **Episode notes never updated at all.** `_render_notes_section_oob` was only called from `media_save`, and as written it could not have served `episode_save`: `Episode` has no `user` field (it is scoped through `related_season`), so its `filter(user=...)` would have raised `FieldError` — and inside that `except Exception` the whole save response degrades silently to a minimal confirmation. The helper now takes the watches and the modal ids from its caller, and `_write_episode_save_oob` passes the episode page's own modal namespace.
- Also keeps the edit affordance reachable without a hover pointer. Moving it from the section header into each note block put it behind `x-show="hovered"`, fed only by `mouseenter`/`mouseleave`; a touch device never fires those, so the only way to edit a note was unreachable there, and keyboard users could not reach it either. It now also shows when the pointer cannot hover, following the pattern already used for the home-screen row controls — keyed on `(hover: hover)` rather than a width breakpoint, because a large tablet clears any width threshold while still having no hover.

No user-visible layout change, so no before/after screenshots: the visible difference is that buttons which previously did nothing now work.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_details` -> Passed (143 tests, OK). Includes 4 new regression tests, each confirmed to fail against the pre-fix code:
  - `test_episode_notes_blocks_get_distinct_modal_targets` — pre-fix produced `hx-target` `['', '']`; now one unique target per watch, each matching its own anchor.
  - `test_first_saved_note_swaps_into_a_pre_existing_section` — pre-fix the anchor was absent, so the OOB fragment was dropped.
  - `test_clearing_the_last_note_leaves_no_bare_heading`
  - `test_editing_an_episode_note_swaps_the_section_back` — pre-fix the response carried the track button, rating chip and track-action fragments but no notes section at all.
- `SECRET=test-only scripts/test.sh app.tests.views.test_crud` -> 5 failures, **identical on `latest` with this branch checked out or not**. They are TMDB calls in a sandbox with no outbound network (`UnexpectedExternalNetworkAccessError`), not caused by this change.
- Manual browser check that OOB-swapped note blocks hydrate their markdown correctly after a save.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`) -> Passed
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #1012
