### PR TITLE
Fix escape handling, year paging and three more date picker bugs

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -513,15 +513,6 @@ html.light .theme-toggle-icon-moon {
   min-height: 2.25rem;
 }
 
-.date-picker-year-input {
-  -moz-appearance: textfield;
-}
-
-.date-picker-year-input::-webkit-outer-spin-button,
-.date-picker-year-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
 
 .date-picker-day-cell {
   min-width: 2.25rem;

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -6057,13 +6057,6 @@ html.light .theme-toggle-icon-moon {
   min-width: 2.25rem;
   min-height: 2.25rem;
 }
-.date-picker-year-input {
-  -moz-appearance: textfield;
-}
-.date-picker-year-input::-webkit-outer-spin-button, .date-picker-year-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
 .date-picker-day-cell {
   min-width: 2.25rem;
   min-height: 2.25rem;

--- a/src/static/js/calendar.js
+++ b/src/static/js/calendar.js
@@ -1,4 +1,9 @@
 (function() {
+  // The year grid is laid out four to a row, so this wants to stay a
+  // multiple of four. yearRange() and the year-view chevrons both read it,
+  // so a page and a step can never disagree.
+  const YEAR_PAGE_SIZE = 20;
+
   function parseMonth(value) {
     const match = /^(\d{4})-(\d{2})$/.exec(value || "");
     if (!match) {
@@ -167,6 +172,19 @@
         this.yearInput = String(this.viewYear);
       },
 
+      // The year view shows a whole YEAR_PAGE_SIZE block, so its chevrons step
+      // a block. Stepping a single year there appears to do nothing: the grid
+      // only shifts on the years that straddle a boundary.
+      gotoPrevYearPage() {
+        this.viewYear -= YEAR_PAGE_SIZE;
+        this.yearInput = String(this.viewYear);
+      },
+
+      gotoNextYearPage() {
+        this.viewYear += YEAR_PAGE_SIZE;
+        this.yearInput = String(this.viewYear);
+      },
+
       onYearInput(event) {
         const digits = event.target.value.replace(/\D/g, "").slice(0, 4);
         this.yearInput = digits;
@@ -192,8 +210,9 @@
       },
 
       yearRange() {
-        const start = Math.floor(this.viewYear / 20) * 20;
-        return Array.from({ length: 20 }, (_, i) => start + i);
+        const start =
+          Math.floor(this.viewYear / YEAR_PAGE_SIZE) * YEAR_PAGE_SIZE;
+        return Array.from({ length: YEAR_PAGE_SIZE }, (_, i) => start + i);
       },
 
       calendarDayHasActivity(cell) {

--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -553,6 +553,28 @@ if (!window.__floppyDateTimePickerBound) {
       this.closePicker();
     },
 
+    // Escape steps back through the picker before it reaches the modal:
+    // years -> months -> days -> close the picker -> (next press) close the
+    // modal. Bound with .capture on window so this runs before the modal's own
+    // window listener; stopPropagation then keeps the event from ever reaching
+    // it, which is what stopped a single press from closing everything.
+    onEscape(event) {
+      if (!this.open) {
+        return;
+      }
+
+      if (this.pickerView === "years") {
+        this.showMonthsView();
+      } else if (this.pickerView === "months") {
+        this.showDaysView();
+      } else {
+        this.closePicker();
+      }
+
+      event.stopPropagation();
+      event.preventDefault();
+    },
+
     openPicker() {
       this.open = true;
       this.pickerView = "days";

--- a/src/templates/app/components/calendar.html
+++ b/src/templates/app/components/calendar.html
@@ -1,11 +1,15 @@
 {# Shared calendar controls and fixed 42-cell day grid. The owning Alpine component provides the selection hooks. #}
 <div data-calendar-component>
-  <div class="flex items-center justify-between mb-2">
+  {% comment %}
+    The whole row is bound to the days view. Hiding only the chevrons left
+    the month label stacked above the month and year views' own headers,
+    and knocked off centre by its display:none siblings.
+  {% endcomment %}
+  <div class="flex items-center justify-between mb-2" x-show="pickerView === 'days'">
     <button type="button"
             @click="gotoPrevMonth()"
             aria-label="Previous month"
-            class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer"
-            x-show="pickerView === 'days'">{% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}</button>
+            class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">{% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}</button>
     <button type="button"
             @click="showMonthsView()"
             aria-label="Select month"
@@ -14,8 +18,7 @@
     <button type="button"
             @click="gotoNextMonth()"
             aria-label="Next month"
-            class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer"
-            x-show="pickerView === 'days'">{% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}</button>
+            class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">{% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}</button>
   </div>
 
   <template x-if="pickerView === 'months'">
@@ -69,11 +72,11 @@
         </button>
         <input type="text"
                inputmode="numeric"
-               x-model="yearInput"
+               :value="yearInput"
                @input="onYearInput($event)"
                @keydown.enter.prevent="applyYearInput()"
                @keydown.escape.prevent="showDaysView()"
-               class="date-picker-year-input w-20 text-center text-sm font-semibold text-[var(--color-text)] bg-[var(--color-surface-strong)] border border-gray-600 rounded-md px-2 py-1 outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+               class="w-20 text-center text-sm font-semibold text-[var(--color-text)] bg-[var(--color-surface-strong)] border border-gray-600 rounded-md px-2 py-1 outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
                aria-label="Year">
         <button type="button"
                 @click="gotoNextYearPage()"

--- a/src/templates/app/components/calendar.html
+++ b/src/templates/app/components/calendar.html
@@ -62,8 +62,8 @@
     <div>
       <div class="flex items-center justify-between mb-2">
         <button type="button"
-                @click="gotoPrevYear()"
-                aria-label="Previous year"
+                @click="gotoPrevYearPage()"
+                aria-label="Previous years"
                 class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
           {% include "app/icons/chevron-left.svg" with classes="w-4 h-4" %}
         </button>
@@ -76,8 +76,8 @@
                class="date-picker-year-input w-20 text-center text-sm font-semibold text-[var(--color-text)] bg-[var(--color-surface-strong)] border border-gray-600 rounded-md px-2 py-1 outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
                aria-label="Year">
         <button type="button"
-                @click="gotoNextYear()"
-                aria-label="Next year"
+                @click="gotoNextYearPage()"
+                aria-label="Next years"
                 class="p-2 mx-1 rounded-md hover:bg-[var(--color-surface-muted)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] cursor-pointer">
           {% include "app/icons/chevron-right.svg" with classes="w-4 h-4" %}
         </button>

--- a/src/templates/app/components/date_time_picker.html
+++ b/src/templates/app/components/date_time_picker.html
@@ -13,7 +13,7 @@
      })"
      x-init="init"
      {% if suggestion_date_expr %}x-effect="suggestionDate = ({{ suggestion_date_expr }}) || ''"{% endif %}
-     @keydown.escape.window="open && closePicker()">
+     @keydown.escape.window.capture="onEscape($event)">
 
   <div class="flex-1 flex items-stretch border border-gray-600 rounded-md bg-[var(--color-surface-strong)] focus-within:ring-2 focus-within:ring-[var(--color-accent)]">
     {% if mobile_label %}


### PR DESCRIPTION
## Summary
- Five date picker bugs, all of them the ones fixed in #1029 and all of them still reproducing after the picker was refactored onto the shared calendar component. That branch could not be rebased — it patches an 852-line `dateTimePicker.js` that is now 624 lines delegating to `calendar.js` — so the fixes are rewritten against the current structure here and #1029 is closed.
- **Escape closed the whole track modal.** The picker and the modal each bound `@keydown.escape.window`, two bubble-phase listeners on `window`, so one press ran both and everything closed at once. Escape now steps back one view at a time — years → months → days → close the picker — and only once the picker is shut does a further press reach the modal. Binding with `.capture` puts the picker's handler ahead of the modal's, and `stopPropagation` keeps the event from reaching it.
- **The year chevrons appeared to do nothing.** The grid lists a twenty-year block while the chevrons moved a single year, so it only shifted on the years that straddled a boundary. They step a whole block now, and the block size is a constant both the grid and the chevrons read, so a page and a step cannot disagree again. The month view keeps its single-year step, which is what its chevrons are for.
- **The day header showed over the month and year views.** Only its two chevrons were hidden, so the month label sat above those views' own headers, knocked off centre by its `display:none` siblings. The whole row is bound to the days view now.
- **The year input had two writers.** `x-model` and the sanitising `@input` handler both wrote `yearInput` and raced for it. The handler is the only writer now and the input reads back through `:value`.
- **Dead CSS.** `-moz-appearance: textfield` and the `::-webkit-*-spin-button` rules only apply to `type="number"`; the input is `type="text"`, so they never did anything. Removed, along with the class, which had no other rules.
- The session history modal shares `calendar.js` / `calendar.html`, so it gains the year paging and the header fix too.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_track_modal` -> Passed (34 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_details` -> Passed (141 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_history` -> Passed (35 tests, OK)
- `uv run --no-sync python -m app.domain_vocabulary --check` -> Passed (exit 0)
- Escape, in a headless browser against the vendored Alpine 3.14.9, with a window-level listener standing in for the modal's own handler:

  | press | picker view | picker open | modal handler fired |
  |---|---|---|---|
  | start | years | true | 0 |
  | 1 | months | true | 0 |
  | 2 | days | true | 0 |
  | 3 | days | **false** | 0 |
  | 4 | days | false | **1** |

- Year paging, driving the real `calendar.js` rather than a reimplementation:

  ```
  start               grid 2020-2039
  gotoNextYear()      grid 2020-2039   <- unchanged: the bug
  gotoNextYearPage()  grid 2040-2059
  gotoPrevYearPage()  grid 2000-2019
  ```

- Year input sanitising still works with a single writer: `20x6` -> `206`, `2031` -> `2031` (view year 2031), `20315` -> `2031`.
- CSS braces balanced after the removals.
- **No automated test covers the escape or paging behaviour.** Both are Alpine event/state behaviour in template attributes and are not reachable from the Django test client; the suites above only confirm the templates still render. A regression in either would not be caught by CI.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Supersedes #1029, which cannot be rebased onto the refactored picker. Every fix in it is carried over.
- One deliberate difference from #1029: the year input keeps its own escape handler. That branch could drop it as unreachable, which was true of the standalone picker whose root consumed escape first. This template is shared with the session history modal, which has no such root, so removing it there would leave escape unhandled.