### PR TITLE
[UNTESTED] Keep caught-up seasons on the In progress shelf

### DIFF
--- a/src/app/tests/views/test_home_screen_season_status.py
+++ b/src/app/tests/views/test_home_screen_season_status.py
@@ -1,0 +1,96 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from app.models import (
+    TV,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+from users.home_screen import build_home_page_groups
+from users.models import HomeScreenRow, HomeScreenRowTypeChoices
+
+User = get_user_model()
+
+class HomeScreenSeasonStatusTests(TestCase):
+    """Home screen keeps a caught-up season visible as in progress."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.tv_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        self.season_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Create 3 episodes for Season 1
+        for i in range(1, 4):
+            ep_item = Item.objects.create(
+                media_id="1001",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                title=f"Episode {i}",
+                season_number=1,
+                episode_number=i,
+            )
+            Episode.objects.create(
+                item=ep_item,
+                related_season=self.season,
+                end_date=timezone.now(),
+                status=Status.COMPLETED.value,
+            )
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_home_screen_season_group_derivation_drops_caught_up_in_progress_season(
+        self, mock_metadata
+    ):
+        """Home screen in-memory derivation keeps caught-up season as IN_PROGRESS."""
+        mock_metadata.return_value = {"max_progress": 3}
+        self.user.enabled_media_types = [MediaTypes.SEASON.value]
+        self.user.save()
+
+        HomeScreenRow.objects.create(
+            user=self.user,
+            media_type=MediaTypes.SEASON.value,
+            position=0,
+            enabled=True,
+            row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+            filters={"status": [Status.IN_PROGRESS.value]},
+        )
+
+        groups = build_home_page_groups(self.user, items_limit=10)
+        items = [
+            entry.item.title
+            for group in groups
+            for row in group["rows"]
+            for entry in row["items"]
+        ]
+        self.assertIn("Alien: Earth Season 1", items)

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -1824,8 +1824,14 @@ def _media_lookup_for_items(
                         primary_entry.promote_to_completed_if_fully_watched(
                             max_progress=getattr(primary_entry, "max_progress", None),
                         )
-                    primary_entry.status = effective_status
-                    primary_entry.aggregated_status = effective_status
+                    if not (
+                        effective_status == Status.COMPLETED.value
+                        and primary_entry.status == Status.IN_PROGRESS.value
+                    ):
+                        primary_entry.status = effective_status
+                        primary_entry.aggregated_status = effective_status
+                    else:
+                        primary_entry.aggregated_status = primary_entry.status
             _annotate_home_card_images(candidate_entries)
 
             for primary_entry in candidate_entries:

--- a/src/users/tests/views/test_home_screen.py
+++ b/src/users/tests/views/test_home_screen.py
@@ -287,11 +287,11 @@ class HomeScreenViewTests(TestCase):
         )
 
     @patch("app.models.providers.services.get_media_metadata")
-    def test_home_in_progress_row_hides_fully_watched_stale_seasons(
+    def test_home_in_progress_row_preserves_caught_up_in_progress_seasons(
         self,
         mock_get_metadata,
     ):
-        """Home should derive completed status for fully watched season rows."""
+        """Home should preserve in-progress status for caught-up season rows."""
         self._set_enabled_media_types(MediaTypes.SEASON.value)
 
         stale_season_item = Item.objects.create(
@@ -400,11 +400,9 @@ class HomeScreenViewTests(TestCase):
 
         self.assertEqual(
             [entry.item.title for entry in groups[0]["rows"][0]["items"]],
-            ["Home Active Season 1"],
+            ["Home Active Season 1", "Home Completed Season 1"],
         )
         stale_season.refresh_from_db()
-        # Rewatch protection: an in-progress season is never auto-promoted to
-        # Completed in the DB; Home only derives the status for display.
         self.assertEqual(stale_season.status, Status.IN_PROGRESS.value)
 
     @patch("app.models.providers.services.get_media_metadata")


### PR DESCRIPTION
> [!WARNING]
> ## ⚠️ Not tested — please review carefully before merging
>
> **I have not tested this at all.** I did a high-level code scan — a skim — and nothing
> more. No manual verification in a running instance, no line-by-line review.
>
> I am opening it anyway because I do not have the time to take it further and I would
> rather not sit on potential fixes that someone else could pick up or finish. Please treat
> every claim below as *intent*, not as verified behaviour.
>
> Automated tests pass and lint is clean, but that is a floor, not validation. **Assume
> nothing here is proven correct.** If it needs rework or you would rather close it, that
> is entirely fine.

## Summary
- The home screen does not read a season's stored status — it recomputes an "effective" status from episode progress. A season with every *released* episode watched therefore rendered as Completed even while the show is still airing and you are simply caught up. Completed rows are filtered out of the "In progress" shelf, so the show vanished from the home screen while nothing had changed in the database.
- A season you are tracking as In progress now keeps that status in the derived view when it is only caught up, matching what season detail already did — so the two views stop disagreeing.

**Why:** this is one of the ways shows appeared to be "forgotten" in #375. Nothing is written to the database; this is purely how status is derived for display.

## AI Assistance
- `claude-opus-5` (Claude Code) wrote this change and its tests.

## How It Was Tested
- `scripts/test.sh app.tests.views.test_home_screen_season_status` -> Passed (1 test)
- `ruff check src/` -> Clean
- **No manual/browser QA** — and this is a visual change, so it particularly wants a look in a real instance. See the warning at the top.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #375
