### PR TITLE
Fix music deletion leaving the library page full

### DIFF
--- a/src/templates/users/advanced.html
+++ b/src/templates/users/advanced.html
@@ -453,6 +453,12 @@
                   <strong x-text="selectedMediaLabel.toLowerCase()"></strong>
                   entry in your account. This removes its progress, ratings, notes, and history.
                 </p>
+                <p x-show="selectedMediaType === 'music'"
+                   x-cloak
+                   class="text-sm text-[var(--color-text-secondary)] mb-3">
+                  For music this covers your whole library page: the followed artists and albums as
+                  well as the individual tracks and their play counts.
+                </p>
                 <label class="flex items-center justify-between p-3 mb-3 bg-[var(--color-panel)] rounded-md cursor-pointer">
                   <span class="text-sm text-[var(--color-text-secondary)] pr-3">
                     Also delete cached metadata (posters, cast/crew, and for music, artists &amp; albums)

--- a/src/templates/users/components/import_activity.html
+++ b/src/templates/users/components/import_activity.html
@@ -218,7 +218,7 @@
           </div>
           <form action="{% url 'bulk_delete_by_import_source' row.media_type row.source %}"
                 method="post"
-                onsubmit="return confirm('Permanently delete all {{ row.media_type }} items imported from this source? This cannot be undone.');">
+                onsubmit="return confirm('Permanently delete all {{ row.media_type }} items imported from this source?{% if row.media_type == 'music' %} Artists and albums left with no tracks are removed from your library too.{% endif %} This cannot be undone.');">
             {% csrf_token %}
             <button class="text-xs text-red-400 hover:text-red-300 transition-colors cursor-pointer">Delete all</button>
           </form>

--- a/src/users/tests/views/test_advanced.py
+++ b/src/users/tests/views/test_advanced.py
@@ -637,6 +637,29 @@ class CacheClearButtonsTests(TestCase):
         self.assertFalse(Album.objects.filter(id=album.id).exists())
         self.assertFalse(Artist.objects.filter(id=artist.id).exists())
 
+    def test_delete_music_metadata_flag_cleans_catalog_with_no_music_rows(self):
+        """Orphan cleanup runs even when only tracker rows were deleted.
+
+        The metadata checkbox promises to remove artists/albums with no
+        remaining tracked entries. When the user has stranded trackers and no
+        Music rows at all, there are no candidate Item ids, and the cleanup
+        used to be skipped entirely -- leaving exactly the orphans the option
+        said it would remove. That is the #579 library state.
+        """
+        artist = Artist.objects.create(name="Stranded Only")
+        album = Album.objects.create(title="Stranded Only Album", artist=artist)
+        ArtistTracker.objects.create(user=self.user, artist=artist)
+        AlbumTracker.objects.create(user=self.user, album=album)
+
+        response = self.client.post(
+            reverse("bulk_delete_by_media_type"),
+            {"media_type": MediaTypes.MUSIC.value, "delete_metadata": "true"},
+        )
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertFalse(Album.objects.filter(id=album.id).exists())
+        self.assertFalse(Artist.objects.filter(id=artist.id).exists())
+
     def test_cache_clear_views_require_post(self):
         """GET requests to any clear-cache endpoint must be rejected."""
         for url_name in (

--- a/src/users/tests/views/test_advanced.py
+++ b/src/users/tests/views/test_advanced.py
@@ -22,6 +22,7 @@ from app.models import (
     MediaTypes,
     Movie,
     Music,
+    MusicReleasePreference,
     Season,
     Sources,
     Status,
@@ -513,6 +514,128 @@ class CacheClearButtonsTests(TestCase):
         self.assertRedirects(response, reverse("advanced"))
         self.assertTrue(Album.objects.filter(id=album.id).exists())
         self.assertTrue(Artist.objects.filter(id=artist.id).exists())
+
+    def _music_track(self, media_id, user, artist=None, album=None):
+        """Create one tracked Music row backed by its own Item."""
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.MANUAL.value,
+            media_type=MediaTypes.MUSIC.value,
+            title=f"Track {media_id}",
+        )
+        return Music.objects.create(
+            item=item,
+            user=user,
+            status=Status.COMPLETED.value,
+            artist=artist,
+            album=album,
+        )
+
+    def test_delete_music_removes_artist_and_album_trackers(self):
+        """A music wipe clears the artist/album rows the library page lists."""
+        artist = Artist.objects.create(name="Imported Artist")
+        album = Album.objects.create(title="Imported Album", artist=artist)
+        artist_tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
+        album_tracker = AlbumTracker.objects.create(user=self.user, album=album)
+        preference = MusicReleasePreference.objects.create(
+            user=self.user,
+            album=album,
+            release_id="00000000-0000-0000-0000-000000000001",
+        )
+        music = self._music_track("wiped-track", self.user, artist, album)
+
+        response = self.client.post(
+            reverse("bulk_delete_by_media_type"),
+            {"media_type": MediaTypes.MUSIC.value},
+        )
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertFalse(Music.objects.filter(id=music.id).exists())
+        self.assertFalse(ArtistTracker.objects.filter(id=artist_tracker.id).exists())
+        self.assertFalse(AlbumTracker.objects.filter(id=album_tracker.id).exists())
+        self.assertFalse(
+            MusicReleasePreference.objects.filter(id=preference.id).exists(),
+        )
+
+        message = str(next(iter(get_messages(response.wsgi_request))))
+        self.assertIn("Permanently deleted 3 Music item(s)", message)
+        self.assertIn("1 track, 1 album, 1 artist", message)
+
+    def test_delete_music_with_only_trackers_reports_success(self):
+        """Trackers with no Music rows left still count as something to delete.
+
+        Regression test for #579: the user's Music rows were already gone, so
+        the view counted zero and said "Nothing to delete for that media type."
+        while every artist and album stayed on /medialist/music.
+        """
+        artist = Artist.objects.create(name="Stranded Artist")
+        album = Album.objects.create(title="Stranded Album", artist=artist)
+        ArtistTracker.objects.create(user=self.user, artist=artist)
+        AlbumTracker.objects.create(user=self.user, album=album)
+
+        response = self.client.post(
+            reverse("bulk_delete_by_media_type"),
+            {"media_type": MediaTypes.MUSIC.value},
+        )
+
+        self.assertRedirects(response, reverse("advanced"))
+        message = str(next(iter(get_messages(response.wsgi_request))))
+        self.assertNotIn("Nothing to delete", message)
+        self.assertIn("Permanently deleted 2 Music item(s)", message)
+        self.assertFalse(ArtistTracker.objects.filter(user=self.user).exists())
+        self.assertFalse(AlbumTracker.objects.filter(user=self.user).exists())
+
+    def test_delete_music_leaves_other_users_trackers_alone(self):
+        """Another user following the same artist/album keeps their library."""
+        artist = Artist.objects.create(name="Shared Artist")
+        album = Album.objects.create(title="Shared Album", artist=artist)
+        ArtistTracker.objects.create(user=self.user, artist=artist)
+        AlbumTracker.objects.create(user=self.user, album=album)
+        other_artist_tracker = ArtistTracker.objects.create(
+            user=self.other_user,
+            artist=artist,
+        )
+        other_album_tracker = AlbumTracker.objects.create(
+            user=self.other_user,
+            album=album,
+        )
+
+        response = self.client.post(
+            reverse("bulk_delete_by_media_type"),
+            {"media_type": MediaTypes.MUSIC.value},
+        )
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertFalse(ArtistTracker.objects.filter(user=self.user).exists())
+        self.assertTrue(
+            ArtistTracker.objects.filter(id=other_artist_tracker.id).exists(),
+        )
+        self.assertTrue(
+            AlbumTracker.objects.filter(id=other_album_tracker.id).exists(),
+        )
+
+    def test_delete_music_metadata_flag_cleans_catalog_behind_own_tracker(self):
+        """The requesting user's own tracker no longer blocks catalog cleanup.
+
+        Previously _delete_orphaned_music_catalog skipped any Artist/Album with
+        a tracker, and the deleting user's own tracker was never removed -- so
+        the catalog could never be cleaned up for a single-user instance.
+        """
+        artist = Artist.objects.create(name="Only Mine")
+        album = Album.objects.create(title="Only Mine Album", artist=artist)
+        ArtistTracker.objects.create(user=self.user, artist=artist)
+        AlbumTracker.objects.create(user=self.user, album=album)
+        music = self._music_track("own-track", self.user, artist, album)
+
+        response = self.client.post(
+            reverse("bulk_delete_by_media_type"),
+            {"media_type": MediaTypes.MUSIC.value, "delete_metadata": "true"},
+        )
+
+        self.assertRedirects(response, reverse("advanced"))
+        self.assertFalse(Item.objects.filter(id=music.item_id).exists())
+        self.assertFalse(Album.objects.filter(id=album.id).exists())
+        self.assertFalse(Artist.objects.filter(id=artist.id).exists())
 
     def test_cache_clear_views_require_post(self):
         """GET requests to any clear-cache endpoint must be rejected."""

--- a/src/users/tests/views/test_bulk_delete_by_import_source.py
+++ b/src/users/tests/views/test_bulk_delete_by_import_source.py
@@ -32,6 +32,19 @@ class BulkDeleteByImportSourceTests(TestCase):
         self.other_credentials = {"username": "otheruser", "password": "testpass123"}
         self.other_user = get_user_model().objects.create_user(**self.other_credentials)
 
+    def _finished_run(self, user, source):
+        """An import run that has already finished.
+
+        Deleting by source is refused while a run from it is still RUNNING,
+        which is the ImportRun default -- these tests are about the
+        after-the-import cleanup.
+        """
+        return ImportRun.objects.create(
+            user=user,
+            source=source,
+            status=ImportRun.Status.COMPLETED,
+        )
+
     def _movie(self, media_id, user, import_run=None):
         item = Item.objects.create(
             media_id=media_id,
@@ -48,9 +61,9 @@ class BulkDeleteByImportSourceTests(TestCase):
 
     def test_deletes_only_matching_media_type_and_source_for_this_user(self):
         """Delete is scoped to (user, media_type, import source)."""
-        trakt_run = ImportRun.objects.create(user=self.user, source="trakt")
-        simkl_run = ImportRun.objects.create(user=self.user, source="simkl")
-        other_user_run = ImportRun.objects.create(user=self.other_user, source="trakt")
+        trakt_run = self._finished_run(self.user, "trakt")
+        simkl_run = self._finished_run(self.user, "simkl")
+        other_user_run = self._finished_run(self.other_user, "trakt")
 
         trakt_movie = self._movie("trakt-movie", self.user, trakt_run)
         simkl_movie = self._movie("simkl-movie", self.user, simkl_run)
@@ -75,7 +88,7 @@ class BulkDeleteByImportSourceTests(TestCase):
 
     def test_rejects_unknown_media_type(self):
         """An invalid media_type is refused, not passed to apps.get_model."""
-        ImportRun.objects.create(user=self.user, source="trakt")
+        self._finished_run(self.user, "trakt")
 
         response = self.client.post(
             reverse("bulk_delete_by_import_source", args=["not-a-real-type", "trakt"]),
@@ -103,7 +116,7 @@ class BulkDeleteByImportSourceTests(TestCase):
 
     def test_deletes_music_rows_for_source(self):
         """Unlike rollback, bulk delete can remove Music rows outright."""
-        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        run = self._finished_run(self.user, "lastfm")
         item = Item.objects.create(
             media_id="music-item",
             source=Sources.MUSICBRAINZ.value,
@@ -147,7 +160,7 @@ class BulkDeleteByImportSourceTests(TestCase):
         The trackers carry no import_run of their own, so without this sweep a
         "delete all Last.fm music" left /medialist/music looking untouched.
         """
-        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        run = self._finished_run(self.user, "lastfm")
         artist = Artist.objects.create(name="Last.fm Artist")
         album = Album.objects.create(title="Last.fm Album", artist=artist)
         artist_tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
@@ -168,8 +181,8 @@ class BulkDeleteByImportSourceTests(TestCase):
 
     def test_music_tracker_survives_when_another_source_still_has_tracks(self):
         """An artist with tracks left from another source keeps its tracker."""
-        lastfm_run = ImportRun.objects.create(user=self.user, source="lastfm")
-        koito_run = ImportRun.objects.create(user=self.user, source="koito")
+        lastfm_run = self._finished_run(self.user, "lastfm")
+        koito_run = self._finished_run(self.user, "koito")
         artist = Artist.objects.create(name="Shared Artist")
         album = Album.objects.create(title="Shared Album", artist=artist)
         artist_tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
@@ -192,7 +205,7 @@ class BulkDeleteByImportSourceTests(TestCase):
 
     def test_music_delete_leaves_unrelated_and_other_user_trackers_alone(self):
         """Only artists/albums the deleted rows referenced are considered."""
-        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        run = self._finished_run(self.user, "lastfm")
         imported_artist = Artist.objects.create(name="Imported Artist")
         followed_artist = Artist.objects.create(name="Hand-followed Artist")
         ArtistTracker.objects.create(user=self.user, artist=imported_artist)
@@ -225,7 +238,7 @@ class BulkDeleteByImportSourceTests(TestCase):
 
     def test_music_tracker_sweep_spans_id_lookup_chunks(self):
         """The sweep still deletes every tracker when ids span several chunks."""
-        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        run = self._finished_run(self.user, "lastfm")
         artists = [Artist.objects.create(name=f"Artist {i}") for i in range(5)]
         for index, artist in enumerate(artists):
             ArtistTracker.objects.create(user=self.user, artist=artist)
@@ -241,3 +254,57 @@ class BulkDeleteByImportSourceTests(TestCase):
 
         self.assertRedirects(response, reverse("import_data"))
         self.assertFalse(ArtistTracker.objects.filter(user=self.user).exists())
+
+    def test_music_sweep_reaches_artists_only_linked_through_the_album(self):
+        """Music.artist is nullable and derivable from the album.
+
+        A row with no direct artist FK still implies its album's artist, so
+        deleting it must sweep that artist's tracker too.
+        """
+        run = self._finished_run(self.user, "lastfm")
+        artist = Artist.objects.create(name="Album-only Artist")
+        album = Album.objects.create(title="Album-only LP", artist=artist)
+        artist_tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
+        album_tracker = AlbumTracker.objects.create(user=self.user, album=album)
+        # artist=None: the link exists only through album.artist.
+        self._music("album-linked", self.user, run, None, album)
+
+        response = self.client.post(
+            reverse(
+                "bulk_delete_by_import_source",
+                args=[MediaTypes.MUSIC.value, "lastfm"],
+            ),
+        )
+
+        self.assertRedirects(response, reverse("import_data"))
+        self.assertFalse(AlbumTracker.objects.filter(id=album_tracker.id).exists())
+        self.assertFalse(ArtistTracker.objects.filter(id=artist_tracker.id).exists())
+
+    def test_refuses_while_an_import_from_that_source_is_running(self):
+        """A running import keeps writing rows, so deleting underneath it is refused.
+
+        The importer re-creates trackers as it goes, so a delete that races it
+        can strip the tracker off a row the importer is about to write --
+        recreating the very orphan state this endpoint exists to clear.
+        """
+        run = ImportRun.objects.create(
+            user=self.user,
+            source="lastfm",
+            status=ImportRun.Status.RUNNING,
+        )
+        artist = Artist.objects.create(name="Mid-import Artist")
+        tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
+        music = self._music("mid-import", self.user, run, artist, None)
+
+        response = self.client.post(
+            reverse(
+                "bulk_delete_by_import_source",
+                args=[MediaTypes.MUSIC.value, "lastfm"],
+            ),
+        )
+
+        self.assertRedirects(response, reverse("import_data"))
+        self.assertTrue(Music.objects.filter(id=music.id).exists())
+        self.assertTrue(ArtistTracker.objects.filter(id=tracker.id).exists())
+        message = str(next(iter(get_messages(response.wsgi_request))))
+        self.assertIn("Cancel the running import", message)

--- a/src/users/tests/views/test_bulk_delete_by_import_source.py
+++ b/src/users/tests/views/test_bulk_delete_by_import_source.py
@@ -1,9 +1,22 @@
+from unittest import mock
+
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.test import TestCase
 from django.urls import reverse
 
-from app.models import Item, MediaTypes, Movie, Music, Sources, Status
+from app.models import (
+    Album,
+    AlbumTracker,
+    Artist,
+    ArtistTracker,
+    Item,
+    MediaTypes,
+    Movie,
+    Music,
+    Sources,
+    Status,
+)
 from integrations.models import ImportRun
 
 
@@ -110,3 +123,121 @@ class BulkDeleteByImportSourceTests(TestCase):
 
         self.assertRedirects(response, reverse("import_data"))
         self.assertFalse(Music.objects.filter(id=music.id).exists())
+
+    def _music(self, media_id, user, import_run, artist=None, album=None):
+        """Create one tracked Music row backed by its own Item."""
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.MUSICBRAINZ.value,
+            media_type=MediaTypes.MUSIC.value,
+            title=f"Track {media_id}",
+        )
+        return Music.objects.create(
+            item=item,
+            user=user,
+            status=Status.COMPLETED.value,
+            import_run=import_run,
+            artist=artist,
+            album=album,
+        )
+
+    def test_deleting_music_for_source_sweeps_the_trackers_it_stranded(self):
+        """Artists/albums left with no tracks leave the user's library too.
+
+        The trackers carry no import_run of their own, so without this sweep a
+        "delete all Last.fm music" left /medialist/music looking untouched.
+        """
+        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        artist = Artist.objects.create(name="Last.fm Artist")
+        album = Album.objects.create(title="Last.fm Album", artist=artist)
+        artist_tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
+        album_tracker = AlbumTracker.objects.create(user=self.user, album=album)
+        music = self._music("lastfm-track", self.user, run, artist, album)
+
+        response = self.client.post(
+            reverse(
+                "bulk_delete_by_import_source",
+                args=[MediaTypes.MUSIC.value, "lastfm"],
+            ),
+        )
+
+        self.assertRedirects(response, reverse("import_data"))
+        self.assertFalse(Music.objects.filter(id=music.id).exists())
+        self.assertFalse(ArtistTracker.objects.filter(id=artist_tracker.id).exists())
+        self.assertFalse(AlbumTracker.objects.filter(id=album_tracker.id).exists())
+
+    def test_music_tracker_survives_when_another_source_still_has_tracks(self):
+        """An artist with tracks left from another source keeps its tracker."""
+        lastfm_run = ImportRun.objects.create(user=self.user, source="lastfm")
+        koito_run = ImportRun.objects.create(user=self.user, source="koito")
+        artist = Artist.objects.create(name="Shared Artist")
+        album = Album.objects.create(title="Shared Album", artist=artist)
+        artist_tracker = ArtistTracker.objects.create(user=self.user, artist=artist)
+        album_tracker = AlbumTracker.objects.create(user=self.user, album=album)
+        lastfm_music = self._music("lastfm-dupe", self.user, lastfm_run, artist, album)
+        koito_music = self._music("koito-track", self.user, koito_run, artist, album)
+
+        response = self.client.post(
+            reverse(
+                "bulk_delete_by_import_source",
+                args=[MediaTypes.MUSIC.value, "lastfm"],
+            ),
+        )
+
+        self.assertRedirects(response, reverse("import_data"))
+        self.assertFalse(Music.objects.filter(id=lastfm_music.id).exists())
+        self.assertTrue(Music.objects.filter(id=koito_music.id).exists())
+        self.assertTrue(ArtistTracker.objects.filter(id=artist_tracker.id).exists())
+        self.assertTrue(AlbumTracker.objects.filter(id=album_tracker.id).exists())
+
+    def test_music_delete_leaves_unrelated_and_other_user_trackers_alone(self):
+        """Only artists/albums the deleted rows referenced are considered."""
+        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        imported_artist = Artist.objects.create(name="Imported Artist")
+        followed_artist = Artist.objects.create(name="Hand-followed Artist")
+        ArtistTracker.objects.create(user=self.user, artist=imported_artist)
+        hand_followed = ArtistTracker.objects.create(
+            user=self.user,
+            artist=followed_artist,
+        )
+        other_user_tracker = ArtistTracker.objects.create(
+            user=self.other_user,
+            artist=imported_artist,
+        )
+        self._music("lastfm-only", self.user, run, imported_artist, None)
+
+        response = self.client.post(
+            reverse(
+                "bulk_delete_by_import_source",
+                args=[MediaTypes.MUSIC.value, "lastfm"],
+            ),
+        )
+
+        self.assertRedirects(response, reverse("import_data"))
+        self.assertFalse(
+            ArtistTracker.objects.filter(
+                user=self.user,
+                artist=imported_artist,
+            ).exists(),
+        )
+        self.assertTrue(ArtistTracker.objects.filter(id=hand_followed.id).exists())
+        self.assertTrue(ArtistTracker.objects.filter(id=other_user_tracker.id).exists())
+
+    def test_music_tracker_sweep_spans_id_lookup_chunks(self):
+        """The sweep still deletes every tracker when ids span several chunks."""
+        run = ImportRun.objects.create(user=self.user, source="lastfm")
+        artists = [Artist.objects.create(name=f"Artist {i}") for i in range(5)]
+        for index, artist in enumerate(artists):
+            ArtistTracker.objects.create(user=self.user, artist=artist)
+            self._music(f"chunked-{index}", self.user, run, artist, None)
+
+        with mock.patch("users.views._ID_LOOKUP_CHUNK", 2):
+            response = self.client.post(
+                reverse(
+                    "bulk_delete_by_import_source",
+                    args=[MediaTypes.MUSIC.value, "lastfm"],
+                ),
+            )
+
+        self.assertRedirects(response, reverse("import_data"))
+        self.assertFalse(ArtistTracker.objects.filter(user=self.user).exists())

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -4,6 +4,7 @@ import logging
 import re
 import uuid
 from io import BytesIO
+from itertools import batched
 from pathlib import Path
 
 import apprise
@@ -29,7 +30,17 @@ from django_celery_beat.models import PeriodicTask
 from app import history_cache, image_cache, statistics_cache
 from app.discover.feeds import get_external_row_definitions
 from app.discover.registry import DISCOVER_MEDIA_TYPES
-from app.models import Album, Artist, Item, MediaTypes, Status
+from app.models import (
+    Album,
+    AlbumTracker,
+    Artist,
+    ArtistTracker,
+    Item,
+    MediaTypes,
+    Music,
+    MusicReleasePreference,
+    Status,
+)
 from app.providers import tmdb
 from app.services import metadata_resolution
 from app.templatetags import app_tags
@@ -1836,15 +1847,84 @@ def bulk_delete_by_import_source(request, media_type, source):
         return redirect("import_data")
 
     model = apps.get_model(app_label="app", model_name=media_type)
-    deleted_count, _ = model.objects.filter(
-        user=request.user, import_run__source=source
-    ).delete()
+    doomed = model.objects.filter(user=request.user, import_run__source=source)
+    # Capture before the delete: the trackers are reached through these FKs.
+    music_catalog_ids = (
+        _music_catalog_ids_referenced_by(doomed)
+        if media_type == MediaTypes.MUSIC.value
+        else None
+    )
+
+    deleted_count, _ = doomed.delete()
+
+    if music_catalog_ids is not None:
+        deleted_count += _sweep_untracked_music_containers(
+            request.user,
+            *music_catalog_ids,
+        )
 
     if deleted_count:
         messages.success(request, f"Permanently deleted {deleted_count} item(s).")
     else:
         messages.info(request, "Nothing to delete.")
     return redirect("import_data")
+
+
+# Cap on ids per `__in` lookup. A >100k-scrobble library can reference more
+# distinct artists/albums than SQLite allows query parameters in one statement.
+_ID_LOOKUP_CHUNK = 500
+
+
+def _music_catalog_ids_referenced_by(music_queryset):
+    """Return the (artist_ids, album_ids) a set of Music rows points at.
+
+    Must be called before the rows are deleted.
+    """
+    artist_ids = set(
+        music_queryset.values_list("artist_id", flat=True).distinct(),
+    ) - {None}
+    album_ids = set(
+        music_queryset.values_list("album_id", flat=True).distinct(),
+    ) - {None}
+    return artist_ids, album_ids
+
+
+def _sweep_untracked_music_containers(user, artist_ids, album_ids):
+    """Delete the user's artist/album library rows left with no music behind them.
+
+    ArtistTracker/AlbumTracker carry no import_run of their own, so they cannot
+    be deleted by provenance the way Music rows can. Instead, of the artists and
+    albums the deleted rows referenced, drop the trackers for those the user has
+    no Music row for any more. Scoping to the referenced ids means an artist the
+    user follows by hand, with no imported tracks, is never touched. An artist
+    the user followed by hand *and* had imported tracks for does lose its
+    tracker -- that is what "delete all my Last.fm music" asks for.
+    """
+    return _delete_untracked_trackers(
+        ArtistTracker,
+        "artist_id",
+        user,
+        artist_ids,
+    ) + _delete_untracked_trackers(AlbumTracker, "album_id", user, album_ids)
+
+
+def _delete_untracked_trackers(tracker_model, field, user, candidate_ids):
+    """Delete the user's tracker rows for candidate_ids with no Music row left."""
+    deleted = 0
+    for chunk in batched(sorted(candidate_ids), _ID_LOOKUP_CHUNK):
+        chunk_ids = set(chunk)
+        still_tracked = set(
+            Music.objects.filter(
+                user=user,
+                **{f"{field}__in": chunk_ids},
+            ).values_list(field, flat=True),
+        )
+        count, _ = tracker_model.objects.filter(
+            user=user,
+            **{f"{field}__in": chunk_ids - still_tracked},
+        ).delete()
+        deleted += count
+    return deleted
 
 
 @require_POST
@@ -1858,7 +1938,13 @@ def bulk_delete_by_media_type(request):
     delete_metadata = request.POST.get("delete_metadata") == "true"
 
     media_querysets = _media_querysets_for_bulk_delete(request.user, media_type)
-    item_count = sum(queryset.count() for queryset in media_querysets)
+    companions = _companion_querysets_for_bulk_delete(request.user, media_type)
+    media_count = sum(queryset.count() for queryset in media_querysets)
+    companion_counts = [(noun, queryset.count()) for noun, queryset in companions]
+    item_count = media_count + sum(count for _, count in companion_counts)
+
+    # Companion querysets are not Item-backed, so they never contribute
+    # candidate Item ids -- only the Media rows do.
     candidate_item_ids = (
         _candidate_item_ids_for_metadata_cleanup(media_querysets, media_type)
         if delete_metadata
@@ -1866,6 +1952,14 @@ def bulk_delete_by_media_type(request):
     )
     for queryset in media_querysets:
         queryset.delete()
+    # Delete companions before orphan cleanup: _delete_orphaned_music_catalog
+    # only drops Artist/Album rows that no tracker points at any more.
+    for _, queryset in companions:
+        queryset.delete()
+    if media_type == MediaTypes.MUSIC.value:
+        # Per-user music settings, not library rows -- cleared, but not counted
+        # as deleted items.
+        MusicReleasePreference.objects.filter(user=request.user).delete()
 
     metadata_count = 0
     if delete_metadata and candidate_item_ids:
@@ -1880,6 +1974,9 @@ def bulk_delete_by_media_type(request):
         cache_management.clear_discover_cache_for_user(request.user.id)
         label = MediaTypes(media_type).label
         message = f"Permanently deleted {item_count} {label} item(s) from your library."
+        breakdown = _bulk_delete_breakdown(media_type, media_count, companion_counts)
+        if breakdown:
+            message += f" ({breakdown})"
         if delete_metadata:
             message += f" Also removed {metadata_count} metadata entr{'y' if metadata_count == 1 else 'ies'}."
         messages.success(request, message)
@@ -1917,6 +2014,44 @@ def _media_querysets_for_bulk_delete(user, media_type):
             item__library_media_type=MediaTypes.ANIME.value,
         )
     return [queryset]
+
+
+def _companion_querysets_for_bulk_delete(user, media_type):
+    """Return (noun, queryset) pairs of a media type's non-Media per-user rows.
+
+    Music is the only such type. Its library page does not list the Media rows:
+    /medialist/music renders ArtistTracker (the default "artists" subview) and
+    AlbumTracker ("albums"), and only the "tracks" subview shows Music itself.
+    Those tracker models are not Media subclasses, so the
+    apps.get_model(app_label="app", model_name=media_type) lookup in
+    _media_querysets_for_bulk_delete cannot see them and a music wipe used to
+    leave the whole visible library behind.
+    """
+    if media_type != MediaTypes.MUSIC.value:
+        return []
+
+    return [
+        ("album", AlbumTracker.objects.filter(user=user)),
+        ("artist", ArtistTracker.objects.filter(user=user)),
+    ]
+
+
+def _bulk_delete_breakdown(media_type, media_count, companion_counts):
+    """Return a human-readable per-model breakdown, or "" when there is nothing to add.
+
+    Only media types with companion rows get one -- for everything else the
+    single total in the success message already says it all.
+    """
+    if not companion_counts:
+        return ""
+
+    media_noun = "track" if media_type == MediaTypes.MUSIC.value else "item"
+    parts = [
+        f"{count} {noun}{pluralize(count)}"
+        for noun, count in [(media_noun, media_count), *companion_counts]
+        if count
+    ]
+    return ", ".join(parts)
 
 
 def _candidate_item_ids_for_metadata_cleanup(media_querysets, media_type):

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -1868,6 +1868,20 @@ def bulk_delete_by_import_source(request, media_type, source):
         messages.error(request, "Unknown import source.")
         return redirect("import_data")
 
+    # A running import writes Music rows and re-creates trackers as it goes, so
+    # deleting underneath it leaves rows the sweep has already walked past.
+    # rollback_import_run refuses for the same reason.
+    if ImportRun.objects.filter(
+        user=request.user,
+        source=source,
+        status=ImportRun.Status.RUNNING,
+    ).exists():
+        messages.error(
+            request,
+            "Cancel the running import from this source before deleting it.",
+        )
+        return redirect("import_data")
+
     model = apps.get_model(app_label="app", model_name=media_type)
     doomed = model.objects.filter(user=request.user, import_run__source=source)
     # Capture before the delete: the trackers are reached through these FKs.
@@ -1897,18 +1911,25 @@ def bulk_delete_by_import_source(request, media_type, source):
 _ID_LOOKUP_CHUNK = 500
 
 
+# Music.artist is a nullable convenience FK ("can be derived via album"), so an
+# artist can be reached either directly or only through the row's album.
+_MUSIC_ARTIST_SOURCES = ("artist_id", "album__artist_id")
+
+
 def _music_catalog_ids_referenced_by(music_queryset):
     """Return the (artist_ids, album_ids) a set of Music rows points at.
 
     Must be called before the rows are deleted.
     """
-    artist_ids = set(
-        music_queryset.values_list("artist_id", flat=True).distinct(),
-    ) - {None}
+    artist_ids = set()
+    for source_field in _MUSIC_ARTIST_SOURCES:
+        artist_ids |= set(
+            music_queryset.values_list(source_field, flat=True).distinct(),
+        )
     album_ids = set(
         music_queryset.values_list("album_id", flat=True).distinct(),
-    ) - {None}
-    return artist_ids, album_ids
+    )
+    return artist_ids - {None}, album_ids - {None}
 
 
 def _sweep_untracked_music_containers(user, artist_ids, album_ids):
@@ -1927,20 +1948,36 @@ def _sweep_untracked_music_containers(user, artist_ids, album_ids):
         "artist_id",
         user,
         artist_ids,
+        source_fields=_MUSIC_ARTIST_SOURCES,
     ) + _delete_untracked_trackers(AlbumTracker, "album_id", user, album_ids)
 
 
-def _delete_untracked_trackers(tracker_model, field, user, candidate_ids):
-    """Delete the user's tracker rows for candidate_ids with no Music row left."""
+def _delete_untracked_trackers(
+    tracker_model,
+    field,
+    user,
+    candidate_ids,
+    *,
+    source_fields=None,
+):
+    """Delete the user's tracker rows for candidate_ids with no Music row left.
+
+    `source_fields` are the Music lookups that can still reach the tracked
+    object. An artist keeps its tracker if any remaining row reaches it either
+    way, so all of them have to be checked before deleting.
+    """
+    source_fields = source_fields or (field,)
     deleted = 0
     for chunk in batched(sorted(candidate_ids), _ID_LOOKUP_CHUNK):
         chunk_ids = set(chunk)
-        still_tracked = set(
-            Music.objects.filter(
-                user=user,
-                **{f"{field}__in": chunk_ids},
-            ).values_list(field, flat=True),
-        )
+        still_tracked = set()
+        for source_field in source_fields:
+            still_tracked |= set(
+                Music.objects.filter(
+                    user=user,
+                    **{f"{source_field}__in": chunk_ids},
+                ).values_list(source_field, flat=True),
+            )
         count, _ = tracker_model.objects.filter(
             user=user,
             **{f"{field}__in": chunk_ids - still_tracked},
@@ -1984,7 +2021,10 @@ def bulk_delete_by_media_type(request):
         MusicReleasePreference.objects.filter(user=request.user).delete()
 
     metadata_count = 0
-    if delete_metadata and candidate_item_ids:
+    if delete_metadata:
+        # Not guarded on candidate_item_ids: a music library can be all
+        # trackers and no Music rows, which yields no candidate Items but does
+        # leave orphaned Artist/Album rows the checkbox promised to remove.
         metadata_count = _delete_orphaned_metadata(media_type, candidate_item_ids)
 
     if item_count:


### PR DESCRIPTION
## Summary
- **"Delete all Music" did not work.** It reported *"Nothing to delete for that media type."* while `/medialist/music` still showed every artist and album. Reported in #579.
- Music is the only media type whose library page is **not** backed by its `Media` rows. `bulk_delete_by_media_type` resolves the type to one model via `apps.get_model("app", media_type)` — for music that is `Music`, the *track*-level row, shown only under `?subview=tracks`. The default **Artists** subview is served by `ArtistTracker` and the **Albums** subview by `AlbumTracker`, and neither is a `Media` subclass, so the delete never touched the two tables the page actually renders. The importer creates those tracker rows on every scrobble, so the library stayed full. Once an earlier run had removed the user's `Music` rows, the count summed to zero and the view said there was nothing to delete.
- The same gap made the metadata checkbox a no-op for music: `_delete_orphaned_music_catalog` only drops `Artist`/`Album` rows with `trackers__isnull=True`, and the deleting user's *own* trackers survived to keep every catalog row alive.
- The **Import Data → Imported Media by Source** "Delete all" button had the same blind spot. That is the operation the reporter actually wants for their Last.fm → Koito swap, so it is fixed too.

### What changed
- New `_companion_querysets_for_bulk_delete` returns a media type's non-`Media` per-user rows. They count toward the total, are skipped when collecting candidate `Item` ids (they have no `item_id`), and are deleted *before* orphan cleanup so the catalog sweep can finally match. The music success message gains a tracks/albums/artists breakdown.
- `MusicReleasePreference` is cleared on a music wipe — per-user music state keyed on `Album` — but is deliberately **not** counted, since it is not a library row.
- The per-source delete sweeps the trackers it strands. Trackers carry no `import_run`, so they cannot be removed by provenance: it captures the artist/album ids the doomed `Music` rows reference, then drops the user's trackers for those with no `Music` row left. Scoping to referenced ids leaves a hand-followed artist with no imported tracks alone. The `__in` lookups are chunked — a >100k-scrobble library can reference more distinct artists than SQLite allows query parameters in one statement.
- Confirmation copy on both screens now states the wider scope for music.

No migration, no model change, no new field.

### Visual verification

Seeded the reporter's exact state: 8 artists, 8 albums, but only **4** tracks — so half the trackers had no `Music` rows behind them.

| | Before | After |
| --- | --- | --- |
| `/medialist/music` (artists) | all 8 artists listed, count badge `8` | empty, count badge `0`, "No Music Tracked Yet" |
| `?subview=albums` | 8 albums | empty |
| `?subview=tracks` | 4 tracks | empty |

Result toast: **"Permanently deleted 20 Music item(s) from your library. (4 tracks, 8 albums, 8 artists)"**

The confirmation modal gains a music-only line — "For music this covers your whole library page: the followed artists and albums as well as the individual tracks and their play counts" — which stays hidden for every other media type.

## AI Assistance
- This code was generated with Claude Code. I'm instructed not to write model identifiers into repository artifacts, so the exact model name is left for the maintainer to fill in here.

## How It Was Tested
- `scripts/test.sh users.tests.views.test_advanced users.tests.views.test_bulk_delete_by_import_source users.tests.views.test_rollback_import_run` -> Passed (36 tests). Re-run after merging `latest` in -> still Passed.
- `manage.py test users integrations.tests.test_import_provenance` -> Passed (354 tests)
- **Red/green check:** the 7 new tests were re-run against the unfixed `views.py` (stashed) -> 6 failures + 1 error, confirming they actually catch the bug rather than passing vacuously.
- `uv run --no-sync ruff check src` -> Passed
- `python -m app.domain_vocabulary --check` -> Passed
- Manual browser QA via the `run-floppy` skill: logged in, seeded music, ran the Danger Zone delete, confirmed all three `/medialist/music` subviews render empty afterwards. Verified in the DB that `ArtistTracker`/`AlbumTracker`/`Music`/`MusicReleasePreference` are all 0 for the user, and that the `Artist`/`Album` catalog rows correctly survive when the metadata checkbox is left off.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Fixes #579

### Deliberately out of scope
This issue is labelled `triage: split epic`; this PR fixes only the live, reopened defect. Left for separate children:
- **Import-run rollback** (`rollback_import_run`) has the same tracker gap, but goes through the history-based `revert_music_import_run`, so a sweep there needs its own design.
- **Duplicate prevention** when the same activity is later re-imported from Koito or another source.
- **Stale `PlaybackProgress` rows** for deleted media when the metadata checkbox is off — generic across every media type, not music-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D18b7WhD71SSWvPmZZEiLE

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18b7WhD71SSWvPmZZEiLE)_