### PR TITLE
Stop the copy button disarming the start-date auto-fill

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -573,8 +573,13 @@ html.light .theme-toggle-icon-moon {
   border-color: transparent;
 }
 
-.date-picker-common-time-button:hover {
+.date-picker-common-time-button:hover:not(:disabled) {
   background-color: var(--color-surface-muted);
+}
+
+.date-picker-common-time-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 @media (min-width: 40rem) {

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -6033,8 +6033,12 @@ html.light .theme-toggle-icon-moon {
   box-shadow: 0 0 0 2px #6366f1;
   border-color: transparent;
 }
-.date-picker-common-time-button:hover {
+.date-picker-common-time-button:hover:not(:disabled) {
   background-color: var(--color-surface-muted);
+}
+.date-picker-common-time-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 @media (min-width: 40rem) {
   .date-picker-day-cell {

--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -11,6 +11,7 @@ if (!window.__floppyDateTimePickerBound) {
     suggestionDate: config.suggestionDate || "",
     suggestionRuntimeMinutes: config.suggestionRuntimeMinutes || "",
     copyFrom: config.copyFrom || "",
+    copyAvailable: false,
 
     value: config.initialValue || "",
     open: false,
@@ -175,14 +176,20 @@ if (!window.__floppyDateTimePickerBound) {
     },
 
     parts() {
-      if (!this.value) {
+      return this.partsFor(this.value);
+    },
+
+    // Parses any value in this field's own format, not just the current one,
+    // so the copy-from-the-other-field path can reuse it.
+    partsFor(value) {
+      if (!value) {
         return null;
       }
 
       // Django renders bound DateTimeField values with a space separator,
       // while values selected in this picker use the HTML datetime-local
       // format with a `T` separator.
-      const [datePart, timePart] = this.value.trim().split(/[T ]/, 2);
+      const [datePart, timePart] = value.trim().split(/[T ]/, 2);
       const [y, m, d] = datePart.split("-").map(Number);
       if ([y, m, d].some(Number.isNaN)) {
         return null;
@@ -528,33 +535,27 @@ if (!window.__floppyDateTimePickerBound) {
       this.backfillStartDateIfNeeded();
     },
 
-    copyFromOther() {
+    copySourceValue() {
       if (!this.copyFrom) {
-        return;
+        return "";
       }
-      const form = this.$refs.hiddenInput.closest("form");
-      if (!form) {
-        return;
-      }
-      const sourceInput = form.querySelector(`[name="${this.copyFrom}"]`);
-      if (!sourceInput || !sourceInput.value) {
-        return;
-      }
-      const sourceParts = this.partsFor(sourceInput.value);
+      const form = this.$refs.hiddenInput?.closest("form");
+      return form?.querySelector(`[name="${this.copyFrom}"]`)?.value || "";
+    },
+
+    copyFromOther() {
+      const sourceParts = this.partsFor(this.copySourceValue());
       if (!sourceParts) {
         return;
       }
-      // The form's progress-based start-date auto-fill recomputes start_date
-      // from end_date on every end_date change. A copy is an explicit user
-      // intent, so suppress that auto-fill for this commit regardless of which
-      // field we are writing, otherwise the copied value gets overwritten.
-      if (form && window.Alpine) {
-        try {
-          Alpine.$data(form).manualStartDate = true;
-        } catch {
-          // Ignore Alpine lookup failures.
-        }
-      }
+      // No backfill on this path. The runtime-based auto-fill recomputes
+      // start_date from end_date, which would immediately overwrite a copy
+      // into start_date with end minus the runtime. commit() already marks
+      // start_date as manually set when that is the field being written, and
+      // backfillStartDateIfNeeded honours that flag, so a copy into start_date
+      // also survives later edits to end_date. A copy into end_date leaves the
+      // flag alone: the user has not touched start_date, so the auto-fill must
+      // stay armed for it.
       this.commit(
         this.formatValueFromParts(
           sourceParts.y,
@@ -565,28 +566,6 @@ if (!window.__floppyDateTimePickerBound) {
           sourceParts.s,
         ),
       );
-      this.backfillStartDateIfNeeded();
-    },
-
-    partsFor(value) {
-      if (!value) {
-        return null;
-      }
-      const [datePart, timePart] = value.trim().split(/[T ]/, 2);
-      const [y, m, d] = datePart.split("-").map(Number);
-      if ([y, m, d].some(Number.isNaN)) {
-        return null;
-      }
-      let h = 0;
-      let min = 0;
-      let s = 0;
-      if (timePart) {
-        const segments = timePart.split(":").map(Number);
-        h = segments[0] || 0;
-        min = segments[1] || 0;
-        s = segments[2] || 0;
-      }
-      return { y, m, d, h, min, s };
     },
 
     backfillStartDateIfNeeded() {
@@ -695,6 +674,10 @@ if (!window.__floppyDateTimePickerBound) {
     openPicker() {
       this.open = true;
       this.pickerView = "days";
+      // Recomputed per open rather than watched: the copy button only exists
+      // while the picker is open, and opening one picker closes the other, so
+      // the source field cannot change underneath it.
+      this.copyAvailable = Boolean(this.copySourceValue());
       this.positionPopover();
       this.$nextTick(() => {
         this.positionPopover();

--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -228,7 +228,13 @@
           </button>
         </template>
         {% if copy_from %}
-        <button type="button" @click="copyFromOther()" class="date-picker-common-time-button">
+        {# Disabled rather than removed when the other field is empty, so the #}
+        {# affordance stays put and explains itself instead of doing nothing. #}
+        <button type="button"
+                @click="copyFromOther()"
+                :disabled="!copyAvailable"
+                :title="copyAvailable ? '' : '{{ copy_from_label|default:copy_from|escapejs }} is empty'"
+                class="date-picker-common-time-button">
           {% include "app/icons/copy.svg" with classes="w-3.5 h-3.5" %}
           Copy from {{ copy_from_label|default:copy_from }}
         </button>


### PR DESCRIPTION
## Summary
- Follow-up to #1019, fixing three things found by review after that PR merged.
- **The copy button disarmed the start-date auto-fill.** `copyFromOther` set the form's `manualStartDate` flag before committing, whichever field it was writing. Copying into `end_date` therefore told the form that `start_date` had been set by hand when the user had not touched it, and the runtime-based auto-fill stayed off for the rest of the modal session.
- The flag was there to stop the auto-fill overwriting the value just copied, but `commit()` does not trigger a backfill — the explicit call at the end of `copyFromOther` was the only thing that did, and setting the flag first made that call a no-op anyway. The two lines cancelled each other out; both are gone. Copying into `start_date` still sticks, because `commit()` already marks `start_date` as manual when that is the field being written and the backfill honours it; copying into `end_date` now leaves the auto-fill armed, as it should.
- **`partsFor` was a verbatim copy of `parts()`**, comment included. `parts()` now delegates to it.
- **The button is disabled, with a title naming the empty field, when there is nothing to copy** — it previously looked active and silently did nothing. Availability is recomputed as the picker opens, which is sufficient: the button only exists while the picker is open, and opening one picker closes the other. Added a `:disabled` rule for `.date-picker-common-time-button` and guarded its `:hover` rule with `:not(:disabled)`, so a disabled button no longer lights up on hover.

Note for reviewers: the early-return in `backfillStartDateIfNeeded` is kept deliberately — it is what makes a copy into `start_date` survive later edits to `end_date`. It does change behaviour slightly beyond the button: once `start_date` has been set by hand, changing `end_date` no longer recomputes it.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.test_css_assets` -> Passed (4 tests, OK).
- `djlint src/templates/app/components/date_time_picker.html --lint` -> 0 errors.
- No automated coverage exists for this component, so behaviour was verified by driving the real template with the real Alpine build and the real `dateTimePicker.js` in headless Chromium, with both pickers and the `mediaForm` scope present. Before/after on the core case:
  - copy Start -> End, `manualStartDate` afterwards: **pre-fix `true`** (auto-fill disarmed), **post-fix `false`** (still armed)
  - copy End -> Start preserves the time component (`2026-08-15T20:00`)
  - copy into `start_date`, then move `end_date` to `2026-07-27T20:00`: `start_date` survives at `2026-08-15T20:00`
  - source empty: button visible, disabled, titled "End is empty", and a forced click does nothing
  - source present: button enabled
  - no console errors

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`) -> Passed
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #1019
