### PR TITLE
Stop one failing save fragment discarding the whole response

### DIFF
--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -278,7 +278,29 @@ def media_save(request):
             else media.item.title
         ) or "item"
         if is_htmx:
-            try:
+            fragment_context = (
+                f"{action_verb.lower()} save media_type={media_type} "
+                f"source={source} media_id={media_id} "
+                f"instance_id={instance_id} user_id={request.user.id}"
+            )
+
+            # The status pill is the response itself, not an OOB fragment, so
+            # it stays outside the per-fragment isolation below: if it cannot
+            # render there is nothing to return. This matches the old
+            # behaviour, whose fallback rendered this same template and so
+            # raised again anyway.
+            response = render(
+                request,
+                "app/components/detail_track_action.html",
+                {
+                    "media": media.item,
+                    "current_instance": media,
+                    "return_url": return_url,
+                    "track_action_update": True,
+                },
+            )
+
+            def _activity_subtitle_fragment():
                 user_medias = list(
                     media.__class__.objects.filter(
                         user=request.user, item=media.item
@@ -293,18 +315,7 @@ def media_save(request):
                     user_medias=user_medias,
                     public_view=False,
                 )
-                response = render(
-                    request,
-                    "app/components/detail_track_action.html",
-                    {
-                        "media": media.item,
-                        "current_instance": media,
-                        "return_url": return_url,
-                        "track_action_update": True,
-                    },
-                )
-                activity_subtitle_response = render(
-                    request,
+                return render_to_string(
                     "app/components/detail_activity_subtitle_slot.html",
                     {
                         "media": media.item,
@@ -315,9 +326,11 @@ def media_save(request):
                         "user": request.user,
                         "activity_subtitle_slot_oob": True,
                     },
+                    request=request,
                 )
-                score_chip_response = render(
-                    request,
+
+            def _score_chip_fragment():
+                return render_to_string(
                     "app/components/detail_score_chip_slot.html",
                     {
                         "media": media.item,
@@ -329,84 +342,77 @@ def media_save(request):
                         "csrf_token": request.META.get("CSRF_COOKIE", ""),
                         "score_chip_slot_oob": True,
                     },
+                    request=request,
                 )
-                card_rating_response = render(
-                    request,
+
+            def _card_rating_fragment():
+                return render_to_string(
                     "app/components/media_card_rating_oob.html",
                     {
                         "media_instance_id": media.id,
                         "rating_value": media.formatted_score,
                         "user": request.user,
                     },
+                    request=request,
                 )
-                status_chip_response = render(
-                    request,
+
+            def _status_chip_fragment():
+                return render_to_string(
                     "app/components/media_card_status_chip.html",
                     {
                         "media": media,
                         "status_chip_oob": True,
                     },
+                    request=request,
                 )
-                response.write(activity_subtitle_response.content.decode())
-                response.write(score_chip_response.content.decode())
-                response.write(card_rating_response.content.decode())
-                response.write(status_chip_response.content.decode())
+
+            def _season_cascade_fragment():
                 # A season completing (or reopening) can cascade to complete
                 # (or reopen) its show — Season.save() already applies that
                 # server-side, but nothing else refreshes the show's own
                 # pill, e.g. when marking a season watched from the show
                 # page rather than the season's own page.
-                if media_type == MediaTypes.SEASON.value and media.related_tv_id:
-                    tv = (
-                        TV.objects.filter(pk=media.related_tv_id)
-                        .select_related("item")
-                        .first()
-                    )
-                    if tv:
-                        response.write(
-                            _render_track_action_oob(
-                                request,
-                                tv,
-                                media_url(tv.item),
-                            ),
-                        )
-                if media_type in (
+                if media_type != MediaTypes.SEASON.value or not media.related_tv_id:
+                    return None
+                tv = (
+                    TV.objects.filter(pk=media.related_tv_id)
+                    .select_related("item")
+                    .first()
+                )
+                if not tv:
+                    return None
+                return _render_track_action_oob(request, tv, media_url(tv.item))
+
+            def _notes_section_fragment():
+                if media_type not in (
                     MediaTypes.MOVIE.value,
                     MediaTypes.TV.value,
                     MediaTypes.SEASON.value,
                     MediaTypes.ANIME.value,
                 ):
-                    response.write(
-                        _render_notes_section_oob(
-                            request,
-                            media.__class__.objects.filter(
-                                user=request.user,
-                                item=media.item,
-                            ),
-                            media=media.item,
-                        ),
-                    )
-            except Exception:
-                logger.exception(
-                    "Post-save enrichment failed for %s save "
-                    "media_type=%s source=%s media_id=%s instance_id=%s user_id=%s; "
-                    "record was already saved, falling back to a minimal confirmation.",
-                    action_verb.lower(),
-                    media_type,
-                    source,
-                    media_id,
-                    instance_id,
-                    request.user.id,
-                )
-                response = render(
+                    return None
+                return _render_notes_section_oob(
                     request,
-                    "app/components/detail_track_action.html",
-                    {
-                        "media": media.item,
-                        "current_instance": media,
-                        "return_url": return_url,
-                        "track_action_update": True,
-                    },
+                    media.__class__.objects.filter(
+                        user=request.user,
+                        item=media.item,
+                    ),
+                    media=media.item,
+                )
+
+            for label, build in (
+                ("activity subtitle", _activity_subtitle_fragment),
+                ("score chip", _score_chip_fragment),
+                ("card rating", _card_rating_fragment),
+                ("status chip", _status_chip_fragment),
+                ("season cascade pill", _season_cascade_fragment),
+                ("notes section", _notes_section_fragment),
+            ):
+                _append_optional_fragment(
+                    response,
+                    label,
+                    build,
+                    context=fragment_context,
                 )
             htmx_trigger = {
                 "closeModal": {"formId": track_form_id},
@@ -666,6 +672,32 @@ def media_rewatch(request):
     if request.headers.get("HX-Request"):
         return HttpResponse(status=204, headers={"HX-Redirect": redirect_response.url})
     return redirect_response
+
+
+def _append_optional_fragment(response, label, build, *, context):
+    """Append one optional OOB fragment, or log and skip only that fragment.
+
+    A save response is one required element - the status pill - followed by
+    several independent OOB fragments appended to it. Wrapping all of them in a
+    single try meant a failure in any one discarded the whole response: the
+    handler rebound `response` to a bare confirmation, so the later a fragment
+    failed, the more already-rendered work was thrown away, and the client saw
+    a 200 with most of the page silently not updating.
+
+    Each fragment is now isolated, so a broken one costs exactly itself.
+    """
+    try:
+        html = build()
+    except Exception:
+        logger.exception(
+            "Post-save OOB fragment %s failed for %s; the record was saved and "
+            "the rest of the response is unaffected.",
+            label,
+            context,
+        )
+        return
+    if html:
+        response.write(html)
 
 
 def _render_season_progress_oob(related_season):

--- a/src/app/tests/views/test_save_response_fragments.py
+++ b/src/app/tests/views/test_save_response_fragments.py
@@ -1,0 +1,124 @@
+"""A failing OOB fragment must not take the rest of the save response with it."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models import Item, MediaTypes, Movie, Sources, Status
+
+# Marker present in each fragment of a successful htmx save response.
+FRAGMENT_MARKERS = {
+    "status pill": "data-track-action-root",
+    "activity subtitle": "activity-subtitle",
+    "score chip": "score-chip",
+    "card rating": "media-card-rating",
+    "status chip": "status-chip",
+    "notes section": "detail-notes-section",
+}
+
+METADATA = {
+    "media_id": "238",
+    "title": "Test Movie",
+    "media_type": MediaTypes.MOVIE.value,
+    "source": Sources.TMDB.value,
+    "image": "http://example.com/image.jpg",
+    "synopsis": "Test overview",
+    "max_progress": 1,
+    "details": {},
+    "related": {},
+    "cast": [],
+    "crew": [],
+    "studios_full": [],
+}
+
+
+class SaveResponseFragmentIsolationTests(TestCase):
+    """media_save composes one required pill plus independent OOB fragments."""
+
+    def setUp(self):
+        self.credentials = {"username": "test", "password": "12345"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+        self.client.login(**self.credentials)
+        self.item = Item.objects.create(
+            media_id="238",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Test Movie",
+        )
+        Movie.objects.create(
+            item=self.item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+            notes="a note",
+        )
+
+    def _save(self):
+        return self.client.post(
+            reverse("media_save"),
+            {
+                "media_id": "238",
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.MOVIE.value,
+                "status": Status.COMPLETED.value,
+                "progress": 1,
+                "repeats": 0,
+                "notes": "a note",
+            },
+            headers={"hx-request": "true"},
+        )
+
+    @patch("app.views.services.get_media_metadata", return_value=METADATA)
+    @patch("app.providers.services.get_media_metadata", return_value=METADATA)
+    def test_healthy_save_carries_every_fragment(self, *_mocks):
+        body = self._save().content.decode()
+        for label, marker in FRAGMENT_MARKERS.items():
+            self.assertIn(marker, body, f"{label} missing from a healthy save")
+
+    @patch("app.views.services.get_media_metadata", return_value=METADATA)
+    @patch("app.providers.services.get_media_metadata", return_value=METADATA)
+    def test_one_failing_fragment_costs_only_itself(self, *_mocks):
+        """The notes section is the last fragment appended.
+
+        Before fragments were isolated, a failure here rebound the whole
+        response to a bare confirmation, discarding the five fragments that had
+        already rendered - and still returned 200, so the client saw most of
+        the page silently not update.
+        """
+        with patch(
+            "app.save_views._render_notes_section_oob",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = self._save()
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+
+        for label, marker in FRAGMENT_MARKERS.items():
+            if label == "notes section":
+                self.assertNotIn(marker, body, "the failing fragment should be absent")
+            else:
+                self.assertIn(marker, body, f"{label} was lost to an unrelated failure")
+
+    @patch("app.views.services.get_media_metadata", return_value=METADATA)
+    @patch("app.providers.services.get_media_metadata", return_value=METADATA)
+    def test_an_early_failing_fragment_does_not_stop_later_ones(self, *_mocks):
+        """Isolation runs both ways: a failure first must not skip the rest."""
+        with patch(
+            "app.save_views._build_detail_activity_state",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = self._save()
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+
+        self.assertNotIn(FRAGMENT_MARKERS["activity subtitle"], body)
+        for label in ("status pill", "score chip", "card rating", "notes section"):
+            self.assertIn(
+                FRAGMENT_MARKERS[label],
+                body,
+                f"{label} was skipped after an earlier fragment failed",
+            )


### PR DESCRIPTION
## Summary
- An htmx save response is one required element — the status pill — followed by several independent out-of-band fragments appended to it. All of them sat inside a single `try`, whose handler rebound `response` to a bare confirmation.
- That made the recovery path **destructive rather than protective**: the later a fragment failed, the more already-rendered work was discarded. And because the fallback rendered the same template as the first fragment, the client still received a `200` with well-formed HTML — the status pill swapped, and most of the page silently did not update. The only trace was a single log line.
- Measured on a movie save with only the *last* fragment failing: the response dropped from **24,627 to 1,533 bytes**, losing the activity subtitle, score chip, card rating, status chip and notes section — all of which had rendered successfully.
- Each fragment is now appended through a small helper that logs and skips only that fragment, so a broken one costs exactly itself. The status pill moves outside the isolation because it *is* the response rather than an addition to it; that is not a behaviour change, since the old fallback rendered the same template and would have raised again anyway.
- The bare `except Exception` also could not distinguish a transient problem from a programming error. A `FieldError` from a bad queryset degraded exactly like a blip — permanently and invisibly — while tests asserting only "not a 500" still passed. That is not hypothetical: `Episode` has no `user` field (it is scoped through `related_season`), so a `filter(user=...)` in an episode-side fragment raises `FieldError`, and under the old structure that would have silently emptied every save response instead of surfacing.

No user-visible change when everything works.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_save_response_fragments` -> Passed (3 tests, OK). New file, and **2 of the 3 were re-confirmed to fail against current `latest`** with `save_views.py` reverted and the tests kept:
  - `test_one_failing_fragment_costs_only_itself`
  - `test_an_early_failing_fragment_does_not_stop_later_ones`
  - `test_healthy_save_carries_every_fragment` is a control and passes either way.
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_details` -> Passed (145 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list` -> Passed (95 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_track_modal` -> Passed (34 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_rewatch` -> Passed (26 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_progress` -> Passed (18 tests, OK)
- `uv run --no-sync python -m app.domain_vocabulary --check` -> Passed (exit 0)

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Rebased onto `latest` after #1063 merged. The conflict both of them anticipated is resolved the way it was expected to be: the restored `_render_notes_section_oob` call becomes one more entry in the isolated fragment list, keeping #1063's parameters inside this PR's structure. The rebased result is byte-identical to an independent auto-merge of the two, which is how the resolution was checked.
- The earlier note about conflicting with a `fix/notes-oob-swap` branch is obsolete; that branch no longer exists.
