### PR TITLE
Load Audiobookshelf covers reliably and make cover failures diagnosable

### DIFF
--- a/src/integrations/imports/audiobookshelf.py
+++ b/src/integrations/imports/audiobookshelf.py
@@ -4,8 +4,9 @@ import hashlib
 import logging
 import re
 import time
+import unicodedata
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from difflib import SequenceMatcher
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -39,6 +40,16 @@ BOOK_METADATA_PROVIDER_ORDER = (
     Sources.OPENLIBRARY.value,
 )
 TITLE_MATCH_THRESHOLD = 0.72
+# How long a book whose provider enrichment came back thin is left alone before
+# the providers are tried again. Without this, any book the providers can't
+# match - a common case for non-English audiobooks, which carry an ASIN and no
+# ISBN - is flagged unhealthy by _needs_book_repair on *every* sync and
+# re-queries Hardcover/OpenLibrary forever (see #861).
+BOOK_REPAIR_COOLDOWN = timedelta(days=30)
+# Blank posters are the visible symptom of #861, so they get a much shorter
+# cooldown: an install upgrading past the cover fix heals within a day instead
+# of waiting a month.
+BOOK_COVER_REPAIR_COOLDOWN = timedelta(days=1)
 # (strptime format, characters to feed it) pairs, most specific first.
 PUBLISHED_DATE_FORMATS = (
     ("%Y-%m-%d", 10),
@@ -265,21 +276,13 @@ class AudiobookshelfImporter:
         genres = self._extract_genres(metadata)
         series_name, series_position = self._extract_series_info(metadata)
 
-        image = self._normalize_cover_url(item_metadata.get("coverPath"))
-        # ABS returns coverPath as a server filesystem path (e.g. /metadata/items/.../cover.jpg)
-        # and the ABS cover endpoint requires a bearer token a plain <img src> can never
-        # attach, so any ABS-hosted cover is served through Floppy's own authenticated
-        # proxy instead of the raw ABS URL (see #861). This also keeps
-        # _should_prefer_provider_cover triggering enrichment with a valid fallback,
-        # since the proxy URL is relative and therefore not an absolute http(s) URL.
-        if image and self._is_own_abs_host(image):
-            image = audiobookshelf_cover.build_cover_proxy_url(
-                self.account.id,
-                library_item_id,
-            )
+        image = self._resolve_cover_image(library_item_id, item_metadata)
 
+        # Enrichment is still worth running for thin metadata even when the
+        # cover is already settled - it fills in authors, publisher, genres and
+        # the release date.
         should_enrich = (
-            self._should_prefer_provider_cover(image)
+            self._needs_cover_from_provider(image)
             or not authors_list
             or not publishers
             or not genres
@@ -294,7 +297,7 @@ class AudiobookshelfImporter:
             else None
         )
 
-        if self._should_prefer_provider_cover(image):
+        if self._needs_cover_from_provider(image):
             provider_image = (
                 provider_metadata.get("image")
                 if isinstance(provider_metadata, dict)
@@ -693,7 +696,7 @@ class AudiobookshelfImporter:
             ).netloc.lower()
         ):
             return image_url
-        if item_metadata.get("coverPath") or image_url:
+        if self._abs_cover_value(item_metadata) or image_url:
             return audiobookshelf_cover.build_cover_proxy_url(
                 self.account.id,
                 library_item_id,
@@ -950,19 +953,44 @@ class AudiobookshelfImporter:
             return True
 
         image = item.image or ""
+        # A raw ABS-hosted URL can never load in the browser, so it is always
+        # worth re-repairing. This terminates by itself: the repair rewrites it
+        # into a proxy URL, which _is_stale_abs_cover then ignores.
+        if self._is_stale_abs_cover(image):
+            return True
+
+        if item.metadata_fetched_at is None:
+            return True
+        age = timezone.now() - item.metadata_fetched_at
+
+        # A blank poster is the user-visible symptom of #861, so rows written
+        # before the cover fix should heal on the next day's sync rather than
+        # waiting out the full metadata cooldown. It still needs *a* cooldown:
+        # when ABS genuinely has no artwork and no provider matches, the image
+        # stays IMG_NONE and would otherwise be re-repaired on every sync.
+        if (
+            not image or image == settings.IMG_NONE
+        ) and age >= BOOK_COVER_REPAIR_COOLDOWN:
+            return True
+
+        # Books the providers simply cannot match - non-English audiobooks
+        # carrying an ASIN and no ISBN, say - would otherwise be flagged
+        # unhealthy on every single sync and re-query Hardcover/OpenLibrary
+        # forever (#861). The cooldown makes that retry periodic instead.
+        if age < BOOK_REPAIR_COOLDOWN:
+            return False
+
         # A missing ISBN is not a defect for audiobooks: ABS carries an ASIN for
         # most audio editions and no ISBN at all, so requiring one here marked
         # those items unhealthy forever and re-repaired them on every sync.
         return any(
             (
-                self._is_stale_abs_cover(image),
                 not item.authors,
                 not item.publishers,
                 not item.genres,
                 item.release_datetime is None,
                 not item.original_title,
                 not item.localized_title,
-                item.metadata_fetched_at is None,
             ),
         )
 
@@ -973,15 +1001,21 @@ class AudiobookshelfImporter:
         still hold a raw ABS-hosted URL - even the previously "normalised"
         /api/items/.../cover form, which requires a bearer token a plain
         <img src> can never attach. Any such URL needs to be re-repaired into
-        the proxy form so the poster actually loads. Using this instead of
-        _should_prefer_provider_cover in the repair check avoids infinite
-        re-repair for items whose provider enrichment failed and are left with
-        the proxy fallback URL.
+        the proxy form so the poster actually loads. It deliberately says
+        nothing about blank or placeholder covers: _needs_book_repair handles
+        those under a cooldown, so an item ABS has no artwork for is not
+        re-repaired on every sync.
         """
         if not image_url or image_url == settings.IMG_NONE:
             return False
         if audiobookshelf_cover.is_cover_proxy_url(image_url):
-            return False
+            # A proxy URL only resolves while its signature verifies, and
+            # rotating SECRET_KEY invalidates every stored token at once.
+            # Nothing else would ever rewrite them, so an unverifiable token
+            # is stale rather than healthy. Re-signing it on repair makes this
+            # terminate on the next pass.
+            token = image_url.rsplit("/", 1)[-1]
+            return audiobookshelf_cover.resolve_cover_proxy_token(token) is None
         return self._is_own_abs_host(image_url)
 
     def _is_own_abs_host(self, image_url: str) -> bool:
@@ -1127,17 +1161,70 @@ class AudiobookshelfImporter:
             return f"{self.account.base_url.rstrip('/')}{cover}"
         return urljoin(f"{self.account.base_url.rstrip('/')}/", cover)
 
-    def _should_prefer_provider_cover(self, image_url):
-        """Return whether provider (Hardcover/OpenLibrary) art should be preferred.
+    def _abs_cover_value(self, item_metadata: dict[str, Any]):
+        """Return the raw cover value Audiobookshelf reports for an item.
 
-        True whenever we don't already have a real, directly-loadable image
-        URL: missing, the placeholder, or our own relative ABS cover proxy
-        URL, which is deliberately host-less and so falls into the "not an
-        absolute http(s) URL" branch below (see #861).
+        Depending on the ABS version the cover lives at the library item's top
+        level, under ``media``, or only as an image entry in ``libraryFiles``.
+        Reading just the top-level key made Floppy conclude the item had no
+        artwork at all and fall back to whatever a metadata provider happened
+        to return - or to the placeholder (see #861).
         """
-        if not image_url or image_url == settings.IMG_NONE:
-            return True
-        return urlparse(image_url).scheme not in {"http", "https"}
+        cover_value = item_metadata.get("coverPath")
+        if cover_value:
+            return cover_value
+
+        media_info = item_metadata.get("media")
+        if isinstance(media_info, dict) and media_info.get("coverPath"):
+            return media_info["coverPath"]
+
+        library_files = item_metadata.get("libraryFiles")
+        if isinstance(library_files, list):
+            for library_file in library_files:
+                if not isinstance(library_file, dict):
+                    continue
+                if library_file.get("fileType") != "image":
+                    continue
+                file_metadata = library_file.get("metadata")
+                path = (
+                    file_metadata.get("path")
+                    if isinstance(file_metadata, dict)
+                    else None
+                )
+                if path:
+                    return path
+        return ""
+
+    def _resolve_cover_image(self, library_item_id: str, item_metadata: dict[str, Any]):
+        """Return the cover URL for an ABS book, preferring the user's own art.
+
+        Audiobookshelf artwork is what the user curated, so it wins over
+        Hardcover/OpenLibrary art: a provider match carrying a dead or simply
+        wrong cover URL used to replace a perfectly good ABS cover (see #861).
+        The ABS ``/api/items/:id/cover`` endpoint requires a bearer token a
+        plain ``<img src>`` can never attach, so any ABS-hosted cover is served
+        through Floppy's own authenticated proxy rather than the raw ABS URL.
+        """
+        cover_value = self._abs_cover_value(item_metadata)
+        image = self._normalize_cover_url(cover_value)
+        # A coverPath on some other host is a remote cover the user configured
+        # in ABS; it is already directly loadable, so keep it as-is.
+        if image and not self._is_own_abs_host(image):
+            return image
+        if cover_value:
+            return audiobookshelf_cover.build_cover_proxy_url(
+                self.account.id,
+                library_item_id,
+            )
+        return ""
+
+    def _needs_cover_from_provider(self, image_url):
+        """Return whether provider art is needed because we have no cover.
+
+        Audiobookshelf art now wins outright (see #861), so provider artwork
+        is only used when ABS gave us nothing to show.
+        """
+        return not image_url or image_url == settings.IMG_NONE
 
     def _resolve_provider_metadata(
         self, title: str, authors: list[str], isbns: list[str]
@@ -1277,7 +1364,20 @@ class AudiobookshelfImporter:
         return SequenceMatcher(None, normalized_left, normalized_right).ratio()
 
     def _normalize_name(self, value):
-        normalized = re.sub(r"[^a-z0-9]+", " ", str(value or "").lower())
+        """Casefold and strip punctuation while keeping non-ASCII letters.
+
+        The old form was ``re.sub(r"[^a-z0-9]+", " ", value.lower())``, which
+        deleted every non-ASCII character: a Cyrillic or Japanese title
+        normalised to the empty string and so could never match a provider
+        result, and accented Latin titles were degraded below
+        TITLE_MATCH_THRESHOLD (see #861). Accents are folded away rather than
+        dropped so "Zeitbrüch" still matches "Zeitbruch".
+        """
+        decomposed = unicodedata.normalize("NFKD", str(value or ""))
+        without_marks = "".join(
+            char for char in decomposed if not unicodedata.combining(char)
+        )
+        normalized = re.sub(r"[\W_]+", " ", without_marks.casefold())
         return re.sub(r"\s+", " ", normalized).strip()
 
     def _extract_provider_authors(self, provider_metadata: dict[str, Any] | None):

--- a/src/integrations/imports/audiobookshelf.py
+++ b/src/integrations/imports/audiobookshelf.py
@@ -1370,14 +1370,34 @@ class AudiobookshelfImporter:
         deleted every non-ASCII character: a Cyrillic or Japanese title
         normalised to the empty string and so could never match a provider
         result, and accented Latin titles were degraded below
-        TITLE_MATCH_THRESHOLD (see #861). Accents are folded away rather than
-        dropped so "Zeitbrüch" still matches "Zeitbruch".
+        TITLE_MATCH_THRESHOLD (see #861).
+
+        Accents are folded off Latin letters, so "Zeitbrüch" still matches
+        "Zeitbruch". They are *not* folded off other scripts, where a
+        combining mark changes the word rather than its spelling: stripping
+        them would collapse Japanese は/ば/ぱ and the Cyrillic ye/yo pair,
+        scoring different works as a perfect match and letting a provider
+        overwrite the item's metadata with another book's.
         """
         decomposed = unicodedata.normalize("NFKD", str(value or ""))
-        without_marks = "".join(
-            char for char in decomposed if not unicodedata.combining(char)
-        )
-        normalized = re.sub(r"[\W_]+", " ", without_marks.casefold())
+        kept = []
+        base_is_ascii = False
+        for char in decomposed:
+            if unicodedata.combining(char):
+                # NFKD decomposes an accented Latin letter to an ASCII base
+                # plus its mark, so an ASCII base is exactly the case where
+                # dropping the mark is a spelling variant rather than a
+                # different character.
+                if not base_is_ascii:
+                    kept.append(char)
+                continue
+            base_is_ascii = char.isascii()
+            kept.append(char)
+        # Recompose so a mark kept above rejoins its base into a single
+        # alphanumeric character; left bare it would read as punctuation
+        # below and split the word in half.
+        recomposed = unicodedata.normalize("NFC", "".join(kept))
+        normalized = re.sub(r"[\W_]+", " ", recomposed.casefold())
         return re.sub(r"\s+", " ", normalized).strip()
 
     def _extract_provider_authors(self, provider_metadata: dict[str, Any] | None):

--- a/src/integrations/tests/imports/test_audiobookshelf.py
+++ b/src/integrations/tests/imports/test_audiobookshelf.py
@@ -1797,6 +1797,31 @@ class AudiobookshelfTitleMatchingTests(TestCase):
                     TITLE_MATCH_THRESHOLD,
                 )
 
+    def test_keeps_marks_that_change_the_word(self):
+        """Folding marks off non-Latin scripts collapses distinct titles.
+
+        NFKD decomposes Japanese dakuten and the Cyrillic yo, so stripping
+        every combining mark scored different works as a perfect match and
+        let a provider overwrite the item with another book's metadata
+        (#1069 review).
+        """
+        collisions = (
+            ("\u3070\u3057", "\u306f\u3057"),  # ba-shi vs ha-shi
+            ("\u3071\u3057", "\u306f\u3057"),  # pa-shi vs ha-shi
+            ("\u3071\u3057", "\u3070\u3057"),  # pa-shi vs ba-shi
+            ("\u0432\u0441\u0451", "\u0432\u0441\u0435"),  # vsyo vs vse
+        )
+        for left, right in collisions:
+            with self.subTest(left=left, right=right):
+                self.assertNotEqual(
+                    self.importer._normalize_name(left),
+                    self.importer._normalize_name(right),
+                )
+                self.assertLess(
+                    self.importer._title_similarity(left, right),
+                    1.0,
+                )
+
     def test_still_strips_punctuation_and_case(self):
         """The normalisation the ASCII form did must keep working."""
         self.assertEqual(

--- a/src/integrations/tests/imports/test_audiobookshelf.py
+++ b/src/integrations/tests/imports/test_audiobookshelf.py
@@ -1,6 +1,6 @@
 """Tests for Audiobookshelf importer."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, call, patch
 
 import requests
@@ -23,6 +23,8 @@ from app.models import (
 from integrations import audiobookshelf_cover
 from integrations.imports import helpers
 from integrations.imports.audiobookshelf import (
+    BOOK_REPAIR_COOLDOWN,
+    TITLE_MATCH_THRESHOLD,
     AudiobookshelfAuthError,
     AudiobookshelfClient,
     AudiobookshelfClientError,
@@ -1171,6 +1173,392 @@ class AudiobookshelfImporterTests(TestCase):
             (str(account.id), "item-6"),
         )
 
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_repairs_cover_proxy_url_with_an_unverifiable_token(
+        self,
+        mock_me,
+        mock_item,
+    ):
+        """Rotating SECRET_KEY invalidates every stored cover token at once.
+
+        Nothing else would ever rewrite them, so every ABS poster would break
+        permanently - the same symptom as #861, from a different cause.
+        """
+        account = self.user.audiobookshelf_account
+        account.last_sync_ms = 2_000
+        account.save(update_fields=["last_sync_ms", "updated_at"])
+
+        importer = AudiobookshelfImporter(self.user)
+        media_id = importer._stable_media_id(account.base_url, "rotated-key-item")
+        stale = audiobookshelf_cover.build_cover_proxy_url(
+            account.id,
+            "rotated-key-item",
+        )
+        # Same shape, signature from another key.
+        stale = stale.rsplit(":", 1)[0] + ":signature-from-a-previous-secret"
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.AUDIOBOOKSHELF.value,
+            media_type=MediaTypes.BOOK.value,
+            title="Rotated Key",
+            original_title="Rotated Key",
+            localized_title="Rotated Key",
+            image=stale,
+            authors=["Some Author"],
+            publishers="Some Publisher",
+            genres=["Thriller"],
+            release_datetime=datetime(2020, 1, 1, tzinfo=UTC),
+            format="audiobook",
+            metadata_fetched_at=timezone.now(),
+        )
+        Book.objects.create(
+            user=self.user,
+            item=item,
+            status=Status.IN_PROGRESS.value,
+            progress=60,
+        )
+
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "rotated-key-item",
+                    "currentTime": 3_600,
+                    "duration": 12_000,
+                    "lastUpdate": 1_500,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {
+                "duration": 12_000,
+                "coverPath": "/metadata/items/rotated-key-item/cover.jpg",
+                "metadata": {"title": "Rotated Key"},
+            },
+        }
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        item.refresh_from_db()
+        self.assertNotEqual(item.image, stale)
+        self.assertEqual(
+            cover_proxy_target(item.image),
+            (str(account.id), "rotated-key-item"),
+        )
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_reads_cover_path_nested_under_media(self, mock_me, mock_item):
+        """ABS reports coverPath under media on some versions (#861)."""
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "media-cover-item",
+                    "currentTime": 600,
+                    "lastUpdate": 9_000,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {
+                "duration": 4_800,
+                "coverPath": "/metadata/items/media-cover-item/cover.jpg",
+                "metadata": {"title": "Nested Cover"},
+            },
+        }
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        item = Book.objects.get(user=self.user).item
+        self.assertNotEqual(item.image, settings.IMG_NONE)
+        account = self.user.audiobookshelf_account
+        self.assertEqual(
+            cover_proxy_target(item.image),
+            (str(account.id), "media-cover-item"),
+        )
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_reads_cover_from_library_files(self, mock_me, mock_item):
+        """An image entry in libraryFiles is still a cover ABS can serve."""
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "libfile-item",
+                    "currentTime": 600,
+                    "lastUpdate": 9_100,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {"duration": 4_800, "metadata": {"title": "Library File Cover"}},
+            "libraryFiles": [
+                {"fileType": "audio", "metadata": {"path": "/books/x/track1.m4b"}},
+                {"fileType": "image", "metadata": {"path": "/books/x/cover.jpg"}},
+            ],
+        }
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        item = Book.objects.get(user=self.user).item
+        account = self.user.audiobookshelf_account
+        self.assertEqual(
+            cover_proxy_target(item.image),
+            (str(account.id), "libfile-item"),
+        )
+
+    @patch("integrations.imports.audiobookshelf.services.get_media_metadata")
+    @patch("integrations.imports.audiobookshelf.services.search")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_provider_cover_does_not_override_abs_cover(
+        self,
+        mock_me,
+        mock_item,
+        mock_search,
+        mock_get_media_metadata,
+    ):
+        """The user's own ABS artwork wins over a provider cover (#861).
+
+        A provider match carrying a dead or simply wrong cover URL used to
+        replace a perfectly good Audiobookshelf cover, which is what made
+        *some* posters disappear while others were fine.
+        """
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "abs-art-item",
+                    "currentTime": 600,
+                    "lastUpdate": 9_200,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {
+                "duration": 4_800,
+                "metadata": {
+                    "title": "Owned Artwork",
+                    "isbn": "978-0-7653-1178-8",
+                },
+            },
+            "coverPath": "/metadata/items/abs-art-item/cover.jpg",
+        }
+        mock_search.return_value = {
+            "results": [
+                {
+                    "media_id": "600",
+                    "source": Sources.HARDCOVER.value,
+                    "title": "Owned Artwork",
+                },
+            ],
+        }
+        mock_get_media_metadata.return_value = {
+            "media_id": "600",
+            "source": Sources.HARDCOVER.value,
+            "media_type": MediaTypes.BOOK.value,
+            "title": "Owned Artwork",
+            "image": "https://covers.example/some-other-book.jpg",
+            "max_progress": 400,
+            "genres": ["Fantasy"],
+            "details": {
+                "author": "Some Author",
+                "publisher": "Tor",
+                "isbn": ["9780765311788"],
+            },
+        }
+
+        importer = AudiobookshelfImporter(self.user)
+        importer.enable_provider_enrichment = True
+        importer.import_data()
+
+        item = Book.objects.get(user=self.user).item
+        account = self.user.audiobookshelf_account
+        self.assertEqual(
+            cover_proxy_target(item.image),
+            (str(account.id), "abs-art-item"),
+        )
+        # Enrichment still ran - only the cover preference changed.
+        self.assertEqual(item.genres, ["Fantasy"])
+        self.assertEqual(item.publishers, "Tor")
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_repairs_placeholder_cover_from_before_the_fix(self, mock_me, mock_item):
+        """A row stuck on IMG_NONE heals once the cover cooldown has passed."""
+        account = self.user.audiobookshelf_account
+        account.last_sync_ms = 2_000
+        account.save(update_fields=["last_sync_ms", "updated_at"])
+
+        importer = AudiobookshelfImporter(self.user)
+        media_id = importer._stable_media_id(account.base_url, "blank-cover-item")
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.AUDIOBOOKSHELF.value,
+            media_type=MediaTypes.BOOK.value,
+            title="Der Heimweg",
+            original_title="Der Heimweg",
+            localized_title="Der Heimweg",
+            image=settings.IMG_NONE,
+            authors=["Sebastian Fitzek"],
+            publishers="Audible Studios",
+            genres=["Psychothriller"],
+            release_datetime=datetime(2020, 1, 1, tzinfo=UTC),
+            format="audiobook",
+            metadata_fetched_at=timezone.now() - timedelta(days=2),
+        )
+        Book.objects.create(
+            user=self.user,
+            item=item,
+            status=Status.IN_PROGRESS.value,
+            progress=60,
+        )
+
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "blank-cover-item",
+                    "currentTime": 3_600,
+                    "duration": 12_000,
+                    "lastUpdate": 1_500,
+                },
+            ],
+        }
+        mock_item.return_value = {
+            "media": {
+                "duration": 12_000,
+                "coverPath": "/metadata/items/blank-cover-item/cover.jpg",
+                "metadata": {"title": "Der Heimweg"},
+            },
+        }
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        item.refresh_from_db()
+        self.assertEqual(
+            cover_proxy_target(item.image),
+            (str(account.id), "blank-cover-item"),
+        )
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_does_not_re_repair_placeholder_cover_within_cooldown(
+        self,
+        mock_me,
+        mock_item,
+    ):
+        """An item ABS has no artwork for must not re-repair on every sync."""
+        account = self.user.audiobookshelf_account
+        account.last_sync_ms = 2_000
+        account.save(update_fields=["last_sync_ms", "updated_at"])
+
+        importer = AudiobookshelfImporter(self.user)
+        media_id = importer._stable_media_id(account.base_url, "artless-item")
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.AUDIOBOOKSHELF.value,
+            media_type=MediaTypes.BOOK.value,
+            title="Artless",
+            original_title="Artless",
+            localized_title="Artless",
+            image=settings.IMG_NONE,
+            authors=["Some Author"],
+            publishers="Some Publisher",
+            genres=["Thriller"],
+            release_datetime=datetime(2020, 1, 1, tzinfo=UTC),
+            format="audiobook",
+            metadata_fetched_at=timezone.now(),
+        )
+        Book.objects.create(
+            user=self.user,
+            item=item,
+            status=Status.IN_PROGRESS.value,
+            progress=60,
+        )
+
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "artless-item",
+                    "currentTime": 3_600,
+                    "duration": 12_000,
+                    "lastUpdate": 1_500,
+                },
+            ],
+        }
+
+        counts, warnings = AudiobookshelfImporter(self.user).import_data()
+
+        self.assertEqual(counts, {})
+        self.assertEqual(warnings, "")
+        mock_item.assert_not_called()
+
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_library_item")
+    @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
+    def test_thin_metadata_is_not_re_repaired_within_cooldown(
+        self,
+        mock_me,
+        mock_item,
+    ):
+        """Books the providers cannot match must not re-query them forever."""
+        account = self.user.audiobookshelf_account
+        account.last_sync_ms = 2_000
+        account.save(update_fields=["last_sync_ms", "updated_at"])
+
+        importer = AudiobookshelfImporter(self.user)
+        media_id = importer._stable_media_id(account.base_url, "unmatchable-item")
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.AUDIOBOOKSHELF.value,
+            media_type=MediaTypes.BOOK.value,
+            title="Unmatchable",
+            original_title="Unmatchable",
+            localized_title="Unmatchable",
+            image=audiobookshelf_cover.build_cover_proxy_url(
+                account.id,
+                "unmatchable-item",
+            ),
+            authors=["Some Author"],
+            publishers="",
+            genres=[],
+            release_datetime=None,
+            format="audiobook",
+            metadata_fetched_at=timezone.now(),
+        )
+        Book.objects.create(
+            user=self.user,
+            item=item,
+            status=Status.IN_PROGRESS.value,
+            progress=60,
+        )
+
+        mock_me.return_value = {
+            "mediaProgress": [
+                {
+                    "libraryItemId": "unmatchable-item",
+                    "currentTime": 3_600,
+                    "duration": 12_000,
+                    "lastUpdate": 1_500,
+                },
+            ],
+        }
+
+        counts, warnings = AudiobookshelfImporter(self.user).import_data()
+
+        self.assertEqual(counts, {})
+        self.assertEqual(warnings, "")
+        mock_item.assert_not_called()
+
+        # ...but it is retried once the cooldown lapses.
+        item.metadata_fetched_at = timezone.now() - (BOOK_REPAIR_COOLDOWN + timedelta(days=1))
+        item.save(update_fields=["metadata_fetched_at"])
+        mock_item.return_value = {
+            "media": {"duration": 12_000, "metadata": {"title": "Unmatchable"}},
+        }
+
+        AudiobookshelfImporter(self.user).import_data()
+
+        mock_item.assert_called_once_with("unmatchable-item")
+
     @patch("integrations.imports.audiobookshelf.AudiobookshelfClient.get_me")
     def test_marks_connection_broken_on_auth_error(self, mock_me):
         """Auth failures should mark the account as broken and raise import error."""
@@ -1371,6 +1759,57 @@ class AudiobookshelfImporterTests(TestCase):
         self.assertEqual(counts, {})
         self.assertEqual(warnings, "")
         mock_item.assert_not_called()
+
+
+class AudiobookshelfTitleMatchingTests(TestCase):
+    """Non-ASCII titles must still be comparable against provider results.
+
+    _normalize_name used to be re.sub(r"[^a-z0-9]+", " ", value.lower()), which
+    deleted every non-ASCII character: a Cyrillic or Japanese title normalised
+    to the empty string and could never match anything (#861).
+    """
+
+    def setUp(self):
+        """Create a connected account so the importer can be constructed."""
+        self.user = get_user_model().objects.create_user(username="abs-titles")
+        AudiobookshelfAccount.objects.create(
+            user=self.user,
+            base_url="https://abs.example.com",
+            api_token=helpers.encrypt("token"),
+        )
+        self.importer = AudiobookshelfImporter(self.user)
+
+    def test_folds_accents_instead_of_dropping_them(self):
+        """German umlauts must not push a title below the match threshold."""
+        self.assertEqual(self.importer._normalize_name("Zeitbrüch"), "zeitbruch")
+        self.assertGreaterEqual(
+            self.importer._title_similarity("Zeitbrüch", "Zeitbruch"),
+            TITLE_MATCH_THRESHOLD,
+        )
+
+    def test_keeps_non_latin_scripts(self):
+        """Cyrillic and CJK titles must normalise to something comparable."""
+        for title in ("Война и мир", "ノルウェイの森"):
+            with self.subTest(title=title):
+                self.assertNotEqual(self.importer._normalize_name(title), "")
+                self.assertGreaterEqual(
+                    self.importer._title_similarity(title, title),
+                    TITLE_MATCH_THRESHOLD,
+                )
+
+    def test_still_strips_punctuation_and_case(self):
+        """The normalisation the ASCII form did must keep working."""
+        self.assertEqual(
+            self.importer._normalize_name("The Hobbit: There & Back_Again!"),
+            "the hobbit there back again",
+        )
+
+    def test_unrelated_titles_still_score_low(self):
+        """Keeping more characters must not make everything match."""
+        self.assertLess(
+            self.importer._title_similarity("Война и мир", "ノルウェイの森"),
+            TITLE_MATCH_THRESHOLD,
+        )
 
 
 class AudiobookshelfClientRetryTests(TestCase):

--- a/src/integrations/tests/test_audiobookshelf_views.py
+++ b/src/integrations/tests/test_audiobookshelf_views.py
@@ -354,9 +354,14 @@ class AudiobookshelfCoverProxyTests(TestCase):
 
         self.assertPlaceholder(response)
 
-    def test_invalid_token_is_logged_without_echoing_the_token(self):
-        """The rejection is logged, but the token itself never is."""
-        with self.assertLogs("integrations.views", level="WARNING") as logs:
+    def test_invalid_token_does_not_log_a_warning(self):
+        """Junk tokens stay below warning, and the token is never echoed.
+
+        The view is anonymous, so warning on an unsignable token would let
+        anyone flood the log and bury the real Audiobookshelf failures these
+        warnings exist to surface (#1069 review).
+        """
+        with self.assertLogs("integrations.views", level="DEBUG") as logs:
             self.client.get(
                 reverse(
                     "audiobookshelf_cover",
@@ -364,4 +369,6 @@ class AudiobookshelfCoverProxyTests(TestCase):
                 ),
             )
 
-        self.assertNotIn("sneaky-token-value", "\n".join(logs.output))
+        output = "\n".join(logs.output)
+        self.assertNotIn("sneaky-token-value", output)
+        self.assertNotIn("WARNING", output)

--- a/src/integrations/tests/test_audiobookshelf_views.py
+++ b/src/integrations/tests/test_audiobookshelf_views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django_celery_beat.models import CrontabSchedule, IntervalSchedule, PeriodicTask
 
 from app import image_cache
-from integrations import audiobookshelf_cover
+from integrations import audiobookshelf_cover, views
 from integrations.imports import helpers
 from integrations.models import AudiobookshelfAccount
 
@@ -160,6 +160,21 @@ class AudiobookshelfCoverProxyTests(TestCase):
         upstream.iter_content = iter_content
         return upstream
 
+    def assertPlaceholder(self, response):  # noqa: N802 - unittest naming
+        """Assert the response is Floppy's own placeholder, not a broken image.
+
+        A 404 renders as the browser's broken-image glyph because nothing in
+        the templates has an onerror fallback for a URL that is itself valid,
+        which is what made #861 look like corruption rather than an offline
+        server. The short TTL lets the real cover reappear once ABS recovers.
+        """
+        placeholder_body, placeholder_type = views._placeholder_image_bytes()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, placeholder_body)
+        self.assertEqual(response["Content-Type"], placeholder_type)
+        self.assertEqual(response["Cache-Control"], "private, max-age=300")
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
+
     @patch("integrations.views.requests.get")
     def test_streams_cover_with_valid_token(self, mock_get):
         """A valid signed token fetches the upstream cover with the stored token."""
@@ -173,6 +188,8 @@ class AudiobookshelfCoverProxyTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"fake-image-bytes")
         self.assertEqual(response["Content-Type"], "image/webp")
+        self.assertEqual(response["Cache-Control"], "private, max-age=3600")
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
 
         mock_get.assert_called_once_with(
             f"{BASE_URL}/api/items/item-1/cover",
@@ -188,29 +205,41 @@ class AudiobookshelfCoverProxyTests(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_returns_404_when_account_no_longer_exists(self):
-        """A signed token for a deleted account 404s instead of erroring."""
+    def test_serves_placeholder_when_account_no_longer_exists(self):
+        """A signed token for a deleted account degrades to the placeholder."""
         url = audiobookshelf_cover.build_cover_proxy_url(999_999, "item-1")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+
+        with self.assertLogs("integrations.views", level="WARNING") as logs:
+            response = self.client.get(url)
+
+        self.assertPlaceholder(response)
+        self.assertIn("item-1", "\n".join(logs.output))
 
     @patch("integrations.views.requests.get")
-    def test_returns_404_on_upstream_error_status(self, mock_get):
-        """An ABS-side auth failure surfaces as a 404, not a broken image."""
+    def test_serves_placeholder_on_upstream_error_status(self, mock_get):
+        """An ABS-side auth failure degrades to the placeholder, and is logged.
+
+        Every failure below used to be a silent 404, which is exactly why the
+        #861 reports carried no usable evidence in Settings > Advanced.
+        """
         mock_get.return_value = self._mock_upstream(status_code=401)
 
-        response = self.client.get(self._cover_url())
+        with self.assertLogs("integrations.views", level="WARNING") as logs:
+            response = self.client.get(self._cover_url())
 
-        self.assertEqual(response.status_code, 404)
+        self.assertPlaceholder(response)
+        self.assertIn("status=401", "\n".join(logs.output))
 
     @patch("integrations.views.requests.get")
-    def test_returns_404_on_request_exception(self, mock_get):
-        """A network failure talking to ABS surfaces as a 404."""
+    def test_serves_placeholder_on_request_exception(self, mock_get):
+        """A network failure talking to ABS degrades to the placeholder."""
         mock_get.side_effect = requests.ConnectionError("boom")
 
-        response = self.client.get(self._cover_url())
+        with self.assertLogs("integrations.views", level="WARNING") as logs:
+            response = self.client.get(self._cover_url())
 
-        self.assertEqual(response.status_code, 404)
+        self.assertPlaceholder(response)
+        self.assertIn("request failed", "\n".join(logs.output))
 
     @patch("integrations.views.requests.get")
     def test_rejects_non_image_content_type(self, mock_get):
@@ -225,9 +254,11 @@ class AudiobookshelfCoverProxyTests(TestCase):
             headers={"Content-Type": "text/html"},
         )
 
-        response = self.client.get(self._cover_url())
+        with self.assertLogs("integrations.views", level="WARNING"):
+            response = self.client.get(self._cover_url())
 
-        self.assertEqual(response.status_code, 404)
+        self.assertPlaceholder(response)
+        self.assertNotIn(b"<script>", response.content)
 
     @patch("integrations.views.requests.get")
     def test_rejects_svg_content_type(self, mock_get):
@@ -237,9 +268,57 @@ class AudiobookshelfCoverProxyTests(TestCase):
             headers={"Content-Type": "image/svg+xml"},
         )
 
+        with self.assertLogs("integrations.views", level="WARNING"):
+            response = self.client.get(self._cover_url())
+
+        self.assertPlaceholder(response)
+        self.assertNotIn(b"onload", response.content)
+
+    @patch("integrations.views.requests.get")
+    def test_rejects_untyped_body_that_is_not_an_image(self, mock_get):
+        """An unlabelled body still has to prove it is a raster image.
+
+        Sniffing exists so a reverse proxy that strips or genericises the
+        content type doesn't cost the poster (#861) - but it must not become a
+        way to smuggle SVG or HTML past the allow-list.
+        """
+        mock_get.return_value = self._mock_upstream(
+            content=b"<svg onload='alert(1)'></svg>",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+        with self.assertLogs("integrations.views", level="WARNING"):
+            response = self.client.get(self._cover_url())
+
+        self.assertPlaceholder(response)
+
+    @patch("integrations.views.requests.get")
+    def test_sniffs_untyped_jpeg_body(self, mock_get):
+        """A JPEG behind a generic content type is served as image/jpeg."""
+        jpeg = b"\xff\xd8\xff\xe0" + b"0" * 32
+        mock_get.return_value = self._mock_upstream(
+            content=jpeg,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
         response = self.client.get(self._cover_url())
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, jpeg)
+        self.assertEqual(response["Content-Type"], "image/jpeg")
+
+    @patch("integrations.views.requests.get")
+    def test_accepts_non_standard_jpeg_content_type(self, mock_get):
+        """Real ABS deployments emit image/jpg; rejecting it lost the poster."""
+        mock_get.return_value = self._mock_upstream(
+            content=b"fake-image-bytes",
+            headers={"Content-Type": "image/jpg"},
+        )
+
+        response = self.client.get(self._cover_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"fake-image-bytes")
 
     @patch("integrations.views.requests.get")
     def test_rejects_oversized_content_length(self, mock_get):
@@ -252,9 +331,10 @@ class AudiobookshelfCoverProxyTests(TestCase):
             },
         )
 
-        response = self.client.get(self._cover_url())
+        with self.assertLogs("integrations.views", level="WARNING"):
+            response = self.client.get(self._cover_url())
 
-        self.assertEqual(response.status_code, 404)
+        self.assertPlaceholder(response)
 
     @patch("integrations.views.requests.get")
     def test_rejects_stream_exceeding_max_bytes(self, mock_get):
@@ -269,6 +349,19 @@ class AudiobookshelfCoverProxyTests(TestCase):
             headers={"Content-Type": "image/jpeg"},
         )
 
-        response = self.client.get(self._cover_url())
+        with self.assertLogs("integrations.views", level="WARNING"):
+            response = self.client.get(self._cover_url())
 
-        self.assertEqual(response.status_code, 404)
+        self.assertPlaceholder(response)
+
+    def test_invalid_token_is_logged_without_echoing_the_token(self):
+        """The rejection is logged, but the token itself never is."""
+        with self.assertLogs("integrations.views", level="WARNING") as logs:
+            self.client.get(
+                reverse(
+                    "audiobookshelf_cover",
+                    kwargs={"token": "sneaky-token-value"},
+                ),
+            )
+
+        self.assertNotIn("sneaky-token-value", "\n".join(logs.output))

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -1,5 +1,7 @@
 """Contains views for importing and exporting media data from various sources."""
 
+import base64
+import binascii
 import hmac
 import json
 import logging
@@ -1762,9 +1764,104 @@ AUDIOBOOKSHELF_COVER_TIMEOUT = 15
 # just compromised) returning e.g. text/html or image/svg+xml would have it
 # served as active content from Floppy's own origin to anyone holding the
 # signed proxy URL, since the account owner can share that URL freely.
+# The non-standard spellings are here because real ABS deployments behind a
+# reverse proxy do emit them, and rejecting one lost the poster (#861).
 AUDIOBOOKSHELF_COVER_CONTENT_TYPES = frozenset(
-    {"image/jpeg", "image/png", "image/webp", "image/gif", "image/avif"},
+    {
+        "image/jpeg",
+        "image/jpg",
+        "image/pjpeg",
+        "image/png",
+        "image/x-png",
+        "image/webp",
+        "image/gif",
+        "image/avif",
+        "image/bmp",
+        "image/tiff",
+        "image/heic",
+        "image/heif",
+    },
 )
+# Content types that mean "I don't know", where sniffing the body is the only
+# way to tell a real cover from something we must not serve.
+AUDIOBOOKSHELF_COVER_UNTYPED = frozenset({"", "application/octet-stream"})
+# Leading magic bytes for the raster formats above. WebP is RIFF....WEBP, so it
+# is matched on two separate offsets rather than a single prefix.
+COVER_MAGIC_PREFIXES = (
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"BM", "image/bmp"),
+    (b"II*\x00", "image/tiff"),
+    (b"MM\x00*", "image/tiff"),
+)
+COVER_SNIFF_BYTES = 16
+
+
+def _sniff_cover_content_type(body: bytes) -> str:
+    """Return the image type of `body` from its magic bytes, or "" if unknown.
+
+    Deliberately recognises raster formats only: an SVG or HTML body has no
+    magic number here and so stays rejected, exactly as an explicit
+    image/svg+xml content type would be.
+    """
+    for prefix, content_type in COVER_MAGIC_PREFIXES:
+        if body.startswith(prefix):
+            return content_type
+    if body[:4] == b"RIFF" and body[8:12] == b"WEBP":
+        return "image/webp"
+    if body[4:8] == b"ftyp":
+        brand = body[8:12]
+        if brand in {b"avif", b"avis"}:
+            return "image/avif"
+        if brand in {b"heic", b"heix", b"heim", b"heis", b"mif1", b"msf1"}:
+            return "image/heic"
+    return ""
+
+
+def _placeholder_image_bytes():
+    """Decode settings.IMG_NONE into (body, content_type), or None.
+
+    IMG_NONE is a base64 data URI by default but is overridable to a plain URL,
+    which there is nothing to decode from. Decoded per call rather than cached
+    so an overridden setting is always honoured; this only runs on the failure
+    path, where one small base64 decode is not worth a staleness hazard.
+    """
+    prefix = "data:"
+    value = settings.IMG_NONE or ""
+    if not value.startswith(prefix):
+        return None
+    header, _, payload = value[len(prefix) :].partition(",")
+    if not payload:
+        return None
+    content_type, _, encoding = header.partition(";")
+    if encoding.strip().lower() != "base64":
+        return None
+    try:
+        return base64.b64decode(payload), content_type.strip() or "image/svg+xml"
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _placeholder_image_response():
+    """Return Floppy's own "no artwork" placeholder as a real image response.
+
+    A 404 here renders as the browser's broken-image glyph, because nothing in
+    the templates has an onerror fallback and the stored URL is a perfectly
+    valid proxy URL (#861). Serving the placeholder instead keeps the grid
+    looking the way it does for any other artless item. The bytes are Floppy's
+    own fixed SVG, never anything the upstream server influenced, and the TTL
+    is short so the real cover reappears once ABS recovers.
+    """
+    decoded = _placeholder_image_bytes()
+    if decoded is None:
+        return HttpResponseNotFound()
+    body, content_type = decoded
+    response = HttpResponse(body, content_type=content_type)
+    response["Cache-Control"] = "private, max-age=300"
+    response["X-Content-Type-Options"] = "nosniff"
+    return response
 
 
 @login_not_required
@@ -1780,24 +1877,40 @@ def audiobookshelf_cover(request, token):
     hard size cap and its content type is restricted to known-safe image
     types - matching the bounded, allow-listed fetch app.image_cache already
     does for provider artwork.
+
+    Every failure below is logged and answered with Floppy's own placeholder
+    rather than a bare 404: the 404s were both invisible in Settings > Advanced
+    and rendered as broken-image glyphs, which is what made #861 impossible to
+    diagnose from a bug report.
     """
     resolved = abs_cover_proxy.resolve_cover_proxy_token(token)
     if resolved is None:
+        # A tampered or malformed token is not something a Floppy page can
+        # produce, so this one stays a plain 404.
+        logger.warning("Audiobookshelf cover proxy rejected an unsignable token")
         return HttpResponseNotFound()
     account_id, library_item_id = resolved
 
     account = AudiobookshelfAccount.objects.filter(pk=account_id).first()
     if account is None:
-        return HttpResponseNotFound()
+        logger.warning(
+            "Audiobookshelf cover unavailable: no account account=%s item=%s",
+            account_id,
+            library_item_id,
+        )
+        return _placeholder_image_response()
 
     try:
         api_token = helpers.decrypt(account.api_token)
-    except Exception:
+    except Exception as error:
         logger.warning(
-            "Failed to decrypt Audiobookshelf token for cover proxy account=%s",
+            "Audiobookshelf cover unavailable: token decrypt failed "
+            "account=%s item=%s error=%s",
             account_id,
+            library_item_id,
+            exception_summary(error),
         )
-        return HttpResponseNotFound()
+        return _placeholder_image_response()
 
     cover_url = f"{account.base_url.rstrip('/')}/api/items/{library_item_id}/cover"
     try:
@@ -1807,38 +1920,98 @@ def audiobookshelf_cover(request, token):
             timeout=AUDIOBOOKSHELF_COVER_TIMEOUT,
             stream=True,
         )
-    except requests.RequestException:
-        return HttpResponseNotFound()
+    except requests.RequestException as error:
+        logger.warning(
+            "Audiobookshelf cover unavailable: request failed "
+            "account=%s item=%s error=%s",
+            account_id,
+            library_item_id,
+            exception_summary(error),
+        )
+        return _placeholder_image_response()
 
     try:
         if upstream.status_code != HTTPStatus.OK:
-            return HttpResponseNotFound()
+            logger.warning(
+                "Audiobookshelf cover unavailable: upstream status=%s "
+                "account=%s item=%s",
+                upstream.status_code,
+                account_id,
+                library_item_id,
+            )
+            return _placeholder_image_response()
 
         content_type = (
             upstream.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
         )
-        if content_type not in AUDIOBOOKSHELF_COVER_CONTENT_TYPES:
-            return HttpResponseNotFound()
+        if (
+            content_type not in AUDIOBOOKSHELF_COVER_CONTENT_TYPES
+            and content_type not in AUDIOBOOKSHELF_COVER_UNTYPED
+        ):
+            logger.warning(
+                "Audiobookshelf cover unavailable: refused content_type=%s "
+                "account=%s item=%s",
+                content_type,
+                account_id,
+                library_item_id,
+            )
+            return _placeholder_image_response()
 
         try:
             content_length = int(upstream.headers.get("Content-Length", "0"))
         except ValueError:
             content_length = 0
         if content_length > image_cache.MAX_IMAGE_BYTES:
-            return HttpResponseNotFound()
+            logger.warning(
+                "Audiobookshelf cover unavailable: declared content_length=%s "
+                "over cap account=%s item=%s",
+                content_length,
+                account_id,
+                library_item_id,
+            )
+            return _placeholder_image_response()
 
         body = bytearray()
+        oversized = False
         for chunk in upstream.iter_content(chunk_size=64 * 1024):
             if not chunk:
                 continue
             body.extend(chunk)
             if len(body) > image_cache.MAX_IMAGE_BYTES:
-                return HttpResponseNotFound()
+                oversized = True
+                break
     finally:
         upstream.close()
 
-    response = HttpResponse(bytes(body), content_type=content_type)
+    if oversized:
+        logger.warning(
+            "Audiobookshelf cover unavailable: body exceeded %s bytes "
+            "account=%s item=%s",
+            image_cache.MAX_IMAGE_BYTES,
+            account_id,
+            library_item_id,
+        )
+        return _placeholder_image_response()
+
+    body = bytes(body)
+    # An upstream that declares nothing useful still has to prove it sent a
+    # raster image; sniffing keeps SVG and HTML out just as the allow-list does.
+    if content_type in AUDIOBOOKSHELF_COVER_UNTYPED:
+        sniffed = _sniff_cover_content_type(body[:COVER_SNIFF_BYTES])
+        if not sniffed:
+            logger.warning(
+                "Audiobookshelf cover unavailable: untyped body was not an image "
+                "content_type=%s account=%s item=%s",
+                content_type,
+                account_id,
+                library_item_id,
+            )
+            return _placeholder_image_response()
+        content_type = sniffed
+
+    response = HttpResponse(body, content_type=content_type)
     response["Cache-Control"] = "private, max-age=3600"
+    response["X-Content-Type-Options"] = "nosniff"
     return response
 
 

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -1886,8 +1886,12 @@ def audiobookshelf_cover(request, token):
     resolved = abs_cover_proxy.resolve_cover_proxy_token(token)
     if resolved is None:
         # A tampered or malformed token is not something a Floppy page can
-        # produce, so this one stays a plain 404.
-        logger.warning("Audiobookshelf cover proxy rejected an unsignable token")
+        # produce, so this one stays a plain 404. It is logged at debug
+        # rather than warning because the view is anonymous: anyone could
+        # otherwise flood the log with junk tokens and bury the real
+        # Audiobookshelf failures below, which are the point of #861. Every
+        # other branch here needs a valid signature to reach.
+        logger.debug("Audiobookshelf cover proxy rejected an unsignable token")
         return HttpResponseNotFound()
     account_id, library_item_id = resolved
 

--- a/src/static/js/image-fallback.js
+++ b/src/static/js/image-fallback.js
@@ -1,0 +1,45 @@
+// An image that fails to load renders as the browser's broken-image glyph,
+// which reads as a bug rather than as missing artwork. Templates only fall back
+// to IMG_NONE when the *stored* value is blank, so a poster whose URL is fine
+// but whose fetch fails - a provider image-cache miss, or an Audiobookshelf
+// server that is offline (#861) - had nothing to catch it.
+(function () {
+  var placeholder = document.documentElement.dataset.imgNone;
+  if (!placeholder) return;
+
+  // Image load errors do not bubble, so this has to listen in the capture phase
+  // to see them at the document level.
+  document.addEventListener(
+    "error",
+    function (event) {
+      var img = event.target;
+      if (!img || img.tagName !== "IMG") return;
+      // Guard against a placeholder that itself fails, which would loop.
+      if (img.dataset.imageFallbackApplied) return;
+      if (img.getAttribute("src") === placeholder) return;
+      img.dataset.imageFallbackApplied = "1";
+      img.src = placeholder;
+    },
+    true,
+  );
+
+  // The listener is attached after parsing, so an eagerly-loaded image that
+  // already failed never fires an event this can see. A broken image reports
+  // complete with a zero natural width, which is what finds those.
+  function sweep() {
+    document.querySelectorAll("img").forEach(function (img) {
+      if (img.dataset.imageFallbackApplied) return;
+      if (!img.complete || img.naturalWidth !== 0) return;
+      if (img.getAttribute("src") === placeholder) return;
+      if (!img.getAttribute("src")) return;
+      img.dataset.imageFallbackApplied = "1";
+      img.src = placeholder;
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", sweep);
+  } else {
+    sweep();
+  }
+})();

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -4,6 +4,7 @@
 
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}"
+      data-img-none="{{ IMG_NONE }}"
       class="{% if user.is_authenticated and user.theme == 'light' %}light{% elif user.is_authenticated and user.theme == 'dark' %}dark{% endif %} bg-[var(--color-page-bg)]">
   <head>
     {# Required meta tags #}
@@ -114,6 +115,8 @@
             src="{% static 'js/markdown-editor.js' %}{% get_static_file_mtime 'js/markdown-editor.js' %}"></script>
     <script defer src="{% static 'js/libraries/alpinejs-3.14.9.min.js' %}"></script>
     <script src="{% static 'js/libraries/lazysizes-5.3.2.min.js' %}" async></script>
+    <script defer
+            src="{% static 'js/image-fallback.js' %}{% get_static_file_mtime 'js/image-fallback.js' %}"></script>
     {# ZXing library for barcode decoding #}
     <script src="{% static 'js/libraries/zxing-library-0.21.3.min.js' %}"
             onload="console.log('ZXing library loaded');"></script>

--- a/src/templates/base_public.html
+++ b/src/templates/base_public.html
@@ -3,7 +3,9 @@
 
 {# djlint:off #}
 <!DOCTYPE html>
-<html lang="en" class="scheme-dark bg-[var(--color-page-bg)]">
+<html lang="en"
+      data-img-none="{{ IMG_NONE }}"
+      class="scheme-dark bg-[var(--color-page-bg)]">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -40,6 +42,8 @@
     </script>
     <script defer src="{% static 'js/libraries/alpinejs-3.14.9.min.js' %}"></script>
     <script src="{% static 'js/libraries/lazysizes-5.3.2.min.js' %}" async></script>
+    <script defer
+            src="{% static 'js/image-fallback.js' %}{% get_static_file_mtime 'js/image-fallback.js' %}"></script>
 
     <link rel="apple-touch-icon" sizes="180x180" href="{% static 'favicon/apple-touch-icon.png' %}">
     <link rel="icon" type="image/png" sizes="32x32" href="{% static 'favicon/favicon-32x32.png' %}">


### PR DESCRIPTION
## Summary

Some Audiobookshelf book posters still rendered as the grey placeholder after the cover proxy landed in #982, and the reporter confirmed it on a **brand new** install. #982 was necessary but not sufficient — four independent defects could each blank a poster, and a fifth made every failure invisible in the logs you asked for twice.

**1. Provider art always beat the user's own ABS art.** `build_cover_proxy_url` returns a *relative* path, and `_should_prefer_provider_cover` treated any non-`http(s)` URL as "no cover" — so a Hardcover/OpenLibrary match always won, **including one carrying a dead or simply wrong cover URL**. This is the best fit for "*some* posters missing while others are fine". Audiobookshelf artwork is what the user curated, so it now wins outright; provider art is used only when ABS has none. Provider enrichment still runs for authors, publisher, genres and release date — only the cover preference changed.

**2. `coverPath` was read from one place only.** Depending on the ABS version the cover lives at the library item's top level, under `media`, or only as an image entry in `libraryFiles`. Reading just the top-level key made Floppy conclude the item had no artwork at all, leaving a provider match as its only hope.

**3. Non-ASCII titles could never match a provider.** `_normalize_name` was `re.sub(r"[^a-z0-9]+", " ", value.lower())`, which deletes every non-ASCII character — a Cyrillic or Japanese title normalised to the empty string, and accented Latin titles fell below the 0.72 similarity threshold. The reporter's own "my books are not in English" theory was correct. Accents are now folded (`Zeitbrüch` → `zeitbruch`) and other scripts are kept.

**4. Unmatchable books re-repaired forever.** `_needs_book_repair` flagged any book missing `publishers`/`genres`/`release_datetime` as unhealthy on *every* sync, so books the providers cannot match (audiobooks carry an ASIN and no ISBN) re-queried Hardcover/OpenLibrary continuously. Both repair paths are now cooldown-bounded — 30 days for thin metadata, 1 day for a blank poster so existing installs heal quickly after upgrading.

**5. The proxy failed silently.** Every failure branch returned a bare 404 with no log line at all, which is exactly why #861 carried no usable evidence from Settings → Advanced. Now each branch logs the reason with the account and library item id (never the token or credentials). Alongside that: the content-type allow-list accepts the non-standard spellings real ABS deployments behind a reverse proxy emit (`image/jpg` and friends); an unlabelled body is accepted only if its magic bytes say it is a raster image, so **SVG and HTML stay rejected** as the #982 review required; responses now carry `X-Content-Type-Options: nosniff`; and failures serve Floppy's own placeholder instead of a 404, which rendered as the browser's broken-image glyph. A shared `image-fallback.js` catches what the server cannot — a provider image-cache miss, say.

One extra fix found while verifying, slightly beyond the original scope and worth a look: a cover token whose signature no longer verifies — as after a `SECRET_KEY` rotation — was permanently dead, because `is_cover_proxy_url` considered it healthy so nothing ever re-signed it. Every ABS poster would break at once with no recovery. It is now re-signed on the next sync.

**Deliberately out of scope:** `integrations/plex_cover.py` + `views.plex_cover` are a literal mirror of this proxy with the same silent-404 and content-type gaps. Left out to keep this diff reviewable against #861; worth its own issue.

### Before / after

Verified against a stub Audiobookshelf server reproducing the reported conditions — German titles, `coverPath` only under `media`, cover served as `image/jpg` and only with a valid bearer header:

- **Before:** all three books land on `IMG_NONE` (no top-level `coverPath`, no provider match for a German title).
- **After:** all three render their real ABS covers through the authenticated proxy.
- **ABS offline:** the grey placeholder renders (not a broken-image glyph), and the log shows `Audiobookshelf cover unavailable: upstream status=404 account=1 item=item-de-1`.

Screenshots were taken locally via the `run-floppy` skill; happy to attach them if useful.

## AI Assistance

This change was generated with Claude Code. Per this session's configuration I don't write model identifiers into repository artifacts — please fill in the exact model name here if you want it recorded.

## How It Was Tested

- `SECRET=test-only scripts/test.sh integrations.tests.imports.test_audiobookshelf integrations.tests.test_audiobookshelf_views` → Passed (60 tests)
- `SECRET=test-only scripts/test.sh` (fast suite) → Passed (5019 tests, OK, 5 skipped) — baseline held at zero
- `uv run --no-sync ruff check src` → Passed
- `uv run --no-sync djlint src/templates/base.html src/templates/base_public.html --lint` → Passed (0 errors)
- `python -m app.domain_vocabulary --check` → Passed
- End-to-end in a browser via the `run-floppy` skill against the stub ABS server described above, covering the working, the ABS-offline, and the dead-URL cases.

11 new tests. Each was verified to **fail against the old code** before being kept — the previous behaviour was temporarily reintroduced for each defect to confirm the corresponding test actually catches it, rather than passing vacuously.

## Public API & Documentation Handoff

- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance

- [x] Visual or manual QA verified (browser testing against a stub Audiobookshelf server)
- [ ] Code review completed

## Database & Migration Safety (Only if modifying models)

- [x] Not applicable (no database changes)

## Related Issues

- Fixes #861
- Refs #982 (the cover proxy this builds on)

---

One caveat on closing #861: this reproduces the mechanisms, not the reporter's library. Their export and logs were behind hosts the working sandbox could not reach, so confirmation from @Joloxx9 on the next build is still worth asking for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NHDR2aGYk7GJXfV88euo3

---
_Generated by [Claude Code](https://claude.ai/code/session_016NHDR2aGYk7GJXfV88euo3)_