### PR TITLE
[UNTESTED] Require positive evidence before a Stremio sync completes a show (stacked)

### DIFF
--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -27,7 +27,84 @@ logger = logging.getLogger(__name__)
 # user's resolve_watch_date behavior) from an explicit value, including None
 # (blank date deliberately chosen on the completion form).
 _UNSET_END_DATE = object()
+# Marks an open-but-unfilled metadata memo, see `TV._fetch_tv_metadata`.
+_UNSET_TV_METADATA = object()
 MIN_VALID_RELEASE_YEAR = 1900
+
+# How a provider's production status is classified. Only ENDED permits
+# finalizing a tracked show, so UNKNOWN (the provider said something we do not
+# recognize) and ABSENT (it said nothing) are both non-terminal by
+# construction: a renamed, localized or malformed value must never read as
+# "ended" and silently complete a show the user is still watching (#375).
+PRODUCTION_STATUS_ONGOING = "ongoing"
+PRODUCTION_STATUS_ENDED = "ended"
+PRODUCTION_STATUS_UNKNOWN = "unknown"
+PRODUCTION_STATUS_ABSENT = ""
+
+# TMDB, TVDB and the anime providers each spell these differently. Being
+# non-exhaustive here is safe - an unlisted value falls through to UNKNOWN,
+# which blocks completion - so err towards leaving a value out rather than
+# guessing it is terminal.
+ONGOING_PRODUCTION_STATUSES = frozenset(
+    {
+        # TMDB
+        "returning series",
+        "in production",
+        "post production",
+        "planned",
+        "pilot",
+        # TVDB
+        "continuing",
+        "upcoming",
+        # AniList / MAL
+        "releasing",
+        "ongoing",
+        "currently airing",
+        "not yet aired",
+        "not yet released",
+        "hiatus",
+        "on hiatus",
+    },
+)
+
+# The only vocabulary that lets a show be finalized. Keep it conservative:
+# every addition here is a new way for a sync to complete someone's show.
+TERMINAL_PRODUCTION_STATUSES = frozenset(
+    {
+        # TMDB / TVDB
+        "ended",
+        "canceled",
+        "cancelled",
+        # AniList / MAL
+        "finished",
+        "finished airing",
+        "completed",
+        "complete",
+        "concluded",
+        "discontinued",
+    },
+)
+
+
+def classify_production_status(raw_status):
+    """Classify a provider's production status.
+
+    Returns PRODUCTION_STATUS_ONGOING, _ENDED, _UNKNOWN (the provider reported
+    something unrecognized) or _ABSENT (it reported nothing). Callers must
+    treat anything other than _ENDED as "not proven finished" - an allowlist
+    of ongoing values inverted into "ended" would make every unrecognized
+    string terminal.
+    """
+    text = "" if raw_status is None else str(raw_status).strip()
+    if not text:
+        return PRODUCTION_STATUS_ABSENT
+
+    normalized = text.casefold().replace("_", " ")
+    if normalized in ONGOING_PRODUCTION_STATUSES:
+        return PRODUCTION_STATUS_ONGOING
+    if normalized in TERMINAL_PRODUCTION_STATUSES:
+        return PRODUCTION_STATUS_ENDED
+    return PRODUCTION_STATUS_UNKNOWN
 
 
 class RewatchAlreadyCompleteError(Exception):
@@ -541,6 +618,65 @@ class TV(Media):
                 fields=["status"],
             )
 
+    def _fetch_tv_metadata(self):
+        """Return this show's provider metadata, or None if unreachable.
+
+        None means the provider could not be reached, which callers must not
+        confuse with "the provider answered and carries no status". Reuses the
+        value fetched earlier in the same completion pass when one is open (see
+        `_handle_completed_season`); outside such a pass it always refetches,
+        so a later operation on the same instance can't read stale metadata.
+        """
+        cached = getattr(self, "_tv_metadata_cache", _UNSET_TV_METADATA)
+        if cached is not _UNSET_TV_METADATA:
+            return cached
+
+        try:
+            metadata = providers.services.get_media_metadata(
+                self.item.media_type,
+                self.item.media_id,
+                self.item.source,
+            )
+        except Exception:
+            logger.exception(
+                "Could not fetch metadata for %s (%s, %s)",
+                self.item.title,
+                self.item.media_id,
+                self.item.source,
+            )
+            metadata = None
+
+        if hasattr(self, "_tv_metadata_cache"):
+            self._tv_metadata_cache = metadata
+        return metadata
+
+    def resolve_production_status(self):
+        """Return the provider's production status text for this show.
+
+        None means the provider could not be reached, so a caller deciding
+        whether to finalize a status can tell "we don't know" apart from "the
+        provider carries no status" - guessing "ended" during an outage is
+        exactly the clobbering #375 is about. An empty string means the
+        provider answered but reports no status.
+        """
+        metadata = self._fetch_tv_metadata()
+        if metadata is None:
+            return None
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        details = metadata.get("details")
+        if not isinstance(details, dict):
+            details = {}
+
+        raw_status = (
+            details.get("status")
+            or metadata.get("status")
+            or getattr(self.item, "status", "")
+            or ""
+        )
+        return str(raw_status).strip()
+
     def _start_next_available_season(
         self,
         min_season_number=0,
@@ -560,19 +696,32 @@ class TV(Media):
 
         if not next_unwatched_season:
             # If all existing seasons are watched, get the next available season
-            tv_metadata = providers.services.get_media_metadata(
-                self.item.media_type,
-                self.item.media_id,
-                self.item.source,
+            tv_metadata = self._fetch_tv_metadata()
+
+            if not isinstance(tv_metadata, dict):
+                tv_metadata = {}
+
+            related = (
+                tv_metadata.get("related")
+                if isinstance(tv_metadata.get("related"), dict)
+                else {}
             )
-            related_seasons = tv_metadata.get("related", {}).get("seasons", [])
+            related_seasons = (
+                related.get("seasons")
+                if isinstance(related.get("seasons"), list)
+                else []
+            )
 
             existing_season_numbers = set(
                 all_seasons.values_list("item__season_number", flat=True),
             )
 
             for season_data in related_seasons:
-                season_number = season_data["season_number"]
+                if not isinstance(season_data, dict):
+                    continue
+                season_number = season_data.get("season_number")
+                if season_number is None:
+                    continue
                 if (
                     season_number > min_season_number
                     and season_number not in existing_season_numbers
@@ -635,6 +784,23 @@ class TV(Media):
         completed_season_number,
     ):
         """Start the next season, or complete the TV show if no seasons remain."""
+        # Both halves of this decision - "is there a next season" and "has the
+        # show ended" - need the same provider payload, and this runs once per
+        # season inside the home-screen loop. Open a memo for the pass so it is
+        # fetched once, and close it after so nothing later reads it stale.
+        self._tv_metadata_cache = _UNSET_TV_METADATA
+        try:
+            self._handle_completed_season_inner(completed_season_number)
+        finally:
+            # pop, not del: a nested completion on the same instance closes the
+            # memo first, and the outer teardown must not then raise.
+            self.__dict__.pop("_tv_metadata_cache", None)
+
+    def _handle_completed_season_inner(
+        self,
+        completed_season_number,
+    ):
+        """Body of `_handle_completed_season`, run with a metadata memo open."""
         if self._start_next_available_season(
             completed_season_number,
         ):
@@ -650,13 +816,47 @@ class TV(Media):
             .exists()
         )
 
-        if not incomplete_seasons_exist and self.status != Status.COMPLETED.value:
-            self.status = Status.COMPLETED.value
-            bulk_update_with_history(
-                [self],
-                TV,
-                fields=["status"],
-            )
+        if not incomplete_seasons_exist:
+            production_status = self.resolve_production_status()
+
+            if production_status is None:
+                # The provider is unreachable, so we cannot tell whether the
+                # show has ended. Leave the status alone: defaulting to
+                # Completed here would overwrite a status the user set, for a
+                # reason they can never see (#375).
+                return
+
+            classification = classify_production_status(production_status)
+
+            if classification == PRODUCTION_STATUS_ONGOING:
+                # The show is still running, so finishing its current seasons
+                # does not finish the show. This holds whatever the user set:
+                # Paused and Dropped are their choices too, and completing a
+                # still-airing show over them is the same clobbering as #375.
+                return
+
+            if classification == PRODUCTION_STATUS_UNKNOWN:
+                # The provider reported a status we don't recognize. It may
+                # well mean "still running" - a renamed, localized or new
+                # value - so treat it as indeterminate rather than guessing
+                # the show is over.
+                logger.warning(
+                    "Unrecognized production status %r for %s (%s, %s);"
+                    " leaving status untouched",
+                    production_status,
+                    self.item.title,
+                    self.item.media_id,
+                    self.item.source,
+                )
+                return
+
+            if self.status != Status.COMPLETED.value:
+                self.status = Status.COMPLETED.value
+                bulk_update_with_history(
+                    [self],
+                    TV,
+                    fields=["status"],
+                )
 
 
 class Season(Media):

--- a/src/app/services/tracking_hydration.py
+++ b/src/app/services/tracking_hydration.py
@@ -470,7 +470,11 @@ def ensure_item_metadata(
     if not item.format and format_type:
         item.format = format_type
         update_fields.append("format")
-    if not item.status and status:
+    # Production status is the one field here that legitimately changes over an
+    # item's life (a returning series ends), so refresh it instead of keeping
+    # whatever it was first tracked as - a stale "Returning Series" would stop
+    # the show from ever auto-completing.
+    if status and item.status != status:
         item.status = status
         update_fields.append("status")
     if not item.studios and studios:

--- a/src/app/tests/models/test_show_completion_status.py
+++ b/src/app/tests/models/test_show_completion_status.py
@@ -1,0 +1,222 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+from requests import RequestException
+
+from app.models import (
+    TV,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+from app.models import tv as tv_models
+
+User = get_user_model()
+
+class ShowCompletionStatusTests(TestCase):
+    """A completed season may only finish a show the provider calls finished."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.tv_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        self.season_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Create 3 episodes for Season 1
+        for i in range(1, 4):
+            ep_item = Item.objects.create(
+                media_id="1001",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                title=f"Episode {i}",
+                season_number=1,
+                episode_number=i,
+            )
+            Episode.objects.create(
+                item=ep_item,
+                related_season=self.season,
+                end_date=timezone.now(),
+                status=Status.COMPLETED.value,
+            )
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_overwrites_in_progress_tv_when_no_future_seasons(
+        self, mock_metadata
+    ):
+        """_handle_completed_season preserves TV.status IN_PROGRESS when TMDB has no unstarted seasons."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Returning Series"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_flips_tv_status_for_ended_show(
+        self, mock_metadata
+    ):
+        """_handle_completed_season sets TV.status to COMPLETED when show is ended."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Ended"},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.COMPLETED.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_with_none_nested_metadata(self, mock_metadata):
+        """_handle_completed_season handles None details and related dicts without crashing."""
+        mock_metadata.return_value = {
+            "details": None,
+            "related": None,
+            "status": None,
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        # Should not raise AttributeError
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.COMPLETED.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_leaves_status_alone_when_provider_fails(
+        self, mock_metadata
+    ):
+        """A provider outage must not be read as "the show ended"."""
+        mock_metadata.side_effect = RequestException("TMDB is down")
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_leaves_status_alone_for_unknown_status(
+        self, mock_metadata
+    ):
+        """An unrecognized provider status is indeterminate, not "ended"."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Returning Series (renewed)"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_preserves_user_paused_ongoing_show(
+        self, mock_metadata
+    ):
+        """An ongoing show is left alone whatever status the user chose."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Returning Series"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        for user_status in (Status.PAUSED.value, Status.DROPPED.value):
+            with self.subTest(status=user_status):
+                self.tv.status = user_status
+                self.tv.save()
+                self.season.status = Status.COMPLETED.value
+                self.season.save()
+
+                self.tv._handle_completed_season(completed_season_number=1)
+                self.tv.refresh_from_db()
+                self.assertEqual(self.tv.status, user_status)
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_handle_completed_season_preserves_ongoing_tvdb_series(self, mock_metadata):
+        """TVDB spells an airing series "Continuing", which must count as ongoing."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Continuing"},
+            "related": {"seasons": [{"season_number": 1}]},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        self.season.status = Status.COMPLETED.value
+        self.season.save()
+
+        self.tv._handle_completed_season(completed_season_number=1)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+    def test_production_status_classification(self):
+        """Only a known terminal status may finalize a show."""
+        self.assertEqual(
+            tv_models.classify_production_status("Ended"),
+            tv_models.PRODUCTION_STATUS_ENDED,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status("FINISHED_AIRING"),
+            tv_models.PRODUCTION_STATUS_ENDED,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status("Continuing"),
+            tv_models.PRODUCTION_STATUS_ONGOING,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status("Terminada"),
+            tv_models.PRODUCTION_STATUS_UNKNOWN,
+        )
+        # "Released" is movie/anime vocabulary and is used for airing titles;
+        # it must not finalize a TV show.
+        self.assertEqual(
+            tv_models.classify_production_status("Released"),
+            tv_models.PRODUCTION_STATUS_UNKNOWN,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status(""),
+            tv_models.PRODUCTION_STATUS_ABSENT,
+        )
+        self.assertEqual(
+            tv_models.classify_production_status(None),
+            tv_models.PRODUCTION_STATUS_ABSENT,
+        )

--- a/src/integrations/imports/stremio.py
+++ b/src/integrations/imports/stremio.py
@@ -28,6 +28,7 @@ import app
 import app.providers.mal
 import app.providers.trakt
 from app.models import MediaTypes, Sources, Status
+from app.models.tv import PRODUCTION_STATUS_ENDED, classify_production_status
 from app.providers import services
 from integrations import anime_mapping, import_progress
 from integrations.imports import helpers
@@ -443,6 +444,22 @@ class StremioImporter:
             status = Status.PLANNING.value
         return status, watched
 
+    @staticmethod
+    def _show_has_definitely_ended(tv_instance):
+        """Return whether the provider positively reports the show as finished.
+
+        False when the provider is unreachable, carries no status, or reports
+        one we don't recognize, so a recurring sync never finalizes a show on
+        missing or unfamiliar information.
+        """
+        production_status = tv_instance.resolve_production_status()
+        if production_status is None:
+            return False
+        return (
+            classify_production_status(production_status)
+            == PRODUCTION_STATUS_ENDED
+        )
+
     def _advance_status_in_place(self, instance, new_status, **field_updates):
         """Advance an already-tracked instance's status forward-only.
 
@@ -455,6 +472,19 @@ class StremioImporter:
         old_rank = _STATUS_RANK.get(instance.status)
         new_rank = _STATUS_RANK.get(new_status)
         if old_rank is None or new_rank is None or new_rank <= old_rank:
+            return False
+
+        if (
+            isinstance(instance, app.models.TV)
+            and new_status == Status.COMPLETED.value
+            and not self._show_has_definitely_ended(instance)
+        ):
+            # A background sync only ever sees the episodes Cinemeta happens to
+            # list, so "everything watched" is not evidence a show is over.
+            # Completing it here overwrites a status the user set (#375), so
+            # require positive evidence from the provider instead - and require
+            # it whether the row is Planning or In progress, so the two can't
+            # disagree.
             return False
 
         instance.status = new_status

--- a/src/integrations/tests/imports/test_stremio_status_sync.py
+++ b/src/integrations/tests/imports/test_stremio_status_sync.py
@@ -1,0 +1,221 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from app.models import (
+    TV,
+    Episode,
+    Item,
+    MediaTypes,
+    Season,
+    Sources,
+    Status,
+)
+from integrations.imports import stremio
+from integrations.models import StremioAccount
+
+User = get_user_model()
+
+class StremioStatusSyncTests(TestCase):
+    """A recurring Stremio sync must not overwrite a tracked show's status."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.tv_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        self.season_item = Item.objects.create(
+            media_id="1001",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        self.season = Season.objects.create(
+            item=self.season_item,
+            user=self.user,
+            related_tv=self.tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        # Create 3 episodes for Season 1
+        for i in range(1, 4):
+            ep_item = Item.objects.create(
+                media_id="1001",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.EPISODE.value,
+                title=f"Episode {i}",
+                season_number=1,
+                episode_number=i,
+            )
+            Episode.objects.create(
+                item=ep_item,
+                related_season=self.season,
+                end_date=timezone.now(),
+                status=Status.COMPLETED.value,
+            )
+    @patch("integrations.imports.helpers.decrypt_or_raise", return_value="dummy-key")
+    @patch("app.providers.tmdb.tv_with_seasons")
+    def test_stremio_recurring_sync_overwrites_in_progress_tv_status(
+        self, mock_tv_with_seasons, mock_decrypt
+    ):
+        """Stremio sync does NOT promote IN_PROGRESS show to COMPLETED (season is marked COMPLETED)."""
+        StremioAccount.objects.create(
+            user=self.user,
+            auth_key="encrypted-key",
+        )
+        mock_tv_with_seasons.return_value = {
+            "title": "Alien: Earth",
+            "max_progress": 3,
+            "image": "",
+            "seasons": [{"season_number": 1}],
+            "season/1": {
+                "title": "Alien: Earth Season 1",
+                "max_progress": 3,
+                "episodes": [
+                    {"episode_number": 1, "title": "Ep 1", "image": "", "release_datetime": None, "end_date": None},
+                    {"episode_number": 2, "title": "Ep 2", "image": "", "release_datetime": None, "end_date": None},
+                    {"episode_number": 3, "title": "Ep 3", "image": "", "release_datetime": None, "end_date": None},
+                ],
+            },
+        }
+        importer = stremio.StremioImporter(self.user, mode="new")
+        importer.existing_media[MediaTypes.TV.value][Sources.TMDB.value][self.tv_item.media_id] = self.tv
+        importer.existing_media[MediaTypes.SEASON.value][Sources.TMDB.value][(self.season_item.media_id, 1)] = self.season
+
+        entry = {
+            "_id": "series:1001",
+            "name": "Alien: Earth",
+            "state": {
+                "video_id": "1001:1:3",
+                "timeOffset": 0,
+                "duration": 1000,
+            },
+        }
+        video_ids = ["1001:1:1", "1001:1:2", "1001:1:3"]
+        watched_videos = {"1001:1:1": {}, "1001:1:2": {}, "1001:1:3": {}}
+
+        with patch.object(importer, "_watched_videos", return_value=watched_videos), \
+             patch.object(importer, "_resolve_tmdb_id", return_value="1001"):
+            importer._process_series(
+                entry=entry,
+                video_ids=video_ids,
+            )
+
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.IN_PROGRESS.value)
+        self.season.refresh_from_db()
+        self.assertEqual(self.season.status, Status.COMPLETED.value)
+    @patch("integrations.imports.helpers.decrypt_or_raise", return_value="dummy-key")
+    @patch("app.providers.tmdb.tv_with_seasons")
+    def test_stremio_sync_advances_planning_season_to_in_progress(
+        self, mock_tv_with_seasons, mock_decrypt
+    ):
+        """Stremio sync advances PLANNING season to IN_PROGRESS when partially watched."""
+        StremioAccount.objects.create(
+            user=self.user,
+            auth_key="encrypted-key-2",
+        )
+        self.season.status = Status.PLANNING.value
+        self.season.save()
+
+        mock_tv_with_seasons.return_value = {
+            "title": "Alien: Earth",
+            "max_progress": 3,
+            "image": "",
+            "seasons": [{"season_number": 1}],
+            "season/1": {
+                "title": "Alien: Earth Season 1",
+                "max_progress": 3,
+                "episodes": [
+                    {"episode_number": 1, "title": "Ep 1", "image": "", "release_datetime": None, "end_date": None},
+                    {"episode_number": 2, "title": "Ep 2", "image": "", "release_datetime": None, "end_date": None},
+                    {"episode_number": 3, "title": "Ep 3", "image": "", "release_datetime": None, "end_date": None},
+                ],
+            },
+        }
+        importer = stremio.StremioImporter(self.user, mode="new")
+        importer.existing_media[MediaTypes.TV.value][Sources.TMDB.value][self.tv_item.media_id] = self.tv
+        importer.existing_media[MediaTypes.SEASON.value][Sources.TMDB.value][(self.season_item.media_id, 1)] = self.season
+
+        entry = {
+            "_id": "series:1001",
+            "name": "Alien: Earth",
+            "state": {
+                "video_id": "1001:1:1",
+                "timeOffset": 0,
+                "duration": 1000,
+            },
+        }
+        video_ids = ["1001:1:1", "1001:1:2", "1001:1:3"]
+        watched_videos = {"1001:1:1": {}}
+
+        with patch.object(importer, "_watched_videos", return_value=watched_videos), \
+             patch.object(importer, "_resolve_tmdb_id", return_value="1001"):
+            importer._process_series(
+                entry=entry,
+                video_ids=video_ids,
+            )
+
+        self.season.refresh_from_db()
+        self.assertEqual(self.season.status, Status.IN_PROGRESS.value)
+    @patch("integrations.imports.helpers.decrypt_or_raise", return_value="dummy-key")
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_stremio_sync_does_not_complete_show_with_unknown_status(
+        self, mock_metadata, mock_decrypt
+    ):
+        """An unrecognized status is not the positive evidence the sync requires."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Terminada"},
+        }
+        self.tv.status = Status.PLANNING.value
+        self.tv.save()
+        StremioAccount.objects.create(user=self.user, auth_key="encrypted-key")
+
+        importer = stremio.StremioImporter(self.user, mode="new")
+        advanced = importer._advance_status_in_place(
+            self.tv,
+            Status.COMPLETED.value,
+        )
+
+        self.assertFalse(advanced)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.PLANNING.value)
+    @patch("integrations.imports.helpers.decrypt_or_raise", return_value="dummy-key")
+    @patch("app.models.providers.services.get_media_metadata")
+    def test_stremio_sync_completes_show_the_provider_calls_ended(
+        self, mock_metadata, mock_decrypt
+    ):
+        """A positively ended show still completes, from Planning or In progress."""
+        mock_metadata.return_value = {
+            "title": "Alien: Earth",
+            "details": {"status": "Ended"},
+        }
+        self.tv.status = Status.IN_PROGRESS.value
+        self.tv.save()
+        StremioAccount.objects.create(user=self.user, auth_key="encrypted-key")
+
+        importer = stremio.StremioImporter(self.user, mode="new")
+        advanced = importer._advance_status_in_place(
+            self.tv,
+            Status.COMPLETED.value,
+        )
+
+        self.assertTrue(advanced)
+        self.tv.refresh_from_db()
+        self.assertEqual(self.tv.status, Status.COMPLETED.value)


### PR DESCRIPTION
> [!WARNING]
> ## ⚠️ Not tested — please review carefully before merging
>
> **I have not tested this at all.** I did a high-level code scan — a skim — and nothing
> more. No manual verification in a running instance, no line-by-line review.
>
> I am opening it anyway because I do not have the time to take it further and I would
> rather not sit on potential fixes that someone else could pick up or finish. Please treat
> every claim below as *intent*, not as verified behaviour.
>
> Automated tests pass and lint is clean, but that is a floor, not validation. **Assume
> nothing here is proven correct.** If it needs rework or you would rather close it, that
> is entirely fine.

> [!IMPORTANT]
> **Stacked PR.** This branch is built on `fix/375-show-completion-status`, so the diff
> below also contains that branch's commits. Please merge
> [the show-completion-status PR](https://github.com/dannyvfilms/Floppy/pulls?q=is%3Apr+head%3Afix%2F375-show-completion-status)
> first — this change calls `classify_production_status` and `resolve_production_status`,
> both introduced there. Only the last two commits belong to this PR.

## Summary
- The recurring Stremio sync marked a show Completed once every episode it knew about was watched. But it only sees the episodes Cinemeta happens to list, so "everything watched" is not evidence the show is over — and completing it overwrites whatever status the user set.
- A TV row is now advanced to Completed only when the provider positively reports the show as finished, and that rule applies from Planning **and** In progress alike. Previously only the In-progress transition was blocked, so the same library could end up completed or not depending on which state an earlier sync had left it in. An unreachable provider, a missing status, or an unrecognized one all leave the row alone.

**Why:** the reporter in #375 was using a recurring Trakt/Stremio import, and this sync was one of the things rewriting their statuses behind them.

**Reviewer note — deliberate asymmetry:** on a *blank* provider status this background sync refuses to complete, while the user-driven season-completion path (the base PR) does complete. The reasoning is that a background job should need positive evidence before finalizing something you are tracking, whereas a user action should not be blocked because a manual-source show carries no status. This is a decision worth confirming rather than assuming.

## AI Assistance
- `claude-opus-5` (Claude Code) wrote this change and its tests.

## How It Was Tested
- `scripts/test.sh integrations.tests.imports.test_stremio_status_sync` -> Passed (4 tests)
- `ruff check src/` -> Clean
- **No manual/browser QA**, and in particular no run against a real Stremio account. See the warning at the top.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #375
