### PR TITLE
Restore the work the session history modal overwrote

### DIFF
--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime
 from django.views.decorators.http import require_GET, require_POST
@@ -378,9 +379,11 @@ def media_save(request):
                     response.write(
                         _render_notes_section_oob(
                             request,
-                            request.user,
-                            media.item,
-                            media,
+                            media.__class__.objects.filter(
+                                user=request.user,
+                                item=media.item,
+                            ),
+                            media=media.item,
                         ),
                     )
             except Exception:
@@ -688,30 +691,41 @@ def _render_season_progress_oob(related_season):
     return spans
 
 
-def _render_notes_section_oob(request, user, item, instance):
+def _render_notes_section_oob(
+    request,
+    entries,
+    *,
+    media=None,
+    detail_notes_target_id="",
+    detail_notes_modal_url="",
+    detail_return_url="",
+):
     """Render the detail notes section as an OOB swap after a watch save.
 
     The notes section lists one block per watch (see detail_notes_section),
     so a note edited in the track modal must be pushed back into the page
     without a full reload.
+
+    The caller supplies the watches rather than this building the queryset:
+    Episode has no `user` field (it is scoped through related_season), so a
+    single `filter(user=...)` here cannot serve both the media and episode
+    save paths. The modal ids are caller-supplied for the same reason — the
+    episode page namespaces its modal targets differently from the movie,
+    season and show pages.
     """
     return render_to_string(
         "app/components/detail_notes_section.html",
         {
             "notes_entries": [
-                entry
-                for entry in instance.__class__.objects.filter(
-                    user=user, item=item
-                )
-                if entry.notes and entry.notes.strip()
+                entry for entry in entries if entry.notes and entry.notes.strip()
             ],
-            "media": item,
-            "user": user,
+            "media": media,
+            "user": request.user,
             "public_notes_view": False,
             "public_view": False,
-            "detail_return_url": "",
-            "detail_notes_modal_url": "",
-            "detail_notes_target_id": "",
+            "detail_return_url": detail_return_url,
+            "detail_notes_modal_url": detail_notes_modal_url,
+            "detail_notes_target_id": detail_notes_target_id,
             "notes_section_oob": True,
         },
         request=request,
@@ -810,6 +824,35 @@ def _write_episode_save_oob(
         response.write(
             _render_track_action_oob(request, related_season, parsed_next),
         )
+        # The episode page lists every watch note, same as the movie/season
+        # pages, so an edited note has to be pushed back the same way. Episode
+        # rows are scoped by season rather than by user, and the page namespaces
+        # its modal targets per episode, so both are passed in explicitly.
+        if episode.item_id:
+            response.write(
+                _render_notes_section_oob(
+                    request,
+                    Episode.objects.filter(
+                        related_season=related_season,
+                        item=episode.item,
+                    ).select_related("item"),
+                    media=episode.item,
+                    detail_notes_target_id=(
+                        f"episode-notes-modal-{source}-{media_id}"
+                        f"-{season_number}-{episode_number}"
+                    ),
+                    detail_notes_modal_url=reverse(
+                        "track_modal",
+                        kwargs={
+                            "source": source,
+                            "media_type": MediaTypes.EPISODE.value,
+                            "media_id": media_id,
+                            "season_number": season_number,
+                        },
+                    ),
+                    detail_return_url=parsed_next,
+                ),
+            )
         # Season-progress spans only exist on the season page — nothing to target here.
         return
 

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC, datetime, timedelta
 from html import unescape
 from unittest.mock import patch
@@ -9659,6 +9660,359 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         item.refresh_from_db()
         self.assertEqual(item.image, existing_image)
+
+
+    @patch("integrations.tasks.fetch_collection_metadata_for_item.delay")
+    @patch("app.views.credits.sync_item_credits_from_metadata")
+    @patch("app.views.metadata_utils.apply_item_metadata", return_value=[])
+    @patch("app.providers.services.get_media_metadata")
+    def test_first_saved_note_swaps_into_a_pre_existing_section(
+        self,
+        mock_get_metadata,
+        _mock_apply_item_metadata,
+        _mock_sync_credits,
+        _mock_fetch_delay,
+    ):
+        """The notes section anchor exists before there is any note to show.
+
+        media_save returns the section as an hx-swap-oob fragment. htmx drops an
+        OOB fragment whose target is not already in the DOM, so gating the
+        section on having a note meant the *first* note saved never appeared
+        until a reload.
+        """
+        mock_get_metadata.return_value = {
+            "media_id": "238",
+            "title": "Test Movie",
+            "media_type": MediaTypes.MOVIE.value,
+            "source": Sources.TMDB.value,
+            "image": "http://example.com/image.jpg",
+            "synopsis": "Test overview",
+            "max_progress": 1,
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        item = Item.objects.create(
+            media_id="238",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Test Movie",
+            image="http://example.com/image.jpg",
+        )
+        Movie.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+        )
+
+        fragment = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_type": MediaTypes.MOVIE.value,
+                    "media_id": item.media_id,
+                    "title": "test-movie",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(fragment.status_code, 200)
+        # The anchor is present with no notes yet, and carries no stray heading.
+        self.assertContains(fragment, 'id="detail-notes-section"', html=False)
+        self.assertNotContains(
+            fragment, '<h2 class="text-xl font-bold">Your Notes</h2>', html=False
+        )
+
+        saved = self.client.post(
+            reverse("media_save"),
+            {
+                "media_id": item.media_id,
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.MOVIE.value,
+                "status": Status.COMPLETED.value,
+                "progress": 1,
+                "repeats": 0,
+                "notes": "First note ever",
+            },
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(saved.status_code, 200)
+        body = saved.content.decode()
+        section = body[body.index('id="detail-notes-section"') :]
+        self.assertIn('hx-swap-oob="outerHTML"', section)
+        self.assertIn('<h2 class="text-xl font-bold">Your Notes</h2>', section)
+        self.assertIn("First note ever", section)
+    @patch("integrations.tasks.fetch_collection_metadata_for_item.delay")
+    @patch("app.views.credits.sync_item_credits_from_metadata")
+    @patch("app.views.metadata_utils.apply_item_metadata", return_value=[])
+    @patch("app.providers.services.get_media_metadata")
+    def test_clearing_the_last_note_leaves_no_bare_heading(
+        self,
+        mock_get_metadata,
+        _mock_apply_item_metadata,
+        _mock_sync_credits,
+        _mock_fetch_delay,
+    ):
+        """The mirror case: an emptied section must not keep its heading."""
+        mock_get_metadata.return_value = {
+            "media_id": "238",
+            "title": "Test Movie",
+            "media_type": MediaTypes.MOVIE.value,
+            "source": Sources.TMDB.value,
+            "image": "http://example.com/image.jpg",
+            "synopsis": "Test overview",
+            "max_progress": 1,
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        item = Item.objects.create(
+            media_id="238",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="Test Movie",
+            image="http://example.com/image.jpg",
+        )
+        movie = Movie.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+            notes="Soon to be cleared",
+        )
+
+        saved = self.client.post(
+            reverse("media_save"),
+            {
+                "media_id": item.media_id,
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.MOVIE.value,
+                "status": Status.COMPLETED.value,
+                "progress": 1,
+                "repeats": 0,
+                "instance_id": movie.id,
+                "notes": "",
+            },
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(saved.status_code, 200)
+        body = saved.content.decode()
+        section = body[body.index('id="detail-notes-section"') :]
+        self.assertIn('hx-swap-oob="outerHTML"', section)
+        self.assertNotIn('<h2 class="text-xl font-bold">Your Notes</h2>', section)
+    def test_editing_an_episode_note_swaps_the_section_back(self):
+        """Episode saves push the notes section back like movie saves do.
+
+        Episode rows are scoped through related_season rather than a `user`
+        field, so the notes OOB helper cannot build its own `filter(user=...)`
+        queryset — episodes were left out entirely and an edited note only
+        showed up after a reload.
+        """
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test TV Show",
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Season 1",
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="Episode 1",
+        )
+        episode = Episode.objects.create(
+            item=episode_item,
+            related_season=season,
+            notes="note before the edit",
+            end_date=datetime(2026, 8, 1, tzinfo=UTC),
+        )
+
+        next_path = reverse(
+            "episode_details",
+            kwargs={
+                "source": Sources.TMDB.value,
+                "media_id": "1668",
+                "title": "test-tv-show",
+                "season_number": 1,
+                "episode_number": 1,
+            },
+        )
+        response = self.client.post(
+            f"{reverse('episode_save')}?next={next_path}",
+            {
+                "media_id": "1668",
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.EPISODE.value,
+                "season_number": 1,
+                "episode_number": 1,
+                "instance_id": episode.id,
+                "status": Status.COMPLETED.value,
+                "end_date": "2026-08-01T00:00",
+                "notes": "note after the edit",
+            },
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('id="detail-notes-section"', body)
+        section = body[body.index('id="detail-notes-section"') :]
+        self.assertIn('hx-swap-oob="outerHTML"', section)
+        self.assertIn("note after the edit", section)
+        self.assertNotIn("note before the edit", section)
+        # The swapped-in blocks must keep the episode page's own modal
+        # namespace, not fall back to the movie/season component ids.
+        self.assertIn(
+            f"episode-notes-modal-tmdb-1668-1-1-{episode.id}",
+            section,
+        )
+    @patch("app.views.tmdb.episode", return_value={})
+    @patch("app.providers.services.get_media_metadata")
+    @patch("app.providers.tmdb.process_episodes")
+    def test_episode_notes_blocks_get_distinct_modal_targets(
+        self,
+        mock_process_episodes,
+        mock_get_metadata,
+        _mock_episode,
+    ):
+        """Every watch note renders its own edit-modal target.
+
+        The target id is built by concatenating the episode's modal id with the
+        watch's pk. Django's `add` filter returns "" for str + int, so an
+        unstringified pk silently emptied every id and left the edit buttons
+        pointing at "#".
+        """
+        tv_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Test TV Show",
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+            title="Season 1",
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            season_number=1,
+            episode_number=1,
+            title="Episode 1",
+        )
+        watches = [
+            Episode.objects.create(
+                item=episode_item,
+                related_season=season,
+                notes=f"Watch note {index}",
+                end_date=datetime(2026, 8, index, tzinfo=UTC),
+            )
+            for index in (1, 2)
+        ]
+
+        mock_get_metadata.side_effect = lambda *_args, **_kwargs: {
+            "title": "Test TV Show",
+            "media_id": "1668",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.TV.value,
+            "image": "http://example.com/image.jpg",
+            "season/1": {
+                "title": "Season 1",
+                "season_title": "Season 1",
+                "media_id": "1668",
+                "media_type": MediaTypes.SEASON.value,
+                "source": Sources.TMDB.value,
+                "image": "http://example.com/season.jpg",
+                "episodes": [{"episode_number": 1}],
+            },
+        }
+        mock_process_episodes.return_value = [
+            {
+                "media_id": "1668",
+                "source": Sources.TMDB.value,
+                "media_type": MediaTypes.EPISODE.value,
+                "season_number": 1,
+                "episode_number": 1,
+                "title": "Episode 1",
+                "air_date": "2023-01-01",
+                "watched": True,
+                "history": watches,
+            },
+        ]
+
+        response = self.client.get(
+            reverse(
+                "episode_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "test-tv-show",
+                    "season_number": 1,
+                    "episode_number": 1,
+                },
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [entry.notes for entry in response.context["notes_entries"]],
+            ["Watch note 1", "Watch note 2"],
+        )
+
+        html = response.content.decode()
+        section = html[html.index('id="detail-notes-section"') :]
+        targets = re.findall(r'hx-target="#([^"]*)"', section)
+        anchors = re.findall(r'<div id="([^"]*)"></div>', section)
+
+        expected = [
+            f"{response.context['episode_notes_modal_target_id']}-{watch.pk}"
+            for watch in watches
+        ]
+        self.assertEqual(targets, expected)
+        self.assertEqual(anchors, expected)
 
 
 class AnimeNextEpisodeRedirectTests(TestCase):

--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -16,6 +16,7 @@ if (!window.__floppyDateTimePickerBound) {
     suggestionDate: config.suggestionDate || "",
     suggestionRuntimeMinutes: config.suggestionRuntimeMinutes || "",
     copyFrom: config.copyFrom || "",
+    copyAvailable: false,
 
     value: config.initialValue || "",
     open: false,
@@ -389,6 +390,14 @@ if (!window.__floppyDateTimePickerBound) {
       this.backfillStartDateIfNeeded();
     },
 
+    copySourceValue() {
+      if (!this.copyFrom) {
+        return "";
+      }
+      const form = this.$refs.hiddenInput?.closest("form");
+      return form?.querySelector(`[name="${this.copyFrom}"]`)?.value || "";
+    },
+
     copyFromOther() {
       if (!this.copyFrom) {
         return;
@@ -555,6 +564,7 @@ if (!window.__floppyDateTimePickerBound) {
 
     openPicker() {
       this.open = true;
+      this.copyAvailable = Boolean(this.copySourceValue());
       this.pickerView = "days";
       this.positionPopover();
       this.$nextTick(() => {

--- a/src/templates/app/comic_issue_details.html
+++ b/src/templates/app/comic_issue_details.html
@@ -141,12 +141,12 @@
                 {% endif %}
               </button>
               <div x-show="trackOpen"
+              @mousedown.self="trackOpen = false"
                    x-cloak
                    @keydown.escape.window="trackOpen = false"
                    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                 <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                      style="width: min(96vw, 72rem);"
-                     @click.outside="trackOpen = false"
                      @click.stop>
                   <div id="{% component_id 'track' media %}"></div>
                 </div>
@@ -166,11 +166,11 @@
                   {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                 </button>
                 <div x-show="listsOpen"
+                @mousedown.self="listsOpen = false"
                      x-cloak
                      @keydown.escape.window="listsOpen = false"
                      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                  <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                       @click.outside="listsOpen = false">
+                  <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                     <div id="{% component_id 'lists' media %}"></div>
                   </div>
                 </div>
@@ -187,11 +187,11 @@
                   {% include "app/icons/history.svg" with classes="w-4 h-4" %}
                 </button>
                 <div x-show="historyOpen"
+                @mousedown.self="historyOpen = false"
                      @keydown.escape.window="historyOpen = false"
                      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                   <div class="w-full max-h-[90vh] px-4 md:px-0 relative z-60"
-                       style="width: min(96vw, 72rem);"
-                       @click.outside="historyOpen = false">
+                       style="width: min(96vw, 72rem);">
                     <div id="{% component_id 'history' media %}"></div>
                   </div>
                 </div>
@@ -277,10 +277,10 @@
                   title="Add collection data">{% include "app/icons/plus.svg" with classes="w-3.5 h-3.5" %}</button>
 
           <div x-show="collectionOpen"
+          @mousedown.self="if (!$event.target.closest('[data-cf-dropdown-menu]')) collectionOpen = false"
                @keydown.escape.window="collectionOpen = false"
                class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"
-                 @click.outside="if (!$event.target.closest('[data-cf-dropdown-menu]')) collectionOpen = false">
+            <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60">
               <div id="{% component_id 'collection' media %}"></div>
             </div>
           </div>

--- a/src/templates/app/components/album_list_grid_items.html
+++ b/src/templates/app/components/album_list_grid_items.html
@@ -90,12 +90,12 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         @mousedown.self="trackOpen = false"
          x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-           style="width: min(96vw, 72rem);"
-           @click.outside="trackOpen = false">
+           style="width: min(96vw, 72rem);">
         <div id="album-track-modal-{{ tracker.album.id }}"></div>
       </div>
     </div>

--- a/src/templates/app/components/artist_grid_items.html
+++ b/src/templates/app/components/artist_grid_items.html
@@ -106,12 +106,12 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         @mousedown.self="trackOpen = false"
          x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-           style="width: min(96vw, 72rem);"
-           @click.outside="trackOpen = false">
+           style="width: min(96vw, 72rem);">
         <div id="artist-track-modal-{{ tracker.artist.id }}"></div>
       </div>
     </div>

--- a/src/templates/app/components/cells/album_image_cell.html
+++ b/src/templates/app/components/cells/album_image_cell.html
@@ -20,11 +20,11 @@
 
 {# Track Modal #}
 <div x-show="trackOpen"
+     @mousedown.self="trackOpen = false"
      x-cloak
      @keydown.escape.window="trackOpen = false"
      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-  <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"
-       @click.outside="trackOpen = false">
+  <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60">
     <div id="album-track-modal-{{ media.album.id }}"></div>
   </div>
 </div>

--- a/src/templates/app/components/cells/artist_image_cell.html
+++ b/src/templates/app/components/cells/artist_image_cell.html
@@ -21,11 +21,11 @@
 
 {# Track Modal #}
 <div x-show="trackOpen"
+     @mousedown.self="trackOpen = false"
      x-cloak
      @keydown.escape.window="trackOpen = false"
      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-  <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"
-       @click.outside="trackOpen = false">
+  <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60">
     <div id="artist-track-modal-{{ media.artist.id }}"></div>
   </div>
 </div>

--- a/src/templates/app/components/cells/media_image_cell.html
+++ b/src/templates/app/components/cells/media_image_cell.html
@@ -14,12 +14,12 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         @mousedown.self="trackOpen = false"
          x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-           style="width: min(96vw, 72rem);"
-           @click.outside="trackOpen = false">
+           style="width: min(96vw, 72rem);">
         <div id="{% component_id 'track' media.item track_id %}"></div>
       </div>
     </div>

--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -57,7 +57,7 @@
        :aria-modal="isMobile ? 'true' : 'false'"
        aria-label="{{ field_label|default:'Date' }} picker"
        @keydown.tab="trapFocus($event)"
-       @click.outside="!isMobile && !$refs.trigger.contains($event.target) && closePicker()"
+       @mousedown.outside="!isMobile && !$refs.trigger.contains($event.target) && closePicker()"
        :style="popoverStyle"
        class="date-picker-popover fixed inset-x-0 bottom-0 rounded-t-xl max-h-[85dvh] overflow-y-auto overscroll-contain bg-[var(--color-surface)] border-t border-[var(--color-border)] shadow-2xl p-4 sm:inset-x-auto sm:bottom-auto sm:w-[22rem] sm:rounded-lg sm:border"
        x-transition:enter="transition ease-out duration-150"
@@ -127,7 +127,11 @@
           </button>
         </template>
         {% if copy_from %}
-        <button type="button" @click="copyFromOther()" class="date-picker-common-time-button">
+        <button type="button"
+                @click="copyFromOther()"
+                :disabled="!copyAvailable"
+                :title="copyAvailable ? '' : '{{ copy_from_label|default:copy_from|escapejs }} is empty'"
+                class="date-picker-common-time-button">
           {% include "app/icons/copy.svg" with classes="w-3.5 h-3.5" %}
           Copy from {{ copy_from_label|default:copy_from }}
         </button>

--- a/src/templates/app/components/detail_action_buttons.html
+++ b/src/templates/app/components/detail_action_buttons.html
@@ -32,12 +32,12 @@
               </button>
 
               <div x-show="trackOpen"
+              @mousedown.self="trackOpen = false"
                    x-cloak
                    @keydown.escape.window="trackOpen = false"
                    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                 <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                      style="width: min(96vw, 72rem)"
-                     @click.outside="trackOpen = false"
                      @click.stop>
                   <div id="podcast-show-track-modal"></div>
                 </div>
@@ -82,23 +82,23 @@
                   </div>
 
                   <div x-show="editTrackOpen"
+                  @mousedown.self="editTrackOpen = false"
                        x-cloak
                        @keydown.escape.window="editTrackOpen = false"
                        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                          style="width: min(96vw, 72rem)"
-                         @click.outside="editTrackOpen = false"
                          @click.stop>
                       <div id="{% component_id 'track' media current_instance.id %}"></div>
                     </div>
                   </div>
 
                   <div x-show="createTrackOpen"
+                  @mousedown.self="createTrackOpen = false"
                        @keydown.escape.window="createTrackOpen = false"
                        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                          style="width: min(96vw, 72rem)"
-                         @click.outside="createTrackOpen = false"
                          @click.stop>
                       <div id="{% component_id 'track' media %}"></div>
                     </div>
@@ -207,11 +207,11 @@
               </div>
 
               <div x-show="tagsOpen"
+              @mousedown.self="tagsOpen = false"
                    x-cloak
                    @keydown.escape.window="tagsOpen = false"
                    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                     @click.outside="tagsOpen = false">
+                <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                   <div id="{% component_id 'tags' media %}"></div>
                 </div>
               </div>
@@ -227,11 +227,11 @@
                       @click="listsOpen = true">{% include "app/icons/list-add.svg" with classes="w-4 h-4" %}</button>
 
               <div x-show="listsOpen"
+              @mousedown.self="listsOpen = false"
                    x-cloak
                    @keydown.escape.window="listsOpen = false"
                    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                     @click.outside="listsOpen = false">
+                <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                   <div id="{% component_id 'lists' media %}"></div>
                 </div>
               </div>

--- a/src/templates/app/components/detail_music_album.html
+++ b/src/templates/app/components/detail_music_album.html
@@ -104,12 +104,12 @@
         </button>
 
         <div x-show="trackOpen"
+        @mousedown.self="trackOpen = false"
              x-cloak
              @keydown.escape.window="trackOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                style="width: min(96vw, 72rem);"
-               @click.outside="trackOpen = false"
                @click.stop>
             <div id="{{ detail_primary_action.target_id }}"></div>
           </div>
@@ -209,11 +209,11 @@
           </div>
 
           <div x-show="tagsOpen"
+          @mousedown.self="tagsOpen = false"
                x-cloak
                @keydown.escape.window="tagsOpen = false"
                class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                 @click.outside="tagsOpen = false">
+            <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
               <div id="{% component_id 'tags' media %}"></div>
             </div>
           </div>
@@ -229,11 +229,11 @@
                   @click="listsOpen = true">{% include "app/icons/list-add.svg" with classes="w-4 h-4" %}</button>
 
           <div x-show="listsOpen"
+          @mousedown.self="listsOpen = false"
                x-cloak
                @keydown.escape.window="listsOpen = false"
                class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                 @click.outside="listsOpen = false">
+            <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
               <div id="{% component_id 'lists' media %}"></div>
             </div>
           </div>

--- a/src/templates/app/components/detail_music_artist.html
+++ b/src/templates/app/components/detail_music_artist.html
@@ -126,12 +126,12 @@
         </button>
 
         <div x-show="trackOpen"
+        @mousedown.self="trackOpen = false"
              x-cloak
              @keydown.escape.window="trackOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                style="width: min(96vw, 72rem);"
-               @click.outside="trackOpen = false"
                @click.stop>
             <div id="{{ detail_primary_action.target_id }}"></div>
           </div>

--- a/src/templates/app/components/detail_music_track_actions.html
+++ b/src/templates/app/components/detail_music_track_actions.html
@@ -19,9 +19,9 @@
       <div x-show="listsOpen"
            x-cloak
            @keydown.escape.window="listsOpen = false"
-           class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-             @click.outside="listsOpen = false">
+           class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+           @mousedown.self="listsOpen = false">
+        <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
           <div id="lists-modal-{{ track_data.track.id }}"></div>
         </div>
       </div>
@@ -40,9 +40,9 @@
       </button>
       <div x-show="historyOpen"
            @keydown.escape.window="historyOpen = false"
-           class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-             @click.outside="historyOpen = false">
+           class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+           @mousedown.self="historyOpen = false">
+        <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
           <div id="history-modal-{{ track_data.track.id }}"></div>
         </div>
       </div>

--- a/src/templates/app/components/detail_notes_section.html
+++ b/src/templates/app/components/detail_notes_section.html
@@ -1,22 +1,39 @@
 {% load app_tags %}
 {% load user_tags %}
 
-<section id="detail-notes-section" class="mb-8" {% if notes_section_oob %}hx-swap-oob="outerHTML"{% endif %}>
-  <div class="mb-4 flex items-center gap-2">
-    <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
-  </div>
+{% comment %}
+  The section element renders even with no notes, and is deliberately inert when
+  empty: it is the OOB target media_save swaps into, so it has to already exist
+  in the DOM the first time a note is saved. Gating it on having a note meant
+  htmx found no target and dropped the fragment, and the note only appeared on a
+  reload. The heading is inside the emptiness check for the mirror case — the
+  last note being cleared must not leave a bare "Your Notes" behind.
+{% endcomment %}
+<section id="detail-notes-section" class="{% if notes_entries or notes_entry %}mb-8{% endif %}" {% if notes_section_oob %}hx-swap-oob="outerHTML"{% endif %}>
+  {% if notes_entries or notes_entry %}
+    <div class="mb-4 flex items-center gap-2">
+      <h2 class="text-xl font-bold">{% if public_notes_view|default:False %}Notes{% else %}Your Notes{% endif %}</h2>
+    </div>
+  {% endif %}
 
   {% for entry in notes_entries %}
-    {% with notes_modal_id=entry.id|stringformat:"s"|add:"-notes" notes_content_id=entry.id|stringformat:"s"|add:"-notes-content" %}
+    {% comment %}
+      entry_id must be stringified before it is concatenated below: Django's
+      `add` filter returns "" for str + int, which silently emptied the modal
+      target id and left the edit button pointing at "#".
+    {% endcomment %}
+    {% with entry_id=entry.id|stringformat:"s" %}
+    {% with notes_modal_id=entry_id|add:"-notes" notes_content_id=entry_id|add:"-notes-content" %}
       {{ entry.notes|json_script:notes_content_id }}
       {% if detail_notes_target_id %}
-        {% with notes_modal_target_id=detail_notes_target_id|add:"-"|add:entry.id %}
+        {% with notes_modal_target_id=detail_notes_target_id|add:"-"|add:entry_id %}
           {% include "app/components/detail_notes_block.html" with entry=entry notes_modal_target_id=notes_modal_target_id %}
         {% endwith %}
       {% else %}
         {% component_id 'track' media notes_modal_id as notes_modal_target_id %}
         {% include "app/components/detail_notes_block.html" with entry=entry notes_modal_target_id=notes_modal_target_id %}
       {% endif %}
+    {% endwith %}
     {% endwith %}
   {% empty %}
     {% if notes_entry %}

--- a/src/templates/app/components/detail_row_actions.html
+++ b/src/templates/app/components/detail_row_actions.html
@@ -6,12 +6,12 @@
     <div x-data="{ trackOpen: false }">
       {% include "app/components/detail_episode_track_button.html" with episode=episode detail_return_url=detail_return_url request=request track_button_oob=False only %}
       <div x-show="trackOpen"
+      @mousedown.self="trackOpen = false"
            x-cloak
            @keydown.escape.window="trackOpen = false"
            class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
              style="width: min(96vw, 72rem);"
-             @click.outside="trackOpen = false"
              @click.stop>
           <div id="{% component_id 'track' episode %}"></div>
         </div>
@@ -32,12 +32,12 @@
         {% endif %}
       </button>
       <div x-show="trackOpen"
+      @mousedown.self="trackOpen = false"
            x-cloak
            @keydown.escape.window="trackOpen = false"
            class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
              style="width: min(96vw, 72rem);"
-             @click.outside="trackOpen = false"
              @click.stop>
           <div id="{% component_id 'track' episode %}"></div>
         </div>
@@ -58,11 +58,11 @@
       </button>
 
       <div x-show="listsOpen"
+      @mousedown.self="listsOpen = false"
            x-cloak
            @keydown.escape.window="listsOpen = false"
            class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-             @click.outside="listsOpen = false">
+        <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
           <div id="{% if episode.item %}{% component_id 'lists' episode.item %}{% else %}{% component_id 'lists' episode %}{% endif %}"></div>
         </div>
       </div>
@@ -81,11 +81,11 @@
         {% include "app/icons/history.svg" with classes="w-4 h-4" %}
       </button>
       <div x-show="historyOpen"
+      @mousedown.self="historyOpen = false"
            @keydown.escape.window="historyOpen = false"
            class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div class="w-full max-h-[90vh] px-4 md:px-0 relative z-60"
-             style="width: min(96vw, 72rem);"
-             @click.outside="historyOpen = false">
+             style="width: min(96vw, 72rem);">
           <div id="{% component_id 'history' history_item %}"></div>
         </div>
       </div>

--- a/src/templates/app/components/detail_secondary_content.html
+++ b/src/templates/app/components/detail_secondary_content.html
@@ -52,12 +52,12 @@
                       </button>
 
                       <div x-show="trackOpen"
+                      @mousedown.self="trackOpen = false"
                            x-cloak
                            @keydown.escape.window="trackOpen = false"
                            class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                         <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-                             style="width: min(96vw, 72rem);"
-                             @click.outside="trackOpen = false">
+                             style="width: min(96vw, 72rem);">
                           <div id="{% component_id 'track' media user_media.id %}"></div>
                         </div>
                       </div>
@@ -249,10 +249,10 @@
 
             {# Collection Modal #}
             <div x-show="collectionOpen"
+            @mousedown.self="if (!$event.target.closest('[data-cf-dropdown-menu]')) collectionOpen = false"
                  @keydown.escape.window="collectionOpen = false"
                  class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-              <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"
-                   @click.outside="if (!$event.target.closest('[data-cf-dropdown-menu]')) collectionOpen = false">
+              <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60">
                 <div id="{% component_id 'collection' media %}"></div>
               </div>
             </div>
@@ -328,9 +328,9 @@
 
     {# Related Media #}
     {% if media_type != MediaTypes.PODCAST.value %}
-      {% if notes_entry or media.related or media.cast or media.crew or media_type == MediaTypes.GAME.value or media.episodes %}
+      {% if show_notes|default:False or media.related or media.cast or media.crew or media_type == MediaTypes.GAME.value or media.episodes %}
         <div class="w-full md:w-3/4">
-        {% if show_notes|default:False and notes_entry %}
+        {% if show_notes|default:False %}
           {% include "app/components/detail_notes_section.html" %}
         {% endif %}
         {% if media.related %}

--- a/src/templates/app/components/detail_track_action.html
+++ b/src/templates/app/components/detail_track_action.html
@@ -23,12 +23,12 @@
   </button>
 
   <div x-show="trackOpen"
+  @mousedown.self="trackOpen = false"
        x-cloak
        @keydown.escape.window="trackOpen = false"
        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
     <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
          style="width: min(96vw, 72rem);"
-         @click.outside="trackOpen = false"
          @click.stop>
       <div id="{% component_id 'track' media %}">
         {% if track_modal_content %}

--- a/src/templates/app/components/episode_row.html
+++ b/src/templates/app/components/episode_row.html
@@ -169,12 +169,12 @@
     <div class="shrink-0" x-data="{ trackOpen: false }">
       {% include "app/components/detail_episode_track_button.html" with episode=episode detail_return_url=detail_return_url request=request track_button_oob=False target_suffix="-list" only %}
       <div x-show="trackOpen"
+      @mousedown.self="trackOpen = false"
            x-cloak
            @keydown.escape.window="trackOpen = false"
            class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
         <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
              style="width: min(96vw, 72rem);"
-             @click.outside="trackOpen = false"
              @click.stop>
           <div id="{% component_id 'track' episode %}-list"></div>
         </div>

--- a/src/templates/app/components/fill_track_episode.html
+++ b/src/templates/app/components/fill_track_episode.html
@@ -4,12 +4,12 @@
 
 {# Track Episode Modal #}
 <div x-show="trackOpen"
+     @mousedown.self="trackOpen = false"
      x-cloak
      data-track-modal-root
      @keydown.escape.window="trackOpen = false"
      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-  <div class="w-[400px] max-h-[90vh] px-4 md:px-0 relative z-60"
-       @click.outside="trackOpen = false">
+  <div class="w-[400px] max-h-[90vh] px-4 md:px-0 relative z-60">
     <div class="bg-[var(--color-surface)] p-6 rounded-lg max-h-[70svh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-xl font-bold text-[var(--color-text)]">Track Episode</h2>

--- a/src/templates/app/components/fill_track_song.html
+++ b/src/templates/app/components/fill_track_song.html
@@ -4,12 +4,12 @@
 
 {# Track Song Modal - mirrors fill_track_episode.html #}
 <div x-show="trackOpen"
+     @mousedown.self="trackOpen = false"
      x-cloak
      data-track-modal-root
      @keydown.escape.window="trackOpen = false"
      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-  <div class="w-[400px] max-h-[90vh] px-4 md:px-0 relative z-60"
-       @click.outside="trackOpen = false">
+  <div class="w-[400px] max-h-[90vh] px-4 md:px-0 relative z-60">
     <div class="bg-[var(--color-surface)] p-6 rounded-lg max-h-[70svh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-xl font-bold text-[var(--color-text)]">{% if music and music.item and music.item.media_type == 'podcast' %}Track Episode{% else %}Track Song{% endif %}</h2>

--- a/src/templates/app/components/history_card.html
+++ b/src/templates/app/components/history_card.html
@@ -229,23 +229,23 @@
   {% if entry.item and entry.item.media_type and history_mode != "release" %}
     {# Track Modal #}
     <div x-show="trackOpen"
+    @mousedown.self="trackOpen = false"
          x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-           style="width: min(96vw, 72rem);"
-           @click.outside="trackOpen = false">
+           style="width: min(96vw, 72rem);">
         <div id="{% component_id 'track' entry.item entry.entry_key %}"></div>
       </div>
     </div>
 
     {# Lists Modal #}
     <div x-show="listsOpen"
+    @mousedown.self="listsOpen = false"
          x-cloak
          @keydown.escape.window="listsOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-           @click.outside="listsOpen = false">
+      <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
         <div id="{% component_id 'lists' entry.item entry.entry_key %}"></div>
       </div>
     </div>

--- a/src/templates/app/components/podcast_episode_list.html
+++ b/src/templates/app/components/podcast_episode_list.html
@@ -58,9 +58,9 @@
                 <div x-show="listsOpen"
                      x-cloak
                      @keydown.escape.window="listsOpen = false"
-                     class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                  <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                       @click.outside="listsOpen = false">
+                     class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+                     @mousedown.self="listsOpen = false">
+                  <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                     <div id="{% component_id 'lists' episode.item %}"></div>
                   </div>
                 </div>
@@ -79,10 +79,10 @@
                 </button>
                 <div x-show="historyOpen"
                      @keydown.escape.window="historyOpen = false"
-                     class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+                     class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+                     @mousedown.self="historyOpen = false">
                   <div class="w-full max-h-[90vh] px-4 md:px-0 relative z-60"
-                       style="width: min(96vw, 72rem);"
-                       @click.outside="historyOpen = false">
+                       style="width: min(96vw, 72rem);">
                     <div id="{% component_id 'history' episode.item %}"></div>
                   </div>
                 </div>

--- a/src/templates/app/components/podcast_show_grid_items.html
+++ b/src/templates/app/components/podcast_show_grid_items.html
@@ -103,11 +103,11 @@
 
     {# Track Modal #}
     <div x-show="trackOpen"
+         @mousedown.self="trackOpen = false"
          x-cloak
          @keydown.escape.window="trackOpen = false"
          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60"
-           @click.outside="trackOpen = false">
+      <div class="w-152 modal-max-height overflow-y-auto px-4 md:px-0 relative z-60">
         <div id="podcast-show-track-modal-{{ tracker.show.id }}"></div>
       </div>
     </div>

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -196,12 +196,12 @@
             <div x-data="{ trackOpen: false }" class="w-full sm:w-auto sm:shrink-0">
               {% include "app/components/detail_episode_hero_track_button.html" with episode=episode source=source media_id=media_id season_number=season_number episode_number=episode_number %}
               <div x-show="trackOpen"
+              @mousedown.self="trackOpen = false"
                    x-cloak
                    @keydown.escape.window="trackOpen = false"
                    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                 <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
                      style="width: min(96vw, 72rem);"
-                     @click.outside="trackOpen = false"
                      @click.stop>
                   <div id="episode-track-modal-{{ source }}-{{ media_id }}-{{ season_number }}-{{ episode_number }}"></div>
                 </div>
@@ -222,11 +222,11 @@
                     {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                   </button>
                   <div x-show="listsOpen"
+                  @mousedown.self="listsOpen = false"
                        x-cloak
                        @keydown.escape.window="listsOpen = false"
                        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                    <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                         @click.outside="listsOpen = false">
+                    <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                       <div id="{% if episode.item %}{% component_id 'lists' episode.item %}{% else %}{% component_id 'lists' episode %}{% endif %}"></div>
                     </div>
                   </div>
@@ -245,11 +245,11 @@
                     {% include "app/icons/history.svg" with classes="w-4 h-4" %}
                   </button>
                   <div x-show="historyOpen"
+                  @mousedown.self="historyOpen = false"
                        @keydown.escape.window="historyOpen = false"
                        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <div class="w-full max-h-[90vh] px-4 md:px-0 relative z-60"
-                         style="width: min(96vw, 72rem);"
-                         @click.outside="historyOpen = false">
+                         style="width: min(96vw, 72rem);">
                       <div id="{% component_id 'history' episode.item %}"></div>
                     </div>
                   </div>
@@ -298,7 +298,7 @@
 </div>
 
 {# Your Notes — same component the movie/season pages use, pointed at the watch that carries the note. #}
-{% if show_notes and notes_entry %}
+{% if show_notes %}
   {% include "app/components/detail_notes_section.html" with notes_entries=notes_entries notes_entry=notes_entry detail_notes_target_id=episode_notes_modal_target_id detail_notes_modal_url=episode_notes_modal_url detail_return_url=detail_return_url public_notes_view=public_notes_view %}
 {% endif %}
 

--- a/src/templates/app/history.html
+++ b/src/templates/app/history.html
@@ -587,9 +587,9 @@
   <div x-show="open"
        x-cloak
        @keydown.escape.window="open = false"
-       class="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50">
-    <div class="w-full sm:w-[420px] relative z-60"
-         @click.outside="open = false">
+       class="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50"
+       @mousedown.self="open = false">
+    <div class="w-full sm:w-[420px] relative z-60">
       <div class="bg-[var(--color-surface)] rounded-t-2xl sm:rounded-xl p-6 overflow-y-auto modal-max-height">
         {# Header #}
         <div class="flex items-center justify-between mb-5">

--- a/src/templates/app/music_album_detail.html
+++ b/src/templates/app/music_album_detail.html
@@ -44,11 +44,11 @@
 
         {# Track Modal #}
         <div x-show="trackOpen"
+        @mousedown.self="trackOpen = false"
              x-cloak
              @keydown.escape.window="trackOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div class="w-152 max-h-[90vh] px-4 md:px-0 relative z-60"
-               @click.outside="trackOpen = false">
+          <div class="w-152 max-h-[90vh] px-4 md:px-0 relative z-60">
             <div id="album-track-modal"></div>
           </div>
         </div>
@@ -350,11 +350,11 @@
                               {% include "app/icons/list-add.svg" with classes="w-4 h-4" %}
                             </button>
                             <div x-show="listsOpen"
+                            @mousedown.self="listsOpen = false"
                                  x-cloak
                                  @keydown.escape.window="listsOpen = false"
                                  class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                              <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                                   @click.outside="listsOpen = false">
+                              <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                                 <div id="lists-modal-{{ track_data.track.id }}"></div>
                               </div>
                             </div>
@@ -371,10 +371,10 @@
                               {% include "app/icons/history.svg" with classes="w-4 h-4" %}
                             </button>
                             <div x-show="historyOpen"
+                            @mousedown.self="historyOpen = false"
                                  @keydown.escape.window="historyOpen = false"
                                  class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-                              <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60"
-                                   @click.outside="historyOpen = false">
+                              <div class="w-96 max-h-[90vh] px-4 md:px-0 relative z-60">
                                 <div id="history-modal-{{ track_data.track.id }}"></div>
                               </div>
                             </div>

--- a/src/templates/app/podcast_show_detail.html
+++ b/src/templates/app/podcast_show_detail.html
@@ -43,11 +43,11 @@
 
         {# Track Modal #}
         <div x-show="trackOpen"
+        @mousedown.self="trackOpen = false"
              x-cloak
              @keydown.escape.window="trackOpen = false"
              class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div class="w-152 max-h-[90vh] px-4 md:px-0 relative z-60"
-               @click.outside="trackOpen = false"
                @click.stop>
             <div id="podcast-show-track-modal"></div>
           </div>

--- a/src/templates/app/search.html
+++ b/src/templates/app/search.html
@@ -167,12 +167,12 @@
                   </div>
 
                   <div x-show="trackOpen"
+                  @mousedown.self="trackOpen = false"
                        x-cloak
                        @keydown.escape.window="trackOpen = false"
                        class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <div class="modal-max-height overflow-y-auto px-4 md:px-0 relative z-60 w-full"
-                         style="width: min(96vw, 72rem);"
-                         @click.outside="trackOpen = false">
+                         style="width: min(96vw, 72rem);">
                       <div id="album-track-modal-{{ tracker.album.id }}"></div>
                     </div>
                   </div>

--- a/src/templates/app/statistics.html
+++ b/src/templates/app/statistics.html
@@ -1886,9 +1886,9 @@
     <div x-show="open"
          x-cloak
          @keydown.escape.window="open = false"
-         class="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50">
-      <div class="w-full sm:w-[420px] relative z-60"
-           @click.outside="open = false">
+         class="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50"
+         @mousedown.self="open = false">
+      <div class="w-full sm:w-[420px] relative z-60">
         <div class="bg-[var(--color-surface)] rounded-t-2xl sm:rounded-xl p-6 overflow-visible modal-max-height">
           {# Header #}
           <div class="flex items-center justify-between mb-5">

--- a/src/templates/lists/components/list_form.html
+++ b/src/templates/lists/components/list_form.html
@@ -2,8 +2,8 @@
 {% load app_tags %}
 
 {# djlint:off #}
-<div x-show="showModal" x-cloak class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-  <div @click.outside="showModal = false" class="bg-[var(--color-surface)] p-6 rounded-lg w-152 max-h-[90vh] overflow-y-auto"
+<div x-show="showModal" x-cloak class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" @mousedown.self="showModal = false">
+  <div class="bg-[var(--color-surface)] p-6 rounded-lg w-152 max-h-[90vh] overflow-y-auto"
     x-data="{
       isPublic: {{ form.instance.is_public|yesno:'true,false' }},
       includeNotes: {{ form.instance.include_notes|yesno:'true,false' }},

--- a/src/templates/users/advanced.html
+++ b/src/templates/users/advanced.html
@@ -203,9 +203,9 @@
           <div x-show="confirmOpen"
                x-cloak
                @keydown.escape.window="closeConfirm()"
-               class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-            <div class="w-full max-w-md bg-[var(--color-surface)] rounded-lg shadow-xl"
-                 @click.outside="closeConfirm()">
+               class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+               @mousedown.self="closeConfirm()">
+            <div class="w-full max-w-md bg-[var(--color-surface)] rounded-lg shadow-xl">
               <template x-if="pending === 'search'">
                 <div class="p-6">
                   <div class="flex items-center gap-2 mb-3">
@@ -440,9 +440,9 @@
           <div x-show="confirmOpen"
                x-cloak
                @keydown.escape.window="confirmOpen = false; deleteConfirmation = ''"
-               class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-            <div class="w-full max-w-md bg-[var(--color-surface)] rounded-lg shadow-xl"
-                 @click.outside="confirmOpen = false; deleteConfirmation = ''">
+               class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+               @mousedown.self="confirmOpen = false; deleteConfirmation = ''">
+            <div class="w-full max-w-md bg-[var(--color-surface)] rounded-lg shadow-xl">
               <div class="p-6">
                 <div class="flex items-center gap-2 mb-3">
                   {% include "app/icons/warning.svg" with classes="w-5 h-5 text-[var(--color-error-text)] shrink-0" %}

--- a/src/templates/users/import_data.html
+++ b/src/templates/users/import_data.html
@@ -670,10 +670,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -847,10 +847,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -932,10 +932,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1017,10 +1017,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1113,10 +1113,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1196,10 +1196,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1325,10 +1325,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1428,10 +1428,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1542,10 +1542,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1681,10 +1681,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1817,10 +1817,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -1951,10 +1951,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2010,10 +2010,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2043,10 +2043,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2084,10 +2084,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2156,10 +2156,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2205,10 +2205,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2253,10 +2253,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2301,10 +2301,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2343,10 +2343,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2385,10 +2385,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2435,10 +2435,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2531,10 +2531,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-gray-700/70 bg-[var(--color-surface)]">
@@ -2633,10 +2633,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2677,10 +2677,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2719,10 +2719,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2772,10 +2772,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">
@@ -2814,10 +2814,10 @@
              x-cloak
              @keydown.escape.window="closeModal()"
              x-transition.opacity.duration.150ms
-             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+             @mousedown.self="closeModal()">
           <div class="modal-max-height overflow-y-auto w-full"
-               style="width: min(96vw, 32rem);"
-               @click.outside="closeModal()">
+               style="width: min(96vw, 32rem);">
             <button type="button"
                     @click="closeModal()"
                     class="block w-fit ml-auto mb-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer p-1 rounded-md hover:bg-[var(--color-surface-hover)] bg-[var(--color-surface)]">


### PR DESCRIPTION
## Summary
- `4670d895` ("Add session history modal for per-item activity tracking") rewrote 59 files from stale copies. The modal itself is fine and is left untouched; what went with it was a set of unrelated fixes the feature never needed. This puts them back.
- **Notes out-of-band path**, together with the four tests that guarded it (deleted by the same commit):
  - The notes section is the OOB target `media_save` swaps into, so it has to exist in the DOM *before* the first note is saved. Its include had been re-gated on `notes_entry`, so htmx found no target and a first note only appeared after a page reload. The section renders again and stays inert when empty, with the heading inside the emptiness check so clearing the last note leaves no bare "Your Notes" behind.
  - Multi-entry notes built their modal target as `detail_notes_target_id|add:"-"|add:entry.id` using the integer pk. Django's `add` returns `""` when that concatenation raises, so **every target was an empty string**.
  - `_render_notes_section_oob` lost the parameters the episode page needs, so editing a note on an episode no longer pushed the section back.
- **Backdrop dismissal, across 29 further templates.** `216a8c79` has since restored `media_card.html` and `media_card_list.html`, so those two are skipped here.
  - Worth being precise about what the revert did, because it is easy to get wrong: it did **not** simply rename `@mousedown.self` to `@click.outside`. It also **moved the handler from the backdrop onto the panel inside it**. Restoring only the event name would leave `.self` on the panel, where it means "pressed on the panel" and dismisses the modal on a click into its own padding — worse than the state being fixed. Both the event and its placement are restored here.
  - The two are not equivalent behaviourally either: `mousedown.self` fires when the press lands on the backdrop, while `.outside` fires on a different condition, so a press that began inside a modal and was released outside it would dismiss the modal and lose the edit.
- **Date picker**: the popover closes on press again (keeping the trigger guard added since), and `52281ad5`'s copy affordance is back — the button is disabled and explains itself when the field it copies from is empty, rather than looking live and silently doing nothing.
- **The month and year selectors are *not* part of this.** They were refactored into the shared calendar component (`calendar.js` / `calendar.html`), not removed, and the picker still includes them.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_details` -> Passed (145 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list` -> Passed (95 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_history` -> Passed (35 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_track_modal` -> Passed (34 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_episode_history_poll` -> Passed (3 tests, OK)
- `uv run --no-sync python -m app.domain_vocabulary --check` -> Passed (exit 0)
- **The four restored tests were confirmed to fail against `latest`'s code** — the code files were reverted with the tests in place, and all four failed. They guard real regressions rather than restating current behaviour.
- Django's `add` behaviour was checked against the real template engine rather than assumed: with an integer pk the expression renders `[]`, and stringified it renders `[detail-notes-42]`.
- The backdrop restoration is verified against the pre-revert markup on **placement**, not just counts: 81 `mousedown.self` and 1 `mousedown.outside`, and all 31 `(backdrop x-show, expression)` pairings match `4670d895^` exactly. An unrelated `@click.outside="closeTooltip()"` in `history_card.html` is deliberately untouched.
- `save_views.py` was restored by reverse-applying the offending commit rather than checking out the old file, because `af539e8c` has since added book-percentage handling there; its lines were confirmed still present afterwards.
- The remaining diff against `latest` in the touched templates is only the `>` moving back onto the preceding attribute line, which is the pre-revert markup.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Restores work from `45294e41`, `175c1f7e`, `0799652c`, `0506a18a`, `9ac04c01` and `52281ad5`, all overwritten by `4670d895`.
- Complements `216a8c79`, which restored the same backdrop behaviour in the two card templates.
- Worth noting separately: that commit reverted six commits silently and nothing caught it, because none of the affected behaviour had tests — except the notes path, whose tests it deleted in the same commit.
