### PR TITLE
Fix OverflowError when rendering year-1 sentinel datetimes

### DIFF
--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -406,6 +406,9 @@ def enrich_items_with_user_data(
     return enriched_items
 
 
+MIN_VALID_RELEASE_YEAR = 1900
+
+
 def extract_release_datetime(metadata):
     """Extract release datetime from metadata dict."""
     from datetime import datetime
@@ -424,7 +427,10 @@ def extract_release_datetime(metadata):
         year = metadata.get("details", {}).get("year") or metadata.get("year")
         if year:
             try:
-                return datetime(int(year), 1, 1, tzinfo=ZoneInfo("UTC"))
+                parsed_year = int(year)
+                if parsed_year < MIN_VALID_RELEASE_YEAR:
+                    return None
+                return datetime(parsed_year, 1, 1, tzinfo=ZoneInfo("UTC"))
             except (ValueError, TypeError):
                 return None
         return None
@@ -443,6 +449,8 @@ def extract_release_datetime(metadata):
     for fmt, length in format_lengths.items():
         try:
             dt = datetime.strptime(date_str[:length], fmt)  # noqa: DTZ007  # date-only value; no timezone applies
+            if dt.year < MIN_VALID_RELEASE_YEAR:
+                continue
             return dt.replace(tzinfo=ZoneInfo("UTC"))
         except (ValueError, TypeError):
             continue

--- a/src/app/migrations/0171_fix_year_one_release_datetime.py
+++ b/src/app/migrations/0171_fix_year_one_release_datetime.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def clear_sentinel_release_datetimes(apps, schema_editor):
+    """Clear release_datetime values stuck at the year-1 sentinel.
+
+    These were produced by extract_release_datetime() before it gained a
+    lower-bound sanity check, and crash date-rendering template filters with
+    OverflowError on servers running a negative UTC offset.
+    """
+    Item = apps.get_model("app", "Item")
+    Item.objects.filter(release_datetime__year__lte=1).update(release_datetime=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0170_remove_item_app_item_source_valid_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            clear_sentinel_release_datetimes,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -722,7 +722,10 @@ def release_year(item, media=None):
             return display_year
         release_dt = getattr(media.item, "release_datetime", None)
         if release_dt:
-            return timezone.localtime(release_dt).year
+            try:
+                return timezone.localtime(release_dt).year
+            except (OverflowError, ValueError, OSError):
+                pass
 
     if not item:
         return None
@@ -744,7 +747,10 @@ def release_year(item, media=None):
 
     release_dt = getattr(item, "release_datetime", None)
     if release_dt:
-        return timezone.localtime(release_dt).year
+        try:
+            return timezone.localtime(release_dt).year
+        except (OverflowError, ValueError, OSError):
+            return None
 
     return None
 

--- a/src/app/tests/test_helpers.py
+++ b/src/app/tests/test_helpers.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from app.helpers import (
     enrich_items_with_user_data,
+    extract_release_datetime,
     form_error_messages,
     minutes_to_hhmm,
     normalize_navigation_url,
@@ -85,6 +86,24 @@ class HelpersTest(TestCase):
             "/details/tmdb/movie/118340/guardians-of-the-galaxy",
         )
         self.assertEqual(result, "redirected")
+
+    def test_extract_release_datetime_valid_date_string(self):
+        """A normal release_date string is parsed into a UTC datetime."""
+        result = extract_release_datetime({"release_date": "2020-05-15"})
+        self.assertEqual((result.year, result.month, result.day), (2020, 5, 15))
+
+    def test_extract_release_datetime_valid_year_only(self):
+        """A plausible year-only value produces January 1st of that year."""
+        result = extract_release_datetime({"year": 1999})
+        self.assertEqual((result.year, result.month, result.day), (1999, 1, 1))
+
+    def test_extract_release_datetime_rejects_sentinel_year_one_string(self):
+        """A year-0001 date string must not produce the OverflowError sentinel."""
+        self.assertIsNone(extract_release_datetime({"release_date": "0001-01-01"}))
+
+    def test_extract_release_datetime_rejects_implausible_year(self):
+        """An implausible bare year (e.g. 1) must not produce a datetime."""
+        self.assertIsNone(extract_release_datetime({"year": 1}))
 
     def test_normalize_navigation_url_decodes_encoded_query_separators(self):
         """Navigation URLs from modal forms should restore their query separators."""

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -1,10 +1,11 @@
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 from django.contrib.auth import get_user_model
 from django.template.loader import render_to_string
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
@@ -215,6 +216,22 @@ class AppTagsTests(TestCase):
 
             # Check that it returns a non-empty string
             self.assertTrue(isinstance(result, str))
+
+    @override_settings(TIME_ZONE="America/New_York")
+    def test_release_year_handles_year_one_sentinel_datetime(self):
+        """release_year must not raise OverflowError for a year-0001 release_datetime.
+
+        A negative UTC offset (e.g. America/New_York) underflows below
+        datetime.MINYEAR when converting the sentinel to local time.
+        """
+        item = Item(
+            media_id="118340",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Test Movie",
+            release_datetime=datetime(1, 1, 1, tzinfo=UTC),
+        )
+        self.assertIsNone(app_tags.release_year(item))
 
     def test_natural_day(self):
         """Test the natural_day filter."""

--- a/src/users/templatetags/user_tags.py
+++ b/src/users/templatetags/user_tags.py
@@ -256,11 +256,11 @@ def user_date_format(date, user):
         # Default to system format
         return formats.date_format(local_dt, "DATE_FORMAT")
 
-    except (ValueError, TypeError, AttributeError):
+    except (ValueError, TypeError, AttributeError, OverflowError):
         # Fallback to default format if there's an error
         try:
             return formats.date_format(date, "DATE_FORMAT")
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError, OverflowError):
             # If all else fails, return the original value as a string
             return str(date)
 
@@ -282,11 +282,11 @@ def user_time_format(datetime_obj, user):
         local_dt = timezone.localtime(datetime_obj)
         return _format_time_by_preference(local_dt, user, formats)
 
-    except (ValueError, TypeError, AttributeError):
+    except (ValueError, TypeError, AttributeError, OverflowError):
         # Fallback to default format if there's an error
         try:
             return formats.date_format(datetime_obj, "TIME_FORMAT")
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError, OverflowError):
             # If all else fails, return the original value as a string
             return str(datetime_obj)
 
@@ -349,11 +349,11 @@ def user_datetime_format(datetime_obj, user):
 
         date_part = user_date_format(datetime_obj, user)
         time_part = user_time_format(datetime_obj, user)
-    except (ValueError, TypeError, AttributeError):
+    except (ValueError, TypeError, AttributeError, OverflowError):
         # Fallback to default format if there's an error
         try:
             return formats.date_format(datetime_obj, "DATETIME_FORMAT")
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError, OverflowError):
             # If all else fails, return the original value as a string
             return str(datetime_obj)
     else:

--- a/src/users/tests/test_user_tags.py
+++ b/src/users/tests/test_user_tags.py
@@ -1,0 +1,40 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from django.test import TestCase, override_settings
+
+from users.models import DateFormatChoices
+from users.templatetags import user_tags
+
+
+class UserDateFormatOverflowTests(TestCase):
+    """user_date_format/time/datetime must not raise on the year-1 sentinel."""
+
+    def setUp(self):
+        self.user = MagicMock()
+        self.user.date_format = DateFormatChoices.ISO_8601
+
+    @override_settings(TIME_ZONE="America/New_York")
+    def test_user_date_format_handles_year_one_sentinel(self):
+        """A negative UTC offset underflows below datetime.MINYEAR for year 1.
+
+        The filter must fall back to the default format instead of raising.
+        """
+        sentinel = datetime(1, 1, 1, tzinfo=UTC)
+        result = user_tags.user_date_format(sentinel, self.user)
+        self.assertIsInstance(result, str)
+        self.assertTrue(result)
+
+    @override_settings(TIME_ZONE="America/New_York")
+    def test_user_time_format_handles_year_one_sentinel(self):
+        sentinel = datetime(1, 1, 1, tzinfo=UTC)
+        result = user_tags.user_time_format(sentinel, self.user)
+        self.assertIsInstance(result, str)
+        self.assertTrue(result)
+
+    @override_settings(TIME_ZONE="America/New_York")
+    def test_user_datetime_format_handles_year_one_sentinel(self):
+        sentinel = datetime(1, 1, 1, tzinfo=UTC)
+        result = user_tags.user_datetime_format(sentinel, self.user)
+        self.assertIsInstance(result, str)
+        self.assertTrue(result)


### PR DESCRIPTION
## Summary

This PR fixes crashes that occur when rendering dates with a year-1 sentinel value (used internally to represent missing release dates) on servers running a negative UTC offset timezone. The issue manifests as an `OverflowError` when converting the sentinel datetime to local time, since the offset underflows below `datetime.MINYEAR`.

**Changes:**
- Added `OverflowError` exception handling to three user-facing date/time formatting filters (`user_date_format`, `user_time_format`, `user_datetime_format`) to gracefully fall back to default formatting
- Added `OverflowError` exception handling to the `release_year` template filter to return `None` instead of crashing
- Added validation in `extract_release_datetime()` to reject implausible years (< 1900) and prevent creation of year-1 sentinels going forward
- Created a data migration to clear existing year-1 sentinel values from the database
- Added comprehensive test coverage for all affected code paths

## How It Was Tested

- Added `UserDateFormatOverflowTests` test class with three tests covering the user tag filters with year-1 sentinels in America/New_York timezone
- Added `test_release_year_handles_year_one_sentinel_datetime` to verify the app tag filter handles the sentinel gracefully
- Added four tests to `test_helpers.py` covering `extract_release_datetime()` validation:
  - `test_extract_release_datetime_valid_date_string` - normal dates work
  - `test_extract_release_datetime_valid_year_only` - plausible years work
  - `test_extract_release_datetime_rejects_sentinel_year_one_string` - year-0001 strings are rejected
  - `test_extract_release_datetime_rejects_implausible_year` - implausible bare years are rejected

## Database & Migration Safety

- [x] No existing or shared migrations were altered or renumbered
- [x] New migration `0171_fix_year_one_release_datetime.py` safely clears sentinel values using `RunPython.noop` for reversibility
- [x] Migration hygiene verified (reversible, uses `apps.get_model()`)

## Related Issues

Fixes crashes on servers with negative UTC offsets when rendering items with year-1 sentinel release datetimes.

https://claude.ai/code/session_01VtRXaY16AFW1jeKXHkoCky