### PR TITLE
[UNTESTED] Scope Trakt play matching to the source being imported

### DIFF
--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -435,6 +435,7 @@ class TraktImporter(TraktMetadataResolverMixin):
         return set(
             app.models.Episode.objects.filter(
                 related_season__user=self.user,
+                item__source=Sources.TMDB.value,
                 end_date__isnull=False,
             ).values_list(
                 "item__media_id",
@@ -447,8 +448,12 @@ class TraktImporter(TraktMetadataResolverMixin):
     def _get_existing_episode_play_times(self):
         """Return existing episode play end_dates keyed by (tmdb_id, season, episode)."""
         play_times = defaultdict(list)
+        # Scoped to the source this importer resolves against: an episode
+        # tracked from another provider can share a media_id with a TMDB one,
+        # and matching across them would skip a play that was never imported.
         rows = app.models.Episode.objects.filter(
             related_season__user=self.user,
+            item__source=Sources.TMDB.value,
             end_date__isnull=False,
         ).values_list(
             "item__media_id",
@@ -465,6 +470,7 @@ class TraktImporter(TraktMetadataResolverMixin):
         play_times = defaultdict(list)
         rows = app.models.Movie.objects.filter(
             user=self.user,
+            item__source=Sources.TMDB.value,
             end_date__isnull=False,
         ).values_list("item__media_id", "end_date")
         for media_id, end_date in rows:

--- a/src/integrations/tests/imports/test_trakt_play_matching.py
+++ b/src/integrations/tests/imports/test_trakt_play_matching.py
@@ -1,0 +1,96 @@
+from datetime import UTC, datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import TV, Episode, Item, MediaTypes, Season, Sources, Status
+from integrations.imports.trakt import TraktImporter
+
+User = get_user_model()
+
+
+class TraktPlayMatchingTests(TestCase):
+    """Which existing local plays count as "already imported" for Trakt."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="password123",
+        )
+        self.watched_at = datetime(2026, 8, 23, 20, 0, 0, tzinfo=UTC)
+
+    def _track_episode(self, source):
+        """Track one watched episode of show 1001 S1E1 under `source`."""
+        tv_item = Item.objects.create(
+            media_id="1001",
+            source=source,
+            media_type=MediaTypes.TV.value,
+            title="Alien: Earth",
+        )
+        season_item = Item.objects.create(
+            media_id="1001",
+            source=source,
+            media_type=MediaTypes.SEASON.value,
+            title="Alien: Earth Season 1",
+            season_number=1,
+        )
+        episode_item = Item.objects.create(
+            media_id="1001",
+            source=source,
+            media_type=MediaTypes.EPISODE.value,
+            title="Episode 1",
+            season_number=1,
+            episode_number=1,
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        Episode.objects.create(
+            item=episode_item,
+            related_season=season,
+            end_date=self.watched_at,
+        )
+
+    def test_tmdb_play_is_recognized_as_already_imported(self):
+        """A TMDB-sourced play of the same episode still matches."""
+        self._track_episode(Sources.TMDB.value)
+        importer = TraktImporter("testuser", self.user, mode="new")
+
+        self.assertTrue(
+            importer._is_duplicate_play(
+                importer.existing_episode_play_times[("1001", 1, 1)],
+                self.watched_at,
+            ),
+        )
+
+    def test_other_provider_play_does_not_shadow_a_tmdb_import(self):
+        """A TVDB episode sharing the media_id must not be matched as a TMDB play."""
+        self._track_episode(Sources.TVDB.value)
+        importer = TraktImporter("testuser", self.user, mode="new")
+
+        self.assertEqual(importer.existing_episode_play_times[("1001", 1, 1)], [])
+        self.assertFalse(
+            importer._is_duplicate_play(
+                importer.existing_episode_play_times[("1001", 1, 1)],
+                self.watched_at,
+            ),
+        )
+
+    def test_other_provider_play_is_not_an_exact_watch_key(self):
+        """The exact-match index is scoped to the imported source too."""
+        self._track_episode(Sources.TVDB.value)
+        importer = TraktImporter("testuser", self.user, mode="new")
+
+        self.assertNotIn(
+            ("1001", 1, 1, self.watched_at),
+            importer.existing_episode_watch_keys,
+        )


### PR DESCRIPTION
> [!WARNING]
> ## ⚠️ Not tested — please review carefully before merging
>
> **I have not tested this at all.** I did a high-level code scan — a skim — and nothing
> more. No manual verification in a running instance, no line-by-line review.
>
> I am opening it anyway because I do not have the time to take it further and I would
> rather not sit on potential fixes that someone else could pick up or finish. Please treat
> every claim below as *intent*, not as verified behaviour.
>
> Automated tests pass and lint is clean, but that is a floor, not validation. **Assume
> nothing here is proven correct.** If it needs rework or you would rather close it, that
> is entirely fine.

## Summary
- A recurring Trakt import re-walks the whole history each run, so it must recognize plays it already imported. It does that with three lookups keyed on `media_id`: the exact watch keys, the episode play times, and the movie play times.
- Provider ids only share a namespace by accident. An episode or movie tracked from TVDB (or any other source) whose `media_id` happens to equal a TMDB id was treated as an existing TMDB play — so the real Trakt play was skipped as a duplicate and silently lost.
- All three lookups are now scoped to TMDB, the source this importer actually resolves against.

**Why:** a silently dropped play is invisible to the user and unrecoverable without a re-import, which is the failure mode #375 is about.

**Note on scope:** this branch was originally much larger. `latest` has since gained its own duplicate-play matching (`_DUPLICATE_PLAY_WINDOW`, `_get_existing_episode_play_times`, `_is_duplicate_play`), which already covers most of what it did — excluding dateless local rows, and importing a play whose timestamp will not parse rather than dropping it. Rather than layer a second mechanism beside yours, the branch was reduced to the one gap that remains.

**One thing I deliberately did *not* change:** `latest` uses a 15-minute window to collapse a webhook play and its Trakt counterpart. That is sound for cross-source lag, but it also means a genuine rewatch of the same episode started within 15 minutes of the first play is absorbed into it. That is rare and your call — reverting a documented decision of yours did not belong in this PR.

## AI Assistance
- `claude-opus-5` (Claude Code) wrote this change and its tests.

## How It Was Tested
- `scripts/test.sh integrations.tests.imports.test_trakt_play_matching` -> Passed (3 tests)
- `scripts/test.sh integrations.tests.imports.test_trakt` -> Passed (57 tests)
- `ruff check src/` -> Clean
- **No manual/browser QA**, and in particular no run against a real Trakt account. See the warning at the top.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #375
