### PR TITLE
Stop the copy button disarming the start-date auto-fill again

### DIFF
--- a/src/static/js/dateTimePicker.js
+++ b/src/static/js/dateTimePicker.js
@@ -175,30 +175,7 @@ if (!window.__floppyDateTimePickerBound) {
     },
 
     parts() {
-      if (!this.value) {
-        return null;
-      }
-
-      // Django renders bound DateTimeField values with a space separator,
-      // while values selected in this picker use the HTML datetime-local
-      // format with a `T` separator.
-      const [datePart, timePart] = this.value.trim().split(/[T ]/, 2);
-      const [y, m, d] = datePart.split("-").map(Number);
-      if ([y, m, d].some(Number.isNaN)) {
-        return null;
-      }
-
-      let h = 0;
-      let min = 0;
-      let s = 0;
-      if (timePart) {
-        const segments = timePart.split(":").map(Number);
-        h = segments[0] || 0;
-        min = segments[1] || 0;
-        s = segments[2] || 0;
-      }
-
-      return { y, m, d, h, min, s };
+      return this.partsFor(this.value);
     },
 
     formatValueFromParts(y, m, d, h, min, s) {
@@ -399,32 +376,18 @@ if (!window.__floppyDateTimePickerBound) {
     },
 
     copyFromOther() {
-      if (!this.copyFrom) {
-        return;
-      }
-      const form = this.$refs.hiddenInput.closest("form");
-      if (!form) {
-        return;
-      }
-      const sourceInput = form.querySelector(`[name="${this.copyFrom}"]`);
-      if (!sourceInput || !sourceInput.value) {
-        return;
-      }
-      const sourceParts = this.partsFor(sourceInput.value);
+      const sourceParts = this.partsFor(this.copySourceValue());
       if (!sourceParts) {
         return;
       }
-      // The form's progress-based start-date auto-fill recomputes start_date
-      // from end_date on every end_date change. A copy is an explicit user
-      // intent, so suppress that auto-fill for this commit regardless of which
-      // field we are writing, otherwise the copied value gets overwritten.
-      if (form && window.Alpine) {
-        try {
-          Alpine.$data(form).manualStartDate = true;
-        } catch {
-          // Ignore Alpine lookup failures.
-        }
-      }
+      // No backfill on this path. The runtime-based auto-fill recomputes
+      // start_date from end_date, which would immediately overwrite a copy into
+      // start_date with end minus the runtime. commit() already marks
+      // start_date as manually set when that is the field being written, and
+      // backfillStartDateIfNeeded honours that flag, so a copy into start_date
+      // survives later edits to end_date too. A copy into end_date leaves the
+      // flag alone: the user has not touched start_date, so the auto-fill must
+      // stay armed for it.
       this.commit(
         this.formatValueFromParts(
           sourceParts.y,
@@ -435,7 +398,6 @@ if (!window.__floppyDateTimePickerBound) {
           sourceParts.s,
         ),
       );
-      this.backfillStartDateIfNeeded();
     },
 
     partsFor(value) {


### PR DESCRIPTION
## Summary
- `4670d895` reverted `52281ad5` along with everything else it overwrote, and the restoration PRs (#1063 in particular) put the copy button's *affordance* back without noticing the handler itself was still the pre-fix version. So the button now enables and disables correctly but still misbehaves when pressed.
- `copyFromOther` set `manualStartDate` on the form before committing and called `backfillStartDateIfNeeded()` afterwards:
  - the backfill recomputes `start_date` from `end_date`, so **a copy into start_date was overwritten with end minus the runtime the moment it landed**;
  - and a copy into `end_date` **disarmed the auto-fill for a start_date the user had never touched**.
  - `commit()` already marks the field it writes as manually set, and the backfill honours that flag, so neither call was doing anything the picker did not already handle.
- `parts()` had also gone back to duplicating `partsFor()` instead of delegating to it. The two bodies are identical once the source variable is substituted, so this is the same behaviour with one implementation rather than two.

Found by auditing `latest` against the commit before the overwrite, rather than by a bug report — it is the last piece of `52281ad5` still missing.

## AI Assistance
- `claude-opus-5`

## How It Was Tested
- `SECRET=test-only scripts/test.sh app.tests.views.test_track_modal` -> Passed (34 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_details` -> Passed (145 tests, OK)
- `SECRET=test-only scripts/test.sh app.tests.views.test_media_list` -> Passed (95 tests, OK)
- `uv run --no-sync python -m app.domain_vocabulary --check` -> Passed (exit 0)
- `parts()` and `partsFor()` were compared programmatically before collapsing them: the bodies are identical after substituting `this.value` for the parameter, so the delegation is behaviour-preserving rather than a judgement call.
- Every function present in both the pre-overwrite file and `latest` was diffed to find this; the only other differences are `init` and `openPicker`, both of which are the legitimate shared-calendar refactor.
- **No automated test covers the copy button.** It is Alpine behaviour in a template attribute and is not reachable from the Django test client.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- Completes the restoration of `52281ad5`, whose affordance half landed in #1063.