### PR TITLE
Keep the navbar search type in context on the history page

### DIFF
--- a/src/app/history_views.py
+++ b/src/app/history_views.py
@@ -1074,6 +1074,16 @@ def history_genres(request):
 @require_GET
 def history(request):
     """Show a day-by-day history of episode and movie plays."""
+    # Surface the media type the user came from (e.g. "view your activity
+    # history" on a movie page) so the navbar search type stays in context
+    # instead of falling back to a stale last_search_type. Invalid values are
+    # dropped so the search bar falls back to last_search_type.
+    requested_media_type = request.GET.get("media_type")
+    context_media_type = (
+        requested_media_type
+        if requested_media_type in MediaTypes.values
+        else None
+    )
     try:
         view_start = time.perf_counter()
         history_mode = request.GET.get("history_mode")
@@ -1266,6 +1276,7 @@ def history(request):
             "active_filters": active_filters,
             "history_refreshing": history_refreshing,
             "history_mode": history_mode,
+            "media_type": context_media_type,
             "use_month_view": use_month_cache,
             "view_year": view_year,
             "view_month": view_month,
@@ -1352,6 +1363,7 @@ def history(request):
             "active_filters": {},
             "database_error": True,
             "history_refreshing": False,
+            "media_type": context_media_type,
         }
         return render(request, "app/history.html", context)
     else:

--- a/src/app/tests/views/test_history.py
+++ b/src/app/tests/views/test_history.py
@@ -784,6 +784,48 @@ class HistoryMonthViewTests(TestCase):
         self.assertNotContains(response, "checkCacheStatus", html=False)
         self.assertNotContains(response, "/api/cache-status/", html=False)
 
+    def test_history_passes_media_type_from_query_into_context(self):
+        response = self.client.get(
+            reverse("history"),
+            {"media_type": MediaTypes.MOVIE.value},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["media_type"], MediaTypes.MOVIE.value)
+
+    def test_history_drops_invalid_media_type_from_query(self):
+        response = self.client.get(
+            reverse("history"),
+            {"media_type": "not-a-media-type"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["media_type"])
+
+    def test_history_keeps_a_non_movie_media_type_in_the_search_bar(self):
+        """A game's history link must not leave the search bar on TV shows.
+
+        Regression for the history button on a game detail page, which links to
+        ?media_type=game&...&logging_style=sessions. Without the media type in
+        context the bar falls back to last_search_type, which defaults to TV.
+        """
+        response = self.client.get(
+            reverse("history"),
+            {
+                "media_type": MediaTypes.GAME.value,
+                "media_id": "1877",
+                "source": "igdb",
+                "logging_style": "sessions",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["media_type"], MediaTypes.GAME.value)
+        # base.html renders the navbar's current type into selectedType; the
+        # dropdown list below it always contains every type, so assert on the
+        # selection itself rather than on the presence of "tv" anywhere.
+        self.assertContains(
+            response,
+            "selectedType: { display: 'Games', value: 'game' }",
+        )
+
     def test_media_type_month_view_uses_cached_month_days(self):
         response = self.client.get(
             reverse("history"),


### PR DESCRIPTION
## Summary
- Opening "View your activity history" from an item left the navbar search selector on **TV shows** or **Music**, whatever you had come from. The history button links to `?media_type=game&…&logging_style=sessions`), but it was never type-specific — it affected everything except TV.
- The history view never passed the media type into the template context. `base.html` derives the selector with `{% firstof media_type user.last_search_type as search_type %}`, so with nothing to use it fell back to `last_search_type` — which defaults to `MediaTypes.TV` and is only written when a search actually runs (`search_views.py`). So it was not choosing TV; it was choosing the default, and the URL's own `media_type` was ignored.
- The view now reads `media_type` from the query string and puts it in context. Values that are not a real media type are dropped, so the selector falls back exactly as before rather than rendering something nonsensical.
- That validation is load-bearing rather than defensive: the history page's own `media_type` parameter is a **multi-select filter**, whose chips serialise comma-joined (`movie,tv`) and are split back into a set server-side. Those values are not a single media type and must not reach the search bar.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_history` -> Passed (35 tests, OK)
- `uv run --no-sync python -m app.domain_vocabulary --check` -> Passed (exit 0)
- Three tests added, and confirmed non-vacuous rather than assumed: `latest`'s history view puts no `media_type` in context, so each fails there. The game case was run directly against the pre-fix view and errored with `KeyError: 'media_type'`.
  - `test_history_passes_media_type_from_query_into_context` — the value reaches the context.
  - `test_history_drops_invalid_media_type_from_query` — an unknown type is dropped, so the bar falls back.
  - `test_history_keeps_a_non_movie_media_type_in_the_search_bar` — the reported game URL, asserting the **rendered** selector (`selectedType: { display: 'Games', value: 'game' }`) rather than only the context key, so the regression is caught where the user sees it.
- The assertion in that last test was tightened during review: an initial `assertNotContains(response, "value: 'tv'")` failed for the wrong reason, because the dropdown below the selector legitimately lists every media type. It now asserts the selection itself.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Related: the navbar selector also failed to persist because switching type never submitted a search — fixed separately in `fix/search-type-preserve-query`, which is what left `last_search_type` stale at its TV default.
