### PR TITLE
Reveal media-card hover actions on a first touch tap

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -251,6 +251,12 @@ html.light .theme-toggle-icon-moon {
   object-fit: none;
 }
 
+/* Cards are tapped twice (first reveals the actions, second opens details);
+   without this, a quick second tap can be swallowed as a double-tap zoom. */
+.media-card {
+  touch-action: manipulation;
+}
+
 .media-card-poster {
   object-fit: cover;
 }
@@ -1091,6 +1097,98 @@ html.light .theme-toggle-icon-moon {
   .search-result-card:hover .media-card-year,
   .search-result-card-square:hover .media-card-year {
     max-height: max-content;
+  }
+}
+
+/*
+ * First touch tap opens a card: match what :hover shows so the subtitle and the
+ * action buttons appear together rather than only the buttons. Kept inside the
+ * coarse-pointer block below so it beats the emulated-hover neutralisation.
+ */
+
+/* ...unless a first touch tap opened it, which is the one case the compact
+   grid does want the actions on screen. */
+@media (pointer: coarse) {
+  body[data-mobile-grid="compact"] .media-card-overlay.media-card-overlay-revealed {
+    display: flex;
+  }
+}
+
+/*
+ * Touch has no hover, but browsers emulate it for a moment on tap. That fires
+ * the card's hover reveals and then reverts them, which reads as a flash - the
+ * title cross-fades between its one-line ::before and the three-line text. On
+ * coarse pointers those reveals are neutralised and driven by the tap state,
+ * so nothing moves until the card is actually opened.
+ */
+@media (pointer: coarse) {
+  .search-result-card:hover .media-card-title-row,
+  .search-result-card-square:hover .media-card-title-row {
+    max-height: var(--card-title-line);
+  }
+
+  .search-result-card:hover .media-card-title[title],
+  .search-result-card-square:hover .media-card-title[title] {
+    color: transparent;
+  }
+
+  .search-result-card:hover .media-card-title[title]::before,
+  .search-result-card-square:hover .media-card-title[title]::before {
+    opacity: 1;
+  }
+
+  .search-result-card:hover .media-card-title[title]:hover,
+  .search-result-card-square:hover .media-card-title[title]:hover {
+    color: transparent;
+  }
+
+  .search-result-card:hover:not(.media-card-subtitle-always) .media-card-year,
+  .search-result-card-square:hover:not(.media-card-subtitle-always) .media-card-year {
+    max-height: 0;
+    margin-top: 0;
+    opacity: 0;
+  }
+
+  .search-result-card.media-card-revealed:not(.media-card-subtitle-always) .media-card-year,
+  .search-result-card-square.media-card-revealed:not(.media-card-subtitle-always) .media-card-year {
+    max-height: 2lh;
+    margin-top: 0.25rem;
+    opacity: 1;
+  }
+
+  @supports (interpolate-size: allow-keywords) {
+    .search-result-card.media-card-revealed:not(.media-card-subtitle-always) .media-card-year,
+    .search-result-card-square.media-card-revealed:not(.media-card-subtitle-always) .media-card-year {
+      max-height: max-content;
+    }
+  }
+
+  .search-result-card.media-card-revealed .media-card-title-row,
+  .search-result-card-square.media-card-revealed .media-card-title-row {
+    max-height: calc(3 * var(--card-title-line));
+  }
+
+  .search-result-card.media-card-revealed .media-card-title[title],
+  .search-result-card.media-card-revealed .media-card-title[title]:hover,
+  .search-result-card-square.media-card-revealed .media-card-title[title],
+  .search-result-card-square.media-card-revealed .media-card-title[title]:hover {
+    color: #fff;
+  }
+
+  .search-result-card.media-card-revealed .media-card-title[title]::before,
+  .search-result-card-square.media-card-revealed .media-card-title[title]::before {
+    opacity: 0;
+  }
+
+  /* The reveal cross-fades the ::before single-line over the three-line text,
+     which briefly dims the title on tap. Snap that colour/opacity swap but
+     keep the row's max-height transition, so the title still expands and
+     collapses smoothly like the hover reveal. */
+  .search-result-card.media-card-revealed .media-card-title,
+  .search-result-card-square.media-card-revealed .media-card-title,
+  .search-result-card.media-card-revealed .media-card-title[title]::before,
+  .search-result-card-square.media-card-revealed .media-card-title[title]::before {
+    transition: none;
   }
 }
 

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -4807,6 +4807,11 @@
       justify-content: space-between;
     }
   }
+  .sm\:justify-end {
+    @media (width >= 40rem) {
+      justify-content: flex-end;
+    }
+  }
   .sm\:justify-start {
     @media (width >= 40rem) {
       justify-content: flex-start;
@@ -5579,6 +5584,16 @@
       display: none;
     }
   }
+  .pointer-coarse\:opacity-100 {
+    @media (pointer: coarse) {
+      opacity: 100%;
+    }
+  }
+  .hover-tap\:pointer-events-auto {
+    &:hover {
+      pointer-events: auto;
+    }
+  }
   .hover-tap\:opacity-100 {
     &:hover {
       opacity: 100%;
@@ -5814,6 +5829,9 @@ html.light .theme-toggle-icon-moon {
 }
 .lazyload, .lazyloading {
   object-fit: none;
+}
+.media-card {
+  touch-action: manipulation;
 }
 .media-card-poster {
   object-fit: cover;
@@ -6465,6 +6483,52 @@ html.light .theme-toggle-icon-moon {
   }
   .search-result-card:hover .media-card-year, .search-result-card-square:hover .media-card-year {
     max-height: max-content;
+  }
+}
+@media (pointer: coarse) {
+  body[data-mobile-grid="compact"] .media-card-overlay.media-card-overlay-revealed {
+    display: flex;
+  }
+}
+@media (pointer: coarse) {
+  .search-result-card:hover .media-card-title-row, .search-result-card-square:hover .media-card-title-row {
+    max-height: var(--card-title-line);
+  }
+  .search-result-card:hover .media-card-title[title], .search-result-card-square:hover .media-card-title[title] {
+    color: transparent;
+  }
+  .search-result-card:hover .media-card-title[title]::before, .search-result-card-square:hover .media-card-title[title]::before {
+    opacity: 1;
+  }
+  .search-result-card:hover .media-card-title[title]:hover, .search-result-card-square:hover .media-card-title[title]:hover {
+    color: transparent;
+  }
+  .search-result-card:hover:not(.media-card-subtitle-always) .media-card-year, .search-result-card-square:hover:not(.media-card-subtitle-always) .media-card-year {
+    max-height: 0;
+    margin-top: 0;
+    opacity: 0;
+  }
+  .search-result-card.media-card-revealed:not(.media-card-subtitle-always) .media-card-year, .search-result-card-square.media-card-revealed:not(.media-card-subtitle-always) .media-card-year {
+    max-height: 2lh;
+    margin-top: 0.25rem;
+    opacity: 1;
+  }
+  @supports (interpolate-size: allow-keywords) {
+    .search-result-card.media-card-revealed:not(.media-card-subtitle-always) .media-card-year, .search-result-card-square.media-card-revealed:not(.media-card-subtitle-always) .media-card-year {
+      max-height: max-content;
+    }
+  }
+  .search-result-card.media-card-revealed .media-card-title-row, .search-result-card-square.media-card-revealed .media-card-title-row {
+    max-height: calc(3 * var(--card-title-line));
+  }
+  .search-result-card.media-card-revealed .media-card-title[title], .search-result-card.media-card-revealed .media-card-title[title]:hover, .search-result-card-square.media-card-revealed .media-card-title[title], .search-result-card-square.media-card-revealed .media-card-title[title]:hover {
+    color: #fff;
+  }
+  .search-result-card.media-card-revealed .media-card-title[title]::before, .search-result-card-square.media-card-revealed .media-card-title[title]::before {
+    opacity: 0;
+  }
+  .search-result-card.media-card-revealed .media-card-title, .search-result-card-square.media-card-revealed .media-card-title, .search-result-card.media-card-revealed .media-card-title[title]::before, .search-result-card-square.media-card-revealed .media-card-title[title]::before {
+    transition: none;
   }
 }
 .stat-scroll-safe.stat-tooltip-safe {

--- a/src/templates/app/components/album_list_grid_items.html
+++ b/src/templates/app/components/album_list_grid_items.html
@@ -5,7 +5,11 @@
   <div {% if forloop.last and media_list.has_next %} hx-get="{% url 'medialist' media_type %}?page={{ media_list.next_page_number }}" hx-trigger="revealed threshold:200px" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" class="pagination-trigger" data-page="{{ media_list.next_page_number }}" {% endif %}
        class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative group hover:ring-2 hover:ring-indigo-500 transition-all search-result-card-square{% if user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}"
        data-media-type="{{ MediaTypes.MUSIC.value }}"
-       x-data="{ trackOpen: false }">
+       x-data="{ trackOpen: false, revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+       @click.capture="tapToReveal($event)"
+       @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+           @click.window="if (revealed && !$root.contains($event.target)) revealed = false"
+       :class="revealed ? 'media-card-revealed' : ''">
     <div class="relative">
       <a href="{{ tracker.album|music_album_url }}">
         {% if tracker.album.image and tracker.album.image != IMG_NONE %}
@@ -40,7 +44,8 @@
       </div>
 
       {# Hover overlay with actions #}
-      <div class="media-card-overlay absolute inset-0 flex items-center justify-center opacity-0 hover-tap:opacity-100 transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
+      <div class="media-card-overlay absolute inset-0 flex items-center justify-center hover-tap:opacity-100 hover-tap:pointer-events-auto transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+            :class="revealed ? 'opacity-100 pointer-events-auto media-card-overlay-revealed' : 'opacity-0 pointer-events-none'">
         <div class="absolute inset-0 bg-black/50 z-0"></div>
         <a href="{{ tracker.album|music_album_url }}" class="absolute inset-0 z-0"></a>
         <div class="relative z-10 flex items-center justify-center space-x-2.5">

--- a/src/templates/app/components/artist_grid_items.html
+++ b/src/templates/app/components/artist_grid_items.html
@@ -5,7 +5,11 @@
   <div {% if forloop.last and media_list.has_next %} hx-get="{% url 'medialist' media_type %}?page={{ media_list.next_page_number }}" hx-trigger="revealed threshold:200px" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" class="pagination-trigger" data-page="{{ media_list.next_page_number }}" {% endif %}
        class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative group hover:ring-2 hover:ring-indigo-500 transition-all search-result-card{% if user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}"
        data-media-type="{{ MediaTypes.MUSIC.value }}"
-       x-data="{ trackOpen: false }">
+       x-data="{ trackOpen: false, revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+       @click.capture="tapToReveal($event)"
+       @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+           @click.window="if (revealed && !$root.contains($event.target)) revealed = false"
+       :class="revealed ? 'media-card-revealed' : ''">
     <div class="relative">
       <a href="{{ tracker.artist|music_artist_url }}">
         {# Artist photo (from Wikipedia) #}
@@ -41,7 +45,8 @@
       </div>
 
       {# Hover overlay with actions #}
-      <div class="media-card-overlay absolute inset-0 flex items-center justify-center opacity-0 hover-tap:opacity-100 transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
+      <div class="media-card-overlay absolute inset-0 flex items-center justify-center hover-tap:opacity-100 hover-tap:pointer-events-auto transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+            :class="revealed ? 'opacity-100 pointer-events-auto media-card-overlay-revealed' : 'opacity-0 pointer-events-none'">
         {# Darkening background layer #}
         <div class="absolute inset-0 bg-black/50 z-0"></div>
         

--- a/src/templates/app/components/detail_notes_block.html
+++ b/src/templates/app/components/detail_notes_block.html
@@ -1,10 +1,20 @@
 {% load app_tags %}
 {% load user_tags %}
 
+{% comment %}
+  canHover keys the edit affordance off the pointer's actual capability rather
+  than a width breakpoint, which a large tablet would defeat. Touch browsers do
+  fire an emulated mouseenter on tap, so a hover-only button is reachable there
+  only by accident: it appears after a tap aimed at something else and vanishes
+  on the next one. Where hover is not real the button is simply always shown.
+  focusin/focusout keep it reachable by keyboard.
+{% endcomment %}
 <div class="mb-2"
-     x-data="{ hovered: false, trackOpen: false }"
+     x-data="{ hovered: false, trackOpen: false, canHover: window.matchMedia('(hover: hover)').matches }"
      @mouseenter="hovered = true"
-     @mouseleave="hovered = false">
+     @mouseleave="hovered = false"
+     @focusin="hovered = true"
+     @focusout="if (!$el.contains($event.relatedTarget)) hovered = false">
   <div x-show="trackOpen"
        x-cloak
        @mousedown.self="trackOpen = false"
@@ -26,7 +36,7 @@
        x-init="$nextTick(() => checkClamp())">
     {% if not public_notes_view|default:False %}
     <div class="absolute top-2 right-2 z-10"
-         x-show="hovered"
+         x-show="!canHover || hovered"
          x-transition.opacity.duration.150ms
          style="display: none;">
       <button type="button"

--- a/src/templates/app/components/episode_row.html
+++ b/src/templates/app/components/episode_row.html
@@ -2,10 +2,17 @@
 {% load user_tags %}
 <div class="bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg"
      x-show="!$store.epLayout || $store.epLayout !== 'list'">
+  {% comment %}
+    canHover keys the blur controls off the pointer's actual capability. Touch
+    fires only an emulated mouseenter, so a hover-gated control is reachable
+    there by accident at best - and the centred button is the only way to
+    unblur a thumbnail, so it must be present outright.
+  {% endcomment %}
   <div class="flex flex-col md:flex-row"
        x-data="{
          revealed: false,
          hovering: false,
+         canHover: window.matchMedia('(hover: hover)').matches,
          epWatched: {{ episode.history|yesno:'true,false' }},
          blurActive: {% if not public_view|default:False and user.is_authenticated %}{{ user.obfuscate_episodes|yesno:'true,false' }}{% else %}false{% endif %},
          syncBlurState(active) {
@@ -57,7 +64,7 @@
       {% if not public_view|default:False and user.is_authenticated %}
         {# Centered reveal button — shows on hover when blurred and not yet revealed #}
         <div class="absolute inset-0 z-20 flex items-center justify-center"
-             x-show="hovering && blurActive && !epWatched && !revealed"
+             x-show="(!canHover || hovering) && blurActive && !epWatched && !revealed"
              x-transition:enter="transition-opacity duration-150"
              x-transition:enter-start="opacity-0"
              x-transition:enter-end="opacity-100"
@@ -73,7 +80,7 @@
         </div>
         {# Corner eyeball — shows on hover; toggles the global blur setting #}
         <div class="absolute top-2 right-2 z-20"
-             x-show="hovering && (!blurActive || epWatched || revealed)"
+             x-show="(!canHover || hovering) && (!blurActive || epWatched || revealed)"
              x-transition:enter="transition-opacity duration-150"
              x-transition:enter-start="opacity-0"
              x-transition:enter-end="opacity-100"

--- a/src/templates/app/components/fill_history.html
+++ b/src/templates/app/components/fill_history.html
@@ -26,8 +26,9 @@
                     hx-swap="outerHTML">{% include "app/icons/edit.svg" with classes="w-4 h-4" %}</button>
           {% endif %}
           <button title="Delete"
-                  class="inline-flex items-center justify-center rounded-md h-8 w-8 text-gray-400 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-opacity duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50 cursor-pointer"
+                  class="inline-flex items-center justify-center rounded-md h-8 w-8 text-gray-400 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50 cursor-pointer"
                   hx-delete="{% url 'delete_history_record' media_type entry.id %}"
+                  hx-confirm="Delete this activity entry? This cannot be undone."
                   hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                   hx-target="#history-{{ entry.id }}"
                   hx-swap="outerHTML">{% include "app/icons/trashcan.svg" with classes="w-5 h-5" %}</button>

--- a/src/templates/app/components/history_card.html
+++ b/src/templates/app/components/history_card.html
@@ -6,7 +6,11 @@
 
 <div class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative {{ card_class }}{% if user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}"
      data-media-type="{{ entry.media_type }}"
-     x-data="{ trackOpen: false, historyOpen: false, listsOpen: false }">
+     x-data="{ trackOpen: false, historyOpen: false, listsOpen: false, revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+     @click.capture="tapToReveal($event)"
+     @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+           @click.window="if (revealed && !$root.contains($event.target)) revealed = false"
+     :class="revealed ? 'media-card-revealed' : ''">
   <div class="media-card-visual relative">
     {% with entry.item|display_title:user as preferred_entry_title %}
     <a hx-boost="true"
@@ -49,7 +53,8 @@
 
     {# Hover overlay with history-specific buttons #}
     {% if entry.item and entry.item.media_type %}
-      <div class="media-card-overlay absolute inset-0 flex items-center justify-center opacity-0 hover-tap:opacity-100 transition-opacity duration-200{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
+      <div class="media-card-overlay absolute inset-0 flex items-center justify-center hover-tap:opacity-100 hover-tap:pointer-events-auto transition-opacity duration-200{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+                :class="revealed ? 'opacity-100 pointer-events-auto media-card-overlay-revealed' : 'opacity-0 pointer-events-none'">
         {# Darkening background layer #}
         <div class="absolute inset-0 bg-black/50 z-0"></div>
         

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -13,7 +13,11 @@
       <div class="media-card {% if secondary_color %}bg-[var(--color-surface-strong)]{% else %}bg-[var(--color-surface)]{% endif %} rounded-lg overflow-hidden shadow-lg relative {% if active %}ring-2 ring-indigo-700{% endif %} {% if from_grid %}hover:ring-2 hover:ring-indigo-500 transition-all {% if resolved_media_type == 'podcast' or resolved_media_type == 'music' %}search-result-card-square{% else %}search-result-card{% endif %}{% endif %} {% if user.media_card_subtitle_display == 'always' %}media-card-subtitle-always{% elif show_episode_identity|default:False and resolved_media_type == MediaTypes.EPISODE.value %}media-card-subtitle-always{% endif %} {% if recommend_mode %}cursor-pointer{% endif %} group"
            data-media-type="{{ item.media_type }}"
            {% if recommend_mode %}hx-get="{% if resolved_search_preview_url %}{{ resolved_search_preview_url }}{% else %}{% url 'recommend_search' recommend_list_id %}{% endif %}?show_preview=true&media_id={{ item.media_id }}&media_type={{ item.media_type }}&source={{ item.source }}&title={{ resolved_item_title|default:title|urlencode }}&image={{ item.image|urlencode }}&q={{ query|urlencode }}&search_media_type={{ media_type|urlencode }}&page={{ page }}" hx-target="{{ resolved_search_modal_target }}" hx-swap="innerHTML"{% endif %}
-           x-data="{ trackOpen: false, listsOpen: false }">
+           x-data="{ trackOpen: false, listsOpen: false, revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+           @click.capture="tapToReveal($event)"
+           @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+           @click.window="if (revealed && !$root.contains($event.target)) revealed = false"
+           :class="revealed ? 'media-card-revealed' : ''">
         <div class="media-card-visual relative">
           {% if recommend_mode %}
             <div class="cursor-pointer">
@@ -171,7 +175,8 @@
           {% endif %}
 
           {% if not recommend_mode and not public_view|default:False %}
-            <div class="media-card-overlay absolute inset-0 flex items-center justify-center opacity-0 hover-tap:opacity-100 transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+            <div class="media-card-overlay absolute inset-0 flex items-center justify-center hover-tap:opacity-100 hover-tap:pointer-events-auto transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+                 :class="revealed ? 'opacity-100 pointer-events-auto media-card-overlay-revealed' : 'opacity-0 pointer-events-none'"
                  {% if enable_bulk_select %}x-show="!selectMode"{% endif %}>
               {# Darkening background layer #}
               <div class="absolute inset-0 bg-black/50 z-0"></div>

--- a/src/templates/app/components/person_card_inline.html
+++ b/src/templates/app/components/person_card_inline.html
@@ -1,7 +1,12 @@
 {% load app_tags %}
 {% load user_tags %}
 <div class="w-32 shrink-0">
-  <div class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative search-result-card hover:ring-2 hover:ring-indigo-500 transition-all group{% if user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}">
+  <div class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative search-result-card hover:ring-2 hover:ring-indigo-500 transition-all group{% if user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}"
+       x-data="{ revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } if (this.$root.classList.contains('media-card-subtitle-always')) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+       @click.capture="tapToReveal($event)"
+       @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+       @click.window="if (revealed && !$root.contains($event.target)) revealed = false"
+       :class="revealed ? 'media-card-revealed' : ''">
     <div class="relative">
       {% if person.person_id and person.name %}
         <a href="{% url 'person_detail' source=media.source person_id=person.person_id name=person.name|slug %}">

--- a/src/templates/app/components/podcast_show_grid_items.html
+++ b/src/templates/app/components/podcast_show_grid_items.html
@@ -4,7 +4,10 @@
 {% for tracker in media_list %}
   <div {% if forloop.last and media_list.has_next %} hx-get="{% url 'medialist' media_type %}?page={{ media_list.next_page_number }}" hx-trigger="revealed threshold:200px" hx-swap="afterend" hx-include="#filter-form" hx-indicator="#loading-indicator" class="pagination-trigger" data-page="{{ media_list.next_page_number }}" {% endif %}
        class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative"
-       x-data="{ trackOpen: false }">
+       x-data="{ trackOpen: false, revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+       @click.capture="tapToReveal($event)"
+       @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+           @click.window="if (revealed && !$root.contains($event.target)) revealed = false">
     <div class="relative">
       <a href="{% url 'podcast_show_detail' tracker.show.id %}">
         {# Show image #}
@@ -45,7 +48,8 @@
       </div>
 
       {# Hover overlay with actions #}
-      <div class="media-card-overlay absolute inset-0 flex items-center justify-center opacity-0 hover-tap:opacity-100 transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
+      <div class="media-card-overlay absolute inset-0 flex items-center justify-center hover-tap:opacity-100 hover-tap:pointer-events-auto transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+            :class="revealed ? 'opacity-100 pointer-events-auto media-card-overlay-revealed' : 'opacity-0 pointer-events-none'">
         {# Darkening background layer #}
         <div class="absolute inset-0 bg-black/50 z-0"></div>
         

--- a/src/templates/app/search.html
+++ b/src/templates/app/search.html
@@ -78,7 +78,11 @@
               {% for tracker in local_music_albums %}
                 <div class="media-card bg-[var(--color-surface)] rounded-lg overflow-hidden shadow-lg relative search-result-card-square hover:ring-2 hover:ring-indigo-500 transition-all group{% if request.user.media_card_subtitle_display == 'always' %} media-card-subtitle-always{% endif %}"
                      data-media-type="{{ MediaTypes.MUSIC.value }}"
-                     x-data="{ trackOpen: false }">
+                     x-data="{ trackOpen: false, revealed: false, tapToReveal(e) { if (this.revealed) { if (e.target.closest('button, a, input, select, textarea')) { return; } const link = this.$root.querySelector('.media-card-overlay a[href]') || this.$root.querySelector('a.media-card-title[href]'); if (link) { e.preventDefault(); e.stopPropagation(); link.click(); } return; } if (!window.matchMedia('(pointer: coarse)').matches) { return; } e.preventDefault(); e.stopPropagation(); this.revealed = true; window.dispatchEvent(new CustomEvent('media-card-revealed', { detail: this.$root })); } }"
+                     @click.capture="tapToReveal($event)"
+                     @media-card-revealed.window="if ($event.detail !== $root) revealed = false"
+           @click.window="if (revealed && !$root.contains($event.target)) revealed = false"
+                     :class="revealed ? 'media-card-revealed' : ''">
                   <div class="relative">
                     <a href="{{ tracker.album|music_album_url }}">
                       {% if tracker.album.image and tracker.album.image != IMG_NONE %}
@@ -111,7 +115,8 @@
                       {% endwith %}
                     </div>
 
-                    <div class="media-card-overlay absolute inset-0 flex items-center justify-center opacity-0 hover-tap:opacity-100 transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}">
+                    <div class="media-card-overlay absolute inset-0 flex items-center justify-center hover-tap:opacity-100 hover-tap:pointer-events-auto transition-opacity duration-200 ease-in-out{% if user.clickable_media_cards %} pointer-coarse:hidden{% endif %}"
+                        :class="revealed ? 'opacity-100 pointer-events-auto media-card-overlay-revealed' : 'opacity-0 pointer-events-none'">
                       <div class="absolute inset-0 bg-black/50 z-0"></div>
                       <a href="{{ tracker.album|music_album_url }}" class="absolute inset-0 z-0"></a>
                       <div class="relative z-10 flex items-center justify-center space-x-2.5">

--- a/src/templates/lists/components/list_grid.html
+++ b/src/templates/lists/components/list_grid.html
@@ -15,7 +15,7 @@
         </a>
 
         {% if not profile_username and custom_list.can_edit %}
-          <button class="absolute top-2 right-2 z-20 p-2 bg-black/50 hover:bg-black/75 rounded-full opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all duration-200 text-white hover:text-indigo-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] cursor-pointer"
+          <button class="absolute top-2 right-2 z-20 p-2 bg-black/50 hover:bg-black/75 rounded-full opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 focus-visible:opacity-100 transition-all duration-200 text-white hover:text-indigo-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] cursor-pointer"
                   hx-get="{% url 'list_edit_form' custom_list.id %}"
                   hx-target="next .list-edit-modal-slot"
                   hx-swap="innerHTML"


### PR DESCRIPTION
## Summary
- Media cards reveal their actions on hover, which a touch device cannot do, so on a phone the track, list and history buttons were simply unreachable. A first tap now opens a card — its action overlay, its subtitle and its full title — and a second tap follows the card as before. Opening one card closes any other, and a tap outside closes it.
- Reaching that meant reconciling the surrounding hover behaviour with touch:
  - The compact mobile grid hides the overlay outright at `(pointer: coarse)`, and `display: none` outranks any opacity, so a tapped card carries a class that beats it. Compact is the default layout, so without this the tap revealed nothing.
  - Browsers emulate hover for a moment on tap, firing the card's hover reveals and then reverting them — visible as a flash. On coarse pointers those are neutralised and driven by the tap state instead. Tailwind's own `hover:` utilities are already gated behind `@media (hover: hover)` and need nothing; the hand-written rules in `main.css` do.
  - The title cross-fades a one-line `::before` against the three-line text over different durations (0.15s vs 0.2s), dipping to ~84% mid-swap. Hover makes that gradual by nature; a tap does not, so the swap is instant there.
  - `touch-action: manipulation` keeps a quick second tap from being swallowed as a double-tap zoom.
- Controls that sit *beside* the tap target rather than covering it do not want a reveal — it would cost a second tap and mean intercepting htmx on the link around them — so the list-card edit button and the activity-history delete are shown outright on coarse pointers. That delete had no confirmation at all, which is worse once it is reachable by thumb, so it now uses `hx-confirm` like the other destructive actions.
- The same treatment reaches two more hover-only affordances: the episode thumbnail's blur controls, where the centred button is the only way to unblur and so was unusable on touch, and cast roles, which render as the `media-card-year` subtitle and therefore follow the Card Subtitles setting — tapped to reveal when hidden, and left alone so the first tap opens the person when already shown.
- Also restores the note edit button's touch and keyboard reachability. `64deecfe` added it; `4670d895` rewrote that template from a stale copy and dropped `canHover` along with the `focusin`/`focusout` handlers, unrelated to the feature it carried.

<!-- TODO: attach before/after screenshots from a phone — the reveal on a media card, and the cast role appearing on tap. -->

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_details` -> Passed (141 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list` -> Passed (95 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_track_modal` -> Passed (34 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_history` -> Passed (32 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_person_detail` -> Passed (12 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_search` -> Passed (10 tests, OK)
- `uv run --no-sync python -m app.domain_vocabulary --check` -> Passed (exit 0)
- Behaviour was verified in a headless browser under emulated touch (`pointer: coarse` confirmed matching), driving this branch's actual `x-data`, with the click recorder bound where htmx binds (target phase) rather than at document capture — bound at capture it records clicks the card legitimately stops, which produced a false failure until corrected:
  - first tap reveals with no navigation; second tap opens `/details/…` (the overlay's first anchor is the detail link, not the history link); tapping another card closes the previous; tapping a button leaves the card open; tapping outside closes.
  - revealed overlay computes `display: flex; opacity: 1; pointer-events: auto`, while an untapped one stays `display: none` under the compact grid.
  - with emulated hover, an unrevealed card is now byte-identical to at-rest (title row 20px, `::before` 1) — previously it cross-faded — and desktop hover is unchanged (row 60px, `::before` 0).
  - cast: with Card Subtitles on "hover" the first tap reveals the role and the second opens the person; set to "always visible" the first tap opens the person directly.
  - note edit button: visible at rest on touch, hover-gated on desktop, reachable by keyboard focus in both.
- Manually exercised in Chrome DevTools device emulation (responsive mode with touch), which reports `pointer: coarse` / `hover: none` and so drives the same code paths this change keys off.
- Not covered by emulation: double-tap zoom behaviour (`touch-action: manipulation`) and iOS Safari's first-tap-as-hover heuristic, both of which need a real device.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #970
