### PR TITLE
[UNTESTED] Start a rewatch pass when a completed season is reopened (stacked)

### DIFF
--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import UTC
 
 from django.conf import settings
 from django.core.validators import (
@@ -995,11 +996,36 @@ class Season(Media):
 
     def play_counts_for_pass(self, episode):
         """Return whether a play belongs to the season's current pass."""
-        started_on = self.pass_started_on
-        if started_on is None:
+        if self.rewatch_started_at is None:
             return True
         played_at = episode.end_date or episode.created_at
-        return played_at is not None and played_at >= started_on
+        if played_at is None:
+            return True
+        rewatch_started = self.rewatch_started_at
+        if timezone.is_naive(played_at):
+            played_at = timezone.make_aware(played_at, UTC)
+        if timezone.is_naive(rewatch_started):
+            rewatch_started = timezone.make_aware(rewatch_started, UTC)
+        if played_at >= rewatch_started:
+            return True
+        started_on = self.pass_started_on
+        if started_on is None:
+            return False
+        if timezone.is_naive(started_on):
+            started_on = timezone.make_aware(started_on, UTC)
+        if played_at < started_on:
+            return False
+        # Date-only plays are stored at local midnight, so compare in the same
+        # local zone `pass_started_on` was built in. Reading the raw UTC value
+        # here would see a non-UTC deployment's local midnight as the previous
+        # day's 22:00Z and drop the play from its own pass.
+        local_played_at = timezone.localtime(played_at)
+        return (
+            local_played_at.hour == 0
+            and local_played_at.minute == 0
+            and local_played_at.second == 0
+            and local_played_at.microsecond == 0
+        )
 
     def _invalidate_episode_stats(self):
         """Drop cached episode stats after the pass or its plays changed."""
@@ -1451,14 +1477,28 @@ class Season(Media):
         """Return episodes needed to complete a season."""
         plays = Episode.objects.filter(related_season=self)
         started_on = self.pass_started_on
-        if started_on is not None:
+        if started_on is None:
+            latest_watched_ep_num = plays.aggregate(
+                latest_watched_ep_num=Max("item__episode_number"),
+            )["latest_watched_ep_num"]
+        else:
+            # Narrow in SQL, then apply `play_counts_for_pass` so the plays
+            # treated as watched here are exactly the ones that count toward
+            # the pass's progress. Any divergence between the two leaves a
+            # season unable to ever reach max_progress.
             plays = plays.filter(
                 models.Q(end_date__gte=started_on)
                 | models.Q(end_date__isnull=True, created_at__gte=started_on),
+            ).select_related("item")
+            latest_watched_ep_num = max(
+                (
+                    play.item.episode_number
+                    for play in plays
+                    if play.item.episode_number is not None
+                    and self.play_counts_for_pass(play)
+                ),
+                default=None,
             )
-        latest_watched_ep_num = plays.aggregate(
-            latest_watched_ep_num=Max("item__episode_number"),
-        )["latest_watched_ep_num"]
 
         if latest_watched_ep_num is None:
             latest_watched_ep_num = 0

--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -182,6 +182,7 @@ class TV(Media):
         """
         from app.models.media import BasicMedia  # avoid a module-load cycle
 
+        is_explicit_start = started_at is not None
         started_at = started_at or timezone.now()
         all_seasons = [
             season
@@ -201,7 +202,8 @@ class TV(Media):
         skipped = [
             season
             for season in seasons
-            if season._would_be_immediately_complete(
+            if is_explicit_start
+            and season._would_be_immediately_complete(
                 started_at,
                 getattr(season, "max_progress", None),
             )
@@ -962,7 +964,12 @@ class Season(Media):
             return False
 
         self.status = Status.COMPLETED.value
-        bulk_update_with_history([self], Season, fields=["status"])
+        update_fields = ["status"]
+        if self.rewatch_started_at is not None:
+            self.rewatch_started_at = None
+            self._invalidate_episode_stats()
+            update_fields.append("rewatch_started_at")
+        bulk_update_with_history([self], Season, fields=update_fields)
         self.related_tv._handle_completed_season(self.item.season_number)
         return True
 
@@ -1047,6 +1054,7 @@ class Season(Media):
         """
         if self.rewatch_started_at is not None:
             return
+        is_explicit_start = started_at is not None
         started_at = started_at or timezone.now()
         if max_progress is None:
             from app.models.media import BasicMedia  # avoid a module-load cycle
@@ -1054,7 +1062,7 @@ class Season(Media):
             BasicMedia.objects.annotate_max_progress([self], MediaTypes.SEASON.value)
             max_progress = getattr(self, "max_progress", None)
 
-        if self._would_be_immediately_complete(started_at, max_progress):
+        if is_explicit_start and self._would_be_immediately_complete(started_at, max_progress):
             already_complete_msg = "Every episode is already watched from that date."
             raise RewatchAlreadyCompleteError(already_complete_msg)
 

--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -257,11 +257,18 @@ def media_save(request):
                 isinstance(media, Season)
                 and old_status == Status.COMPLETED.value
                 and media.status == Status.IN_PROGRESS.value
-                and media.rewatch_started_at is None
             ):
                 # The status dropdown is the only "reopen" affordance there
                 # is - treat it as starting a rewatch pass so a season with
                 # historical repeat plays can still complete normally, see #929.
+                # Deliberately bypasses start_rewatch's "a pass is already
+                # open" no-op: an explicit Completed -> In progress reopen is
+                # the user asking for a new pass from now, so the cutoff has to
+                # move. Only reachable from that transition - any future caller
+                # reaching this with an open pass would strand plays logged
+                # against the original cutoff as pre-cutoff history.
+                if media.rewatch_started_at is not None:
+                    media.rewatch_started_at = None
                 with contextlib.suppress(RewatchAlreadyCompleteError):
                     media.start_rewatch()
         else:

--- a/src/app/tests/models/test_rewatch_pass_window.py
+++ b/src/app/tests/models/test_rewatch_pass_window.py
@@ -1,0 +1,90 @@
+from datetime import UTC
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+from django.utils import timezone
+
+from app.models import (
+    TV,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+
+User = get_user_model()
+
+class RewatchPassWindowTests(TestCase):
+    """Which plays count towards an open rewatch pass."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.tv_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        self.season_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Create 3 episodes for Season 1
+        for i in range(1, 4):
+            ep_item = Item.objects.create(
+                media_id="1001",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                title=f"Episode {i}",
+                season_number=1,
+                episode_number=i,
+            )
+            Episode.objects.create(
+                item=ep_item,
+                related_season=self.season,
+                end_date=timezone.now(),
+                status=Status.COMPLETED.value,
+            )
+    @override_settings(TIME_ZONE="Europe/Brussels", USE_TZ=True)
+    def test_date_only_play_counts_for_pass_outside_utc(self):
+        """A date-only play on the pass start day counts on a non-UTC deployment."""
+        self.season.rewatch_started_at = timezone.localtime(timezone.now()).replace(
+            hour=15,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        self.season.save()
+
+        local_midnight = timezone.localtime(self.season.rewatch_started_at).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        episode = self.season.episodes.first()
+        episode.end_date = local_midnight
+        episode.save()
+
+        self.assertTrue(self.season.play_counts_for_pass(episode))

--- a/src/app/tests/views/test_season_reopen_rewatch.py
+++ b/src/app/tests/views/test_season_reopen_rewatch.py
@@ -1,0 +1,130 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from app.models import (
+    TV,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+from app.save_views import media_save
+
+User = get_user_model()
+
+class SeasonReopenRewatchTests(TestCase):
+    """Reopening a completed season starts a rewatch pass."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.tv_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        self.season_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Create 3 episodes for Season 1
+        for i in range(1, 4):
+            ep_item = Item.objects.create(
+                media_id="1001",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                title=f"Episode {i}",
+                season_number=1,
+                episode_number=i,
+            )
+            Episode.objects.create(
+                item=ep_item,
+                related_season=self.season,
+                end_date=timezone.now(),
+                status=Status.COMPLETED.value,
+            )
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_media_save_reopening_completed_season_fails_to_start_rewatch_pass(
+        self, mock_metadata
+    ):
+        """Setting COMPLETED season to IN_PROGRESS starts rewatch pass and stays IN_PROGRESS."""
+        mock_metadata.return_value = {"max_progress": 3}
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        request = self.factory.post(
+            "/save/",
+            {
+                "media_id": self.tv_item.media_id,
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.SEASON.value,
+                "season_number": 1,
+                "instance_id": str(self.season.id),
+                "status": Status.IN_PROGRESS.value,
+            },
+        )
+        request.user = self.user
+        SessionMiddleware(lambda req: None).process_request(request)
+        MessageMiddleware(lambda req: None).process_request(request)
+
+        response = media_save(request)
+        self.season.refresh_from_db()
+        self.assertIsNotNone(self.season.rewatch_started_at)
+        self.assertEqual(self.season.status, Status.IN_PROGRESS.value)
+        self.assertEqual(
+            self.season.derived_status_from_episode_progress(max_progress=3),
+            Status.IN_PROGRESS.value,
+        )
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_media_save_reopening_second_rewatch_pass(self, mock_metadata):
+        """Reopening a season that already had a previous rewatch pass starts a new pass."""
+        mock_metadata.return_value = {"max_progress": 3}
+        self.season.status = Status.COMPLETED.value
+        self.season.rewatch_started_at = timezone.now() - timezone.timedelta(days=30)
+        self.season.save()
+
+        request = self.factory.post(
+            "/save/",
+            {
+                "media_id": self.tv_item.media_id,
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.SEASON.value,
+                "season_number": 1,
+                "instance_id": str(self.season.id),
+                "status": Status.IN_PROGRESS.value,
+            },
+        )
+        request.user = self.user
+        SessionMiddleware(lambda req: None).process_request(request)
+        MessageMiddleware(lambda req: None).process_request(request)
+
+        response = media_save(request)
+        self.season.refresh_from_db()
+        self.assertIsNotNone(self.season.rewatch_started_at)
+        self.assertEqual(self.season.status, Status.IN_PROGRESS.value)


### PR DESCRIPTION
> [!WARNING]
> ## ⚠️ Not tested — please review carefully before merging
>
> **I have not tested this at all.** I did a high-level code scan — a skim — and nothing
> more. No manual verification in a running instance, no line-by-line review.
>
> I am opening it anyway because I do not have the time to take it further and I would
> rather not sit on potential fixes that someone else could pick up or finish. Please treat
> every claim below as *intent*, not as verified behaviour.
>
> Automated tests pass and lint is clean, but that is a floor, not validation. **Assume
> nothing here is proven correct.** If it needs rework or you would rather close it, that
> is entirely fine.

> [!IMPORTANT]
> **Stacked PR.** This branch is built on `fix/375-rewatch-pass-window`, so the diff below
> also contains that branch's commits. Please merge
> [the rewatch-pass-window PR](https://github.com/dannyvfilms/Floppy/pulls?q=is%3Apr+head%3Afix%2F375-rewatch-pass-window)
> first — without it the plays this change is meant to exclude still count and the fix does
> not hold (its test fails on `latest` alone). Only the last three commits belong to this PR.

## Summary
- The status dropdown is a season's only "reopen" affordance, but setting a Completed season back to In progress left its historical plays counting toward the episode total, so the season immediately re-completed. The user could not make the status stick — they set it, and it undid itself.
- Reopening now starts a rewatch pass, so past plays stay as history without counting toward the new pass.
- Two supporting changes: `start_rewatch`'s "nothing left to rewatch" refusal now applies only to an **explicitly supplied** start date rather than firing on the implicit "now" default (which rejected the reopen outright); and completing a season clears any open pass so a completed season never carries a stale cutoff into its next reopen.

**Why:** this is one of the loops described in #375 — a status the user sets that quietly reverts.

**Reviewer note:** the reopen path deliberately clears `rewatch_started_at` before calling `start_rewatch`, bypassing that method's "a pass is already open" no-op, because an explicit reopen means a new pass starting now. That is commented at the call site; it is the bit most worth a second opinion.

## AI Assistance
- `claude-opus-5` (Claude Code) wrote this change and its tests.

## How It Was Tested
- `scripts/test.sh app.tests.views.test_season_reopen_rewatch` -> Passed (2 tests)
- `scripts/test.sh app.tests.models.test_rewatch_pass_window` -> Passed (1 test, from the base branch)
- `ruff check src/` -> Clean
- **No manual/browser QA.** See the warning at the top.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #375
