### PR TITLE
[UNTESTED] Fix 500 on show detail pages from malformed TMDB aggregate credits

### DIFF
--- a/src/app/providers/tmdb.py
+++ b/src/app/providers/tmdb.py
@@ -1703,8 +1703,12 @@ def get_cast_credits(credits_data, is_aggregate=False):
     """Return normalized cast entries."""
     cast_entries = []
     cast_list = credits_data.get("cast", []) if isinstance(credits_data, dict) else []
+    if not isinstance(cast_list, list):
+        cast_list = []
 
     for cast in cast_list:
+        if not isinstance(cast, dict):
+            continue
         role_value = cast.get("character", "")
         episode_count = None
         if is_aggregate:
@@ -1714,31 +1718,59 @@ def get_cast_credits(credits_data, is_aggregate=False):
             # unwraps exactly one level: a role element that is itself a list
             # is iterated, anything else is treated as a single role. Deeper
             # nesting is not a real TMDB shape and is dropped by the dict
-            # filter below.
+            # filter below. A bare dict (rather than a list) is accepted too.
+            raw_roles = cast.get("roles") or []
+            if isinstance(raw_roles, dict):
+                raw_roles = [raw_roles]
             roles = [
                 role
-                for inner in (cast.get("roles") or [])
+                for inner in raw_roles
                 for role in (inner if isinstance(inner, list) else [inner])
                 if isinstance(role, dict)
             ]
             if roles:
-                top_role = max(roles, key=lambda role: role.get("episode_count") or 0)
-                role_value = top_role.get("character") or role_value
+                # episode_count is not always numeric; comparing a string
+                # against an int in max() raises, so rank on the numeric ones
+                # and only fall back to the raw list if none qualify.
+                valid_roles = [
+                    role
+                    for role in roles
+                    if isinstance(role.get("episode_count"), (int, float))
+                ]
+                top_role = max(
+                    valid_roles or roles,
+                    key=lambda role: (
+                        role.get("episode_count")
+                        if isinstance(role.get("episode_count"), (int, float))
+                        else 0
+                    ),
+                )
+                role_char = top_role.get("character")
+                # Only a non-empty role replaces the outer `character`: a blank
+                # or zero aggregate role must not erase the fallback.
+                if role_char and not isinstance(role_char, (dict, list)):
+                    role_value = (
+                        role_char if isinstance(role_char, str) else str(role_char)
+                    )
             # episode_count is the person's total appearances across all their
             # roles in this show, not episodes as the selected top_role only.
-            total_eps = sum(r.get("episode_count") or 0 for r in roles)
+            total_eps = sum(
+                role.get("episode_count") or 0
+                for role in roles
+                if isinstance(role.get("episode_count"), (int, float))
+            )
             episode_count = total_eps if total_eps > 0 else None
 
         cast_entries.append(
             {
                 "person_id": str(cast.get("id")),
-                "name": cast.get("name", ""),
+                "name": cast.get("name", "") if isinstance(cast.get("name"), str) else str(cast.get("name") or ""),
                 "image": get_profile_image_url(cast.get("profile_path")),
-                "known_for_department": cast.get("known_for_department", ""),
+                "known_for_department": cast.get("known_for_department", "") if isinstance(cast.get("known_for_department"), str) else "",
                 "gender": get_gender(cast.get("gender")),
-                "department": cast.get("known_for_department", "Acting"),
-                "role": role_value or "",
-                "order": cast.get("order"),
+                "department": cast.get("known_for_department", "Acting") if isinstance(cast.get("known_for_department"), str) else "Acting",
+                "role": str(role_value or ""),
+                "order": cast.get("order") if isinstance(cast.get("order"), (int, float)) else None,
                 "episode_count": episode_count,
             },
         )
@@ -1756,43 +1788,57 @@ def get_crew_credits(credits_data, is_aggregate=False):
     """Return normalized crew entries."""
     crew_entries = []
     crew_list = credits_data.get("crew", []) if isinstance(credits_data, dict) else []
+    if not isinstance(crew_list, list):
+        crew_list = []
 
     for crew in crew_list:
-        department = crew.get("department", "")
+        if not isinstance(crew, dict):
+            continue
+        department = crew.get("department", "") if isinstance(crew.get("department"), str) else ""
 
         if is_aggregate:
-            jobs = crew.get("jobs", []) or []
+            raw_jobs = crew.get("jobs", [])
+            if isinstance(raw_jobs, list):
+                jobs = [job for job in raw_jobs if isinstance(job, dict)]
+            elif isinstance(raw_jobs, dict):
+                jobs = [raw_jobs]
+            else:
+                jobs = []
+
             if not jobs:
                 crew_entries.append(
                     {
                         "person_id": str(crew.get("id")),
-                        "name": crew.get("name", ""),
+                        "name": crew.get("name", "") if isinstance(crew.get("name"), str) else str(crew.get("name") or ""),
                         "image": get_profile_image_url(crew.get("profile_path")),
-                        "known_for_department": crew.get("known_for_department", ""),
+                        "known_for_department": crew.get("known_for_department", "") if isinstance(crew.get("known_for_department"), str) else "",
                         "gender": get_gender(crew.get("gender")),
                         "department": department,
                         "role": "",
-                        "order": crew.get("order"),
+                        "order": crew.get("order") if isinstance(crew.get("order"), (int, float)) else None,
                     },
                 )
                 continue
 
             seen_jobs = set()
             for job_data in jobs:
-                job_name = (job_data.get("job") or "").strip()
+                if not isinstance(job_data, dict):
+                    continue
+                job_name = (str(job_data.get("job") or "")).strip()
                 if not job_name or job_name.lower() in seen_jobs:
                     continue
                 seen_jobs.add(job_name.lower())
+                job_dept = job_data.get("department", "") if isinstance(job_data.get("department"), str) else ""
                 crew_entries.append(
                     {
                         "person_id": str(crew.get("id")),
-                        "name": crew.get("name", ""),
+                        "name": crew.get("name", "") if isinstance(crew.get("name"), str) else str(crew.get("name") or ""),
                         "image": get_profile_image_url(crew.get("profile_path")),
-                        "known_for_department": crew.get("known_for_department", ""),
+                        "known_for_department": crew.get("known_for_department", "") if isinstance(crew.get("known_for_department"), str) else "",
                         "gender": get_gender(crew.get("gender")),
-                        "department": department or job_data.get("department", ""),
+                        "department": department or job_dept,
                         "role": job_name,
-                        "order": crew.get("order"),
+                        "order": crew.get("order") if isinstance(crew.get("order"), (int, float)) else None,
                     },
                 )
             continue
@@ -1800,13 +1846,13 @@ def get_crew_credits(credits_data, is_aggregate=False):
         crew_entries.append(
             {
                 "person_id": str(crew.get("id")),
-                "name": crew.get("name", ""),
+                "name": crew.get("name", "") if isinstance(crew.get("name"), str) else str(crew.get("name") or ""),
                 "image": get_profile_image_url(crew.get("profile_path")),
-                "known_for_department": crew.get("known_for_department", ""),
+                "known_for_department": crew.get("known_for_department", "") if isinstance(crew.get("known_for_department"), str) else "",
                 "gender": get_gender(crew.get("gender")),
                 "department": department,
-                "role": crew.get("job", "") or "",
-                "order": crew.get("order"),
+                "role": crew.get("job", "") if isinstance(crew.get("job"), str) else str(crew.get("job") or ""),
+                "order": crew.get("order") if isinstance(crew.get("order"), (int, float)) else None,
             },
         )
 

--- a/src/app/tests/providers/test_tmdb_aggregate_credits.py
+++ b/src/app/tests/providers/test_tmdb_aggregate_credits.py
@@ -1,0 +1,81 @@
+from django.test import SimpleTestCase
+
+
+class TmdbAggregateCreditsTests(SimpleTestCase):
+    """TMDB aggregate-credits parsing against malformed provider payloads."""
+
+    def test_tmdb_aggregate_credits_normalization_handles_nested_and_malformed_roles(self):
+        """TMDB aggregate credits with non-dict roles or nested lists normalize cleanly."""
+        from app.providers import tmdb
+
+        credits_data = {
+            "cast": [
+                {
+                    "id": 101,
+                    "name": "Diego Luna",
+                    "roles": [
+                        [{"character": "Cassian Andor", "episode_count": 24}],
+                        {"character": "Cassian Jeron Andor", "episode_count": 12},
+                        "malformed string entry",
+                        None,
+                    ],
+                    "known_for_department": "Acting",
+                    "gender": 2,
+                    "order": 0,
+                },
+                {
+                    "id": 102,
+                    "name": "Stellan Skarsgard",
+                    "roles": "invalid roles structure",
+                    "known_for_department": "Acting",
+                    "gender": 2,
+                    "order": 1,
+                },
+            ],
+            "crew": [
+                {
+                    "id": 201,
+                    "name": "Tony Gilroy",
+                    "jobs": [
+                        [{"job": "Executive Producer", "department": "Production"}],
+                        {"job": "Writer", "department": "Writing"},
+                        123,
+                    ],
+                    "department": "Writing",
+                    "gender": 2,
+                    "order": 0,
+                },
+            ],
+        }
+
+        cast = tmdb.get_cast_credits(credits_data, is_aggregate=True)
+        crew = tmdb.get_crew_credits(credits_data, is_aggregate=True)
+
+        self.assertEqual(len(cast), 2)
+        self.assertEqual(cast[0]["name"], "Diego Luna")
+        self.assertIn(cast[0]["role"], ["Cassian Andor", "Cassian Jeron Andor"])
+        self.assertEqual(cast[1]["name"], "Stellan Skarsgard")
+
+        self.assertTrue(len(crew) >= 1)
+        self.assertEqual(crew[0]["name"], "Tony Gilroy")
+    def test_tmdb_credits_sorting_with_non_int_order(self):
+        """get_cast_credits and get_crew_credits handle string/non-int order fields cleanly."""
+        from app.providers import tmdb
+
+        credits_data = {
+            "cast": [
+                {"id": 1, "name": "Actor A", "order": "invalid_string"},
+                {"id": 2, "name": "Actor B", "order": 0},
+            ],
+            "crew": [
+                {"id": 3, "name": "Crew A", "order": "invalid_string"},
+                {"id": 4, "name": "Crew B", "order": 1},
+            ],
+        }
+
+        cast = tmdb.get_cast_credits(credits_data, is_aggregate=True)
+        crew = tmdb.get_crew_credits(credits_data, is_aggregate=True)
+        self.assertEqual(len(cast), 2)
+        self.assertEqual(cast[0]["name"], "Actor B")
+        self.assertEqual(cast[1]["name"], "Actor A")
+        self.assertEqual(len(crew), 2)


### PR DESCRIPTION
> [!WARNING]
> ## ⚠️ Not tested — please review carefully before merging
>
> **I have not tested this at all.** I did a high-level code scan — a skim — and nothing
> more. No manual verification in a running instance, no line-by-line review.
>
> I am opening it anyway because I do not have the time to take it further and I would
> rather not sit on potential fixes that someone else could pick up or finish. Please treat
> every claim below as *intent*, not as verified behaviour.
>
> Automated tests pass and lint is clean, but that is a floor, not validation. **Assume
> nothing here is proven correct.** If it needs rework or you would rather close it, that
> is entirely fine.

## Summary
- TMDB's *aggregate* credits endpoint returns a per-person `roles` list whose shape varies in practice: sometimes a bare dict instead of a list, sometimes `episode_count` missing or non-numeric, sometimes a blank character. The credits parser assumed the well-formed case, so a malformed payload raised and returned a 500 for the whole show detail page. This is the `AttributeError: 'list' object has no attribute 'get'` traceback reported in #375.
- The parser now normalizes the container (accepting a bare dict as well as `latest`'s nested-list shape), ranks roles only on numeric `episode_count` values so `max()` cannot compare a string against an int, and only lets a **non-empty** role replace the outer `character` so a blank aggregate role stops erasing the fallback.
- Also hardens the surrounding normalization: non-list `cast`/`crew` containers, non-string names, and non-numeric `order` values.

**Why:** this is a crash fix, not a status fix. It surfaced while investigating #375 and stands on its own — it can merge independently of the other #375 branches.

**Note on overlap with `latest`:** `latest` already normalizes the nested-list role shape. That work is kept as-is here; this branch adds the numeric guards on top, because `max(roles, key=lambda r: r.get("episode_count") or 0)` still raises `TypeError` when a role carries a string `episode_count`.

## AI Assistance
- `claude-opus-5` (Claude Code) wrote this change and its tests.

## How It Was Tested
- `scripts/test.sh app.tests.providers.test_tmdb_aggregate_credits` -> Passed (2 tests)
- `scripts/test.sh app.tests.providers.test_crew_sorting` -> Passed (10 tests)
- `ruff check src/` -> Clean
- **No manual/browser QA.** See the warning at the top.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #375
