### PR TITLE
[UNTESTED] Only finalize a show when the provider says it has ended (core #375 fix)

### DIFF
--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -27,7 +27,84 @@ logger = logging.getLogger(__name__)
 # user's resolve_watch_date behavior) from an explicit value, including None
 # (blank date deliberately chosen on the completion form).
 _UNSET_END_DATE = object()
+# Marks an open-but-unfilled metadata memo, see `TV._fetch_tv_metadata`.
+_UNSET_TV_METADATA = object()
 MIN_VALID_RELEASE_YEAR = 1900
+
+# How a provider's production status is classified. Only ENDED permits
+# finalizing a tracked show, so UNKNOWN (the provider said something we do not
+# recognize) and ABSENT (it said nothing) are both non-terminal by
+# construction: a renamed, localized or malformed value must never read as
+# "ended" and silently complete a show the user is still watching (#375).
+PRODUCTION_STATUS_ONGOING = "ongoing"
+PRODUCTION_STATUS_ENDED = "ended"
+PRODUCTION_STATUS_UNKNOWN = "unknown"
+PRODUCTION_STATUS_ABSENT = ""
+
+# TMDB, TVDB and the anime providers each spell these differently. Being
+# non-exhaustive here is safe - an unlisted value falls through to UNKNOWN,
+# which blocks completion - so err towards leaving a value out rather than
+# guessing it is terminal.
+ONGOING_PRODUCTION_STATUSES = frozenset(
+    {
+        # TMDB
+        "returning series",
+        "in production",
+        "post production",
+        "planned",
+        "pilot",
+        # TVDB
+        "continuing",
+        "upcoming",
+        # AniList / MAL
+        "releasing",
+        "ongoing",
+        "currently airing",
+        "not yet aired",
+        "not yet released",
+        "hiatus",
+        "on hiatus",
+    },
+)
+
+# The only vocabulary that lets a show be finalized. Keep it conservative:
+# every addition here is a new way for a sync to complete someone's show.
+TERMINAL_PRODUCTION_STATUSES = frozenset(
+    {
+        # TMDB / TVDB
+        "ended",
+        "canceled",
+        "cancelled",
+        # AniList / MAL
+        "finished",
+        "finished airing",
+        "completed",
+        "complete",
+        "concluded",
+        "discontinued",
+    },
+)
+
+
+def classify_production_status(raw_status):
+    """Classify a provider's production status.
+
+    Returns PRODUCTION_STATUS_ONGOING, _ENDED, _UNKNOWN (the provider reported
+    something unrecognized) or _ABSENT (it reported nothing). Callers must
+    treat anything other than _ENDED as "not proven finished" - an allowlist
+    of ongoing values inverted into "ended" would make every unrecognized
+    string terminal.
+    """
+    text = "" if raw_status is None else str(raw_status).strip()
+    if not text:
+        return PRODUCTION_STATUS_ABSENT
+
+    normalized = text.casefold().replace("_", " ")
+    if normalized in ONGOING_PRODUCTION_STATUSES:
+        return PRODUCTION_STATUS_ONGOING
+    if normalized in TERMINAL_PRODUCTION_STATUSES:
+        return PRODUCTION_STATUS_ENDED
+    return PRODUCTION_STATUS_UNKNOWN
 
 
 class RewatchAlreadyCompleteError(Exception):
@@ -541,6 +618,65 @@ class TV(Media):
                 fields=["status"],
             )
 
+    def _fetch_tv_metadata(self):
+        """Return this show's provider metadata, or None if unreachable.
+
+        None means the provider could not be reached, which callers must not
+        confuse with "the provider answered and carries no status". Reuses the
+        value fetched earlier in the same completion pass when one is open (see
+        `_handle_completed_season`); outside such a pass it always refetches,
+        so a later operation on the same instance can't read stale metadata.
+        """
+        cached = getattr(self, "_tv_metadata_cache", _UNSET_TV_METADATA)
+        if cached is not _UNSET_TV_METADATA:
+            return cached
+
+        try:
+            metadata = providers.services.get_media_metadata(
+                self.item.media_type,
+                self.item.media_id,
+                self.item.source,
+            )
+        except Exception:
+            logger.exception(
+                "Could not fetch metadata for %s (%s, %s)",
+                self.item.title,
+                self.item.media_id,
+                self.item.source,
+            )
+            metadata = None
+
+        if hasattr(self, "_tv_metadata_cache"):
+            self._tv_metadata_cache = metadata
+        return metadata
+
+    def resolve_production_status(self):
+        """Return the provider's production status text for this show.
+
+        None means the provider could not be reached, so a caller deciding
+        whether to finalize a status can tell "we don't know" apart from "the
+        provider carries no status" - guessing "ended" during an outage is
+        exactly the clobbering #375 is about. An empty string means the
+        provider answered but reports no status.
+        """
+        metadata = self._fetch_tv_metadata()
+        if metadata is None:
+            return None
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        details = metadata.get("details")
+        if not isinstance(details, dict):
+            details = {}
+
+        raw_status = (
+            details.get("status")
+            or metadata.get("status")
+            or getattr(self.item, "status", "")
+            or ""
+        )
+        return str(raw_status).strip()
+
     def _start_next_available_season(
         self,
         min_season_number=0,
@@ -560,19 +696,32 @@ class TV(Media):
 
         if not next_unwatched_season:
             # If all existing seasons are watched, get the next available season
-            tv_metadata = providers.services.get_media_metadata(
-                self.item.media_type,
-                self.item.media_id,
-                self.item.source,
+            tv_metadata = self._fetch_tv_metadata()
+
+            if not isinstance(tv_metadata, dict):
+                tv_metadata = {}
+
+            related = (
+                tv_metadata.get("related")
+                if isinstance(tv_metadata.get("related"), dict)
+                else {}
             )
-            related_seasons = tv_metadata.get("related", {}).get("seasons", [])
+            related_seasons = (
+                related.get("seasons")
+                if isinstance(related.get("seasons"), list)
+                else []
+            )
 
             existing_season_numbers = set(
                 all_seasons.values_list("item__season_number", flat=True),
             )
 
             for season_data in related_seasons:
-                season_number = season_data["season_number"]
+                if not isinstance(season_data, dict):
+                    continue
+                season_number = season_data.get("season_number")
+                if season_number is None:
+                    continue
                 if (
                     season_number > min_season_number
                     and season_number not in existing_season_numbers
@@ -635,6 +784,23 @@ class TV(Media):
         completed_season_number,
     ):
         """Start the next season, or complete the TV show if no seasons remain."""
+        # Both halves of this decision - "is there a next season" and "has the
+        # show ended" - need the same provider payload, and this runs once per
+        # season inside the home-screen loop. Open a memo for the pass so it is
+        # fetched once, and close it after so nothing later reads it stale.
+        self._tv_metadata_cache = _UNSET_TV_METADATA
+        try:
+            self._handle_completed_season_inner(completed_season_number)
+        finally:
+            # pop, not del: a nested completion on the same instance closes the
+            # memo first, and the outer teardown must not then raise.
+            self.__dict__.pop("_tv_metadata_cache", None)
+
+    def _handle_completed_season_inner(
+        self,
+        completed_season_number,
+    ):
+        """Body of `_handle_completed_season`, run with a metadata memo open."""
         if self._start_next_available_season(
             completed_season_number,
         ):
@@ -650,13 +816,47 @@ class TV(Media):
             .exists()
         )
 
-        if not incomplete_seasons_exist and self.status != Status.COMPLETED.value:
-            self.status = Status.COMPLETED.value
-            bulk_update_with_history(
-                [self],
-                TV,
-                fields=["status"],
-            )
+        if not incomplete_seasons_exist:
+            production_status = self.resolve_production_status()
+
+            if production_status is None:
+                # The provider is unreachable, so we cannot tell whether the
+                # show has ended. Leave the status alone: defaulting to
+                # Completed here would overwrite a status the user set, for a
+                # reason they can never see (#375).
+                return
+
+            classification = classify_production_status(production_status)
+
+            if classification == PRODUCTION_STATUS_ONGOING:
+                # The show is still running, so finishing its current seasons
+                # does not finish the show. This holds whatever the user set:
+                # Paused and Dropped are their choices too, and completing a
+                # still-airing show over them is the same clobbering as #375.
+                return
+
+            if classification == PRODUCTION_STATUS_UNKNOWN:
+                # The provider reported a status we don't recognize. It may
+                # well mean "still running" - a renamed, localized or new
+                # value - so treat it as indeterminate rather than guessing
+                # the show is over.
+                logger.warning(
+                    "Unrecognized production status %r for %s (%s, %s);"
+                    " leaving status untouched",
+                    production_status,
+                    self.item.title,
+                    self.item.media_id,
+                    self.item.source,
+                )
+                return
+
+            if self.status != Status.COMPLETED.value:
+                self.status = Status.COMPLETED.value
+                bulk_update_with_history(
+                    [self],
+                    TV,
+                    fields=["status"],
+                )
 
 
 class Season(Media):

--- a/src/app/services/tracking_hydration.py
+++ b/src/app/services/tracking_hydration.py
@@ -470,7 +470,11 @@ def ensure_item_metadata(
     if not item.format and format_type:
         item.format = format_type
         update_fields.append("format")
-    if not item.status and status:
+    # Production status is the one field here that legitimately changes over an
+    # item's life (a returning series ends), so refresh it instead of keeping
+    # whatever it was first tracked as - a stale "Returning Series" would stop
+    # the show from ever auto-completing.
+    if status and item.status != status:
         item.status = status
         update_fields.append("status")
     if not item.studios and studios:

--- a/src/app/tests/models/test_show_completion_status.py
+++ b/src/app/tests/models/test_show_completion_status.py
@@ -1,0 +1,222 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+from requests import RequestException
+
+from app.models import (
+    TV,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+from app.models import tv as tv_models
+
+User = get_user_model()
+
+class ShowCompletionStatusTests(TestCase):
+    """A completed season may only finish a show the provider calls finished."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.tv_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        self.season_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Create 3 episodes for Season 1
+        for i in range(1, 4):
+            ep_item = Item.objects.create(
+                media_id="1001",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                title=f"Episode {i}",
+                season_number=1,
+                episode_number=i,
+            )
+            Episode.objects.create(
+                item=ep_item,
+                related_season=self.season,
+                end_date=timezone.now(),
+                status=Status.COMPLETED.value,
+            )
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_overwrites_in_progress_tv_when_no_future_seasons(
+        self, mock_metadata
+    ):
+        """_handle_completed_season preserves TV.status IN_PROGRESS when TMDB has no unstarted seasons."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Returning Series"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_flips_tv_status_for_ended_show(
+        self, mock_metadata
+    ):
+        """_handle_completed_season sets TV.status to COMPLETED when show is ended."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Ended"},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.COMPLETED.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_with_none_nested_metadata(self, mock_metadata):
+        """_handle_completed_season handles None details and related dicts without crashing."""
+        mock_metadata.return_value = {
+            "details": None,
+            "related": None,
+            "status": None,
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        # Should not raise AttributeError
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.COMPLETED.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_leaves_status_alone_when_provider_fails(
+        self, mock_metadata
+    ):
+        """A provider outage must not be read as "the show ended"."""
+        mock_metadata.side_effect = RequestException("TMDB is down")
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_leaves_status_alone_for_unknown_status(
+        self, mock_metadata
+    ):
+        """An unrecognized provider status is indeterminate, not "ended"."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Returning Series (renewed)"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_preserves_user_paused_ongoing_show(
+        self, mock_metadata
+    ):
+        """An ongoing show is left alone whatever status the user chose."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Returning Series"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        for user_status in (Status.PAUSED.value, Status.DROPPED.value):
+            with self.subTest(status=user_status):
+                self.tv.status = user_status
+                self.tv.save()
+                self.season.status = Status.COMPLETED.value
+                self.season.save()
+
+                self.tv._handle_completed_season(completed_season_number=1)
+                self.tv.refresh_from_db()
+                self.assertEqual(self.tv.status, user_status)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_preserves_ongoing_tvdb_series(self, mock_metadata):
+        """TVDB spells an airing series "Continuing", which must count as ongoing."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Continuing"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    def test_production_status_classification(self):
+        """Only a known terminal status may finalize a show."""
+        self.assertEqual(
+            tv_models.classify_production_status("Ended"),
+            tv_models.PRODUCTION_STATUS_ENDED,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status("FINISHED_AIRING"),
+            tv_models.PRODUCTION_STATUS_ENDED,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status("Continuing"),
+            tv_models.PRODUCTION_STATUS_ONGOING,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status("Terminada"),
+            tv_models.PRODUCTION_STATUS_UNKNOWN,
+        )
+        # "Released" is movie/anime vocabulary and is used for airing titles;
+        # it must not finalize a TV show.
+        self.assertEqual(
+            tv_models.classify_production_status("Released"),
+            tv_models.PRODUCTION_STATUS_UNKNOWN,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status(""),
+            tv_models.PRODUCTION_STATUS_ABSENT,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status(None),
+            tv_models.PRODUCTION_STATUS_ABSENT,
+        )


### PR DESCRIPTION
> [!WARNING]
> ## ⚠️ Not tested — please review carefully before merging
>
> **I have not tested this at all.** I did a high-level code scan — a skim — and nothing
> more. No manual verification in a running instance, no line-by-line review.
>
> I am opening it anyway because I do not have the time to take it further and I would
> rather not sit on potential fixes that someone else could pick up or finish. Please treat
> every claim below as *intent*, not as verified behaviour.
>
> Automated tests pass and lint is clean, but that is a floor, not validation. **Assume
> nothing here is proven correct.** If it needs rework or you would rather close it, that
> is entirely fine.

## Summary
This is the core fix for #375.

- Finishing the last season Floppy knew about marked the whole **show** Completed. For a still-airing series that is wrong — you are caught up, not finished. Completed shows are filtered out of the TV library, so the show vanished; and because a recurring sync re-ran the same logic, setting it back to In progress only held until the next sync.
- A show is now finalized only on positive evidence from the metadata provider:

| Provider says | Result |
|---|---|
| *(unreachable)* | status untouched — an outage must never read as "ended" |
| still running | status untouched, **whatever the user set** — Paused and Dropped are their choices too |
| something unrecognized | status untouched, and the value is logged |
| nothing at all | show completes — manual-source shows never have a status and must stay completable |
| a known terminal status | show completes |

- The "unrecognized" row is the subtle one. An allowlist of *ongoing* statuses with everything else treated as ended would mean any provider rename, localized string or typo silently completes shows — the original bug in a new disguise. `classify_production_status` returns an explicit four-way result instead, and only a match against a deliberately narrow terminal allowlist completes anything.
- Supporting changes: provider metadata is fetched through one guarded lookup that distinguishes "could not reach the provider" from "the provider has no status", memoized for a single completion pass (this runs per season inside the home-screen loop); and `Item.status` is refreshed on hydration instead of written once, since a stale `Returning Series` would otherwise stop a show from ever being recognized as ended.

**Why:** this is the mechanism behind "Floppy completely forgets added shows".

**Reviewer note — the design decision most worth challenging:** on a *blank* provider status this user-driven path completes the show, while the Stremio background sync (separate PR) refuses. The reasoning is that a background job should need positive evidence before finalizing something you are tracking, whereas a user action should not be blocked because a manual-source show has no status field. Reasonable people could disagree; it is deliberate, not an oversight.

## AI Assistance
- `claude-opus-5` (Claude Code) wrote this change and its tests.

## How It Was Tested
- `scripts/test.sh app.tests.models.test_show_completion_status` -> Passed (8 tests)
- Full suite on this branch: 4087 tests, 1 failure — `test_paginated_media_layouts_render_correctly`, which fails identically on unmodified `latest` and is unrelated to this change.
- `ruff check src/` -> Clean
- **No manual/browser QA.** See the warning at the top.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #375
