### PR TITLE
Fix escape handling and year paging in the date picker

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -507,16 +507,6 @@ html.light .theme-toggle-icon-moon {
   min-height: 2.25rem;
 }
 
-.date-picker-year-input {
-  -moz-appearance: textfield;
-}
-
-.date-picker-year-input::-webkit-outer-spin-button,
-.date-picker-year-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 .date-picker-day-cell {
   min-width: 2.25rem;
   min-height: 2.25rem;

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -5979,13 +5979,6 @@ html.light .theme-toggle-icon-moon {
   min-width: 2.25rem;
   min-height: 2.25rem;
 }
-.date-picker-year-input {
-  -moz-appearance: textfield;
-}
-.date-picker-year-input::-webkit-outer-spin-button, .date-picker-year-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
 .date-picker-day-cell {
   min-width: 2.25rem;
   min-height: 2.25rem;

--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -1,6 +1,12 @@
 // Bind once: this script is re-evaluated on boosted (hx-boost) navigation.
 if (!window.__floppyDateTimePickerBound) {
   window.__floppyDateTimePickerBound = true;
+
+  // Declared inside the guard, not at file scope: a top-level const would
+  // throw "already been declared" the second time this file is evaluated.
+  // Years shown per page in the year grid, which is laid out four to a row,
+  // so this wants to stay a multiple of four.
+  const YEAR_PAGE_SIZE = 20;
   document.addEventListener("alpine:init", () => {
   Alpine.data("dateTimePicker", (config) => ({
     fieldName: config.fieldName,
@@ -375,6 +381,19 @@ if (!window.__floppyDateTimePickerBound) {
       this.yearInput = String(this.viewYear);
     },
 
+    // The year grid pages in YEAR_PAGE_SIZE blocks, so its chevrons have to
+    // step by a whole block. Stepping by one year there mostly appears to do
+    // nothing: the grid only shifts on the years that straddle a boundary.
+    gotoPrevYearPage() {
+      this.viewYear -= YEAR_PAGE_SIZE;
+      this.yearInput = String(this.viewYear);
+    },
+
+    gotoNextYearPage() {
+      this.viewYear += YEAR_PAGE_SIZE;
+      this.yearInput = String(this.viewYear);
+    },
+
     onYearInput(event) {
       const digits = event.target.value.replace(/\D/g, "").slice(0, 4);
       this.yearInput = digits;
@@ -400,8 +419,8 @@ if (!window.__floppyDateTimePickerBound) {
     },
 
     yearRange() {
-      const start = Math.floor(this.viewYear / 20) * 20;
-      return Array.from({ length: 20 }, (_, i) => start + i);
+      const start = Math.floor(this.viewYear / YEAR_PAGE_SIZE) * YEAR_PAGE_SIZE;
+      return Array.from({ length: YEAR_PAGE_SIZE }, (_, i) => start + i);
     },
 
     selectDay(cell) {
@@ -712,6 +731,34 @@ if (!window.__floppyDateTimePickerBound) {
       }
       this.open = false;
       this.$refs.trigger?.focus();
+    },
+
+    // Escape has to be consumed here or it also reaches the track modal
+    // enclosing the picker, which closes itself on a window-level escape of
+    // its own. Both listeners sit on window, so stopPropagation from an
+    // ordinary handler cannot win - the event reaches window once and every
+    // listener on it fires. This is bound in the capture phase instead, which
+    // runs before the target and before any bubble-phase window listener, so
+    // stopping there keeps the event from ever reaching the modal.
+    //
+    // With the picker closed it does nothing and escape falls through to the
+    // modal as before. Open, it steps back one view at a time, matching what
+    // the Back buttons in the month and year views do.
+    onEscape(event) {
+      if (!this.open) {
+        return;
+      }
+
+      if (this.pickerView === "years") {
+        this.showMonthsView();
+      } else if (this.pickerView === "months") {
+        this.showDaysView();
+      } else {
+        this.closePicker();
+      }
+
+      event.stopPropagation();
+      event.preventDefault();
     },
 
     togglePicker() {

--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -13,7 +13,7 @@
      })"
      x-init="init"
      {% if suggestion_date_expr %}x-effect="suggestionDate = ({{ suggestion_date_expr }}) || ''"{% endif %}
-     @keydown.escape.window="open && closePicker()">
+     @keydown.escape.window.capture="onEscape($event)">
 
   <div class="flex-1 flex items-stretch border border-gray-600 rounded-md bg-[var(--color-surface-strong)] focus-within:ring-2 focus-within:ring-[var(--color-accent)]">
     {% if mobile_label %}
@@ -71,8 +71,12 @@
       </button>
     </div>
 
-    <div class="flex items-center justify-between mb-2">
-      <button type="button" @click="gotoPrevMonth()" aria-label="Previous month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer" x-show="pickerView === 'days'">
+    {# The whole row belongs to the days view: the month and year views each #}
+    {# carry their own header. Hiding only the chevrons left the month label #}
+    {# stacked above that header and knocked it off centre, since its two #}
+    {# justify-between siblings were display:none. #}
+    <div class="flex items-center justify-between mb-2" x-show="pickerView === 'days'">
+      <button type="button" @click="gotoPrevMonth()" aria-label="Previous month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
         {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
       </button>
       <button type="button"
@@ -80,7 +84,7 @@
               aria-label="Select month"
               class="text-sm font-semibold text-[var(--color-text)] hover:bg-[var(--color-surface-muted)] rounded-md px-2 py-1 cursor-pointer"
               x-text="monthLabel()"></button>
-      <button type="button" @click="gotoNextMonth()" aria-label="Next month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer" x-show="pickerView === 'days'">
+      <button type="button" @click="gotoNextMonth()" aria-label="Next month" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
         {% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}
       </button>
     </div>
@@ -120,18 +124,21 @@
     <template x-if="pickerView === 'years'">
       <div>
         <div class="flex items-center justify-between mb-2">
-          <button type="button" @click="gotoPrevYear()" aria-label="Previous year" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+          <button type="button" @click="gotoPrevYearPage()" aria-label="Previous years" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
             {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
           </button>
+          {# :value rather than x-model: x-model would also write yearInput on #}
+          {# input, racing the sanitising @input handler for the same property. #}
           <input type="text"
                  inputmode="numeric"
-                 x-model="yearInput"
+                 :value="yearInput"
                  @input="onYearInput($event)"
                  @keydown.enter.prevent="applyYearInput()"
-                 @keydown.escape.prevent="showDaysView()"
-                 class="date-picker-year-input w-20 text-center text-sm font-semibold text-[var(--color-text)] bg-[var(--color-surface-strong)] border border-gray-600 rounded-md px-2 py-1 outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+                 {# No escape handler here: the root consumes escape in the #}
+                 {# capture phase, so it never reaches this input. #}
+                 class="w-20 text-center text-sm font-semibold text-[var(--color-text)] bg-[var(--color-surface-strong)] border border-gray-600 rounded-md px-2 py-1 outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
                  aria-label="Year">
-          <button type="button" @click="gotoNextYear()" aria-label="Next year" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
+          <button type="button" @click="gotoNextYearPage()" aria-label="Next years" class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
             {% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Follow-up to #1017, fixing four things found by review after that PR merged.
- **Escape closed the whole track modal.** The picker and the modal each handle escape at window level, so the event reaches `window` once and both listeners fire — `stopPropagation` from an ordinary handler cannot win that, because they are siblings on the same target. The picker now binds escape in the **capture** phase, which runs before the target and before any bubble-phase window listener, and consumes the event only while the picker is open. Escape with the picker closed still closes the modal.
- While open, escape now steps back one view at a time — years to months, months to days, days closes the picker — matching the Back buttons those views already have. That also removes the separate escape handler on the year input, which was closing the whole picker for the same reason and is unreachable now anyway.
- **The year grid's chevrons stepped a single year against a grid that pages in twenty**, so they usually appeared to do nothing: the grid only shifted on the years that straddled a boundary. They now step a whole page. The month view keeps its single-year step, which is right for choosing a month within a year.
- **The day header stayed visible in the month and year views** because only its two chevrons were hidden, leaving the month label stacked above those views' own headers and knocked off centre by its `display:none` siblings. The whole row is now bound to the days view.
- Also drops the year input's spin-button rules, which only ever apply to `type="number"`, and its `x-model`, which raced the sanitising `@input` handler for the same property.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.test_css_assets` -> Passed (4 tests, OK).
- `djlint src/templates/app/components/date_time_picker.html --lint` -> 0 errors.
- No automated coverage exists for this component, so behaviour was verified by driving the real template with the real Alpine build and the real `dateTimePicker.js` in headless Chromium. All checks green:
  - escape in the year input keeps the picker open; years -> months -> days -> closes
  - escape with the picker open leaves the enclosing modal open; with the picker closed it still closes the modal
  - year chevron steps a page (`viewYear 2026->2006`, grid start `2020->2000`)
  - day header absent in the month view
  - year input still sanitises (`2o0a1x9` -> `2019`)
  - no console errors
- Also checked that evaluating `dateTimePicker.js` twice in one global scope stays clean, since the file re-executes on `hx-boost` navigation and a file-scope `const` would throw `Identifier ... has already been declared` on the second pass.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`) -> Passed
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #1017
