### PR TITLE
Accept an anidb id on the generic scrobble endpoint

### DIFF
--- a/src/api/fork_views_scrobble.py
+++ b/src/api/fork_views_scrobble.py
@@ -135,7 +135,8 @@ class ScrobbleView(drf_views.APIView):
         description=(
             "Record a playback start/pause/stop event from a third-party "
             "client. Movies are identified by tmdb/imdb id; episodes "
-            "additionally require season_number/episode_number. "
+            "additionally require season_number/episode_number. Anime "
+            "clients may add an anidb id to pin the exact MyAnimeList cour. "
             "'start'/'pause' only update the live Now Playing card; "
             "'stop' persists a durable watch/progress update."
         ),
@@ -159,6 +160,15 @@ class ScrobbleView(drf_views.APIView):
                             "tmdb": {"type": "string", "nullable": True},
                             "imdb": {"type": "string", "nullable": True},
                             "tvdb": {"type": "string", "nullable": True},
+                            "anidb": {
+                                "type": "string",
+                                "nullable": True,
+                                "description": "Optional, and never sufficient "
+                                "on its own. When the user's Anime library "
+                                "stores flat MyAnimeList rows, this names the "
+                                "exact cour instead of inferring one from the "
+                                "season and episode numbers.",
+                            },
                         },
                     },
                     "title": {"type": "string", "nullable": True},

--- a/src/integrations/tests/test_generic_scrobble_processor.py
+++ b/src/integrations/tests/test_generic_scrobble_processor.py
@@ -3,7 +3,17 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 
-from app.models import TV, Episode, Item, MediaTypes, Movie, Season, Sources, Status
+from app.models import (
+    TV,
+    Anime,
+    Episode,
+    Item,
+    MediaTypes,
+    Movie,
+    Season,
+    Sources,
+    Status,
+)
 from integrations.webhooks.generic_scrobble import GenericScrobbleProcessor
 
 
@@ -35,8 +45,20 @@ class GenericScrobbleHeuristicTests(TestCase):
         )
         self.assertEqual(
             ids,
-            {"tmdb_id": "603", "imdb_id": "tt0133093", "tvdb_id": None},
+            {
+                "tmdb_id": "603",
+                "imdb_id": "tt0133093",
+                "tvdb_id": None,
+                "anidb_id": None,
+            },
         )
+
+    def test_extract_external_ids_reads_anidb(self):
+        """An anidb id is carried through for the anime routing path."""
+        ids = self.processor._extract_external_ids(
+            {"ids": {"tvdb": "9350138", "anidb": "3651"}},
+        )
+        self.assertEqual(ids["anidb_id"], "3651")
 
     def test_is_played_honors_explicit_completed_override(self):
         """An explicit 'completed' flag overrides the position/duration heuristic."""
@@ -207,6 +229,49 @@ class GenericScrobbleProcessPayloadTests(TestCase):
                 item__episode_number=1,
             ).exists(),
         )
+
+    def test_episode_stop_with_anidb_id_tracks_the_mapped_mal_cour(self):
+        """An anidb id resolves the exact MAL entry without a TMDB round-trip."""
+        self.user.anime_enabled = True
+        self.user.save()
+
+        with (
+            patch(
+                "integrations.webhooks.anime_mappings.fetch_mapping_data",
+                return_value={"anidb:3651:R": {"mal:849": {"1-": "1-"}}},
+            ),
+            patch(
+                "app.providers.mal.anime",
+                return_value={
+                    "title": "Suzumiya Haruhi no Yuutsu",
+                    "image": "",
+                    "max_progress": 14,
+                },
+            ),
+            patch("app.services.metadata_resolution.upsert_provider_links"),
+            patch(
+                "integrations.webhooks.anime_mappings.find_entries_for_mal_id",
+                return_value=[],
+            ),
+        ):
+            self.processor.process_payload(
+                {
+                    "media_type": "episode",
+                    "ids": {"tvdb": "9350138", "anidb": "3651"},
+                    "series_title": "Suzumiya Haruhi no Yuutsu",
+                    "season_number": 1,
+                    "episode_number": 1,
+                    "completed": True,
+                },
+                self.user,
+            )
+
+        anime = Anime.objects.get(item__media_id="849", user=self.user)
+        self.assertEqual(anime.item.source, Sources.MAL.value)
+        self.assertEqual(anime.status, Status.IN_PROGRESS.value)
+        self.assertEqual(anime.progress, 1)
+        # The MAL route is terminal: no parallel TV row is opened for the show.
+        self.assertFalse(TV.objects.filter(user=self.user).exists())
 
     def test_movie_resolution_failure_propagates(self):
         """A provider failure during resolution is not swallowed here."""

--- a/src/integrations/webhooks/generic_scrobble.py
+++ b/src/integrations/webhooks/generic_scrobble.py
@@ -66,11 +66,16 @@ class GenericScrobbleProcessor(BaseWebhookProcessor):
         return payload.get("title") or payload.get("series_title")
 
     def _extract_external_ids(self, payload):
+        # `anidb` is optional and rides alongside the required franchise id.
+        # It lets `BaseWebhookProcessor._process_tv` resolve the exact MAL cour
+        # directly, the same way the Plex/HAMA path already does, instead of
+        # inferring one from a TVDB season and episode number.
         ids = payload.get("ids") or {}
         return {
             "tmdb_id": ids.get("tmdb"),
             "imdb_id": ids.get("imdb"),
             "tvdb_id": ids.get("tvdb"),
+            "anidb_id": ids.get("anidb"),
         }
 
     def _extract_season_episode_from_payload(self, payload):


### PR DESCRIPTION
## Summary

The generic scrobble endpoint (`POST /api/v1/scrobble/`) drops any id that is not tmdb/imdb/tvdb. That leaves anime clients unable to say *which* MyAnimeList entry they are playing: `GenericScrobbleProcessor._extract_external_ids` returns only the three franchise ids, so `BaseWebhookProcessor._process_tv` never sees an `anidb_id` and its AniDB-to-MAL path is unreachable from the API. Floppy then has to infer the cour from a TVDB season and episode number, and for split-cour and franchise-spanning shows it lands on a neighbouring entry — silently, with a 200 response.

This adds `ids.anidb` to the endpoint. Two lines of behaviour:

- `_extract_external_ids` now returns `anidb_id` alongside the existing three, so an anime client can pin the exact entry the same way the Plex/HAMA webhook already does today (`PlexWebhookProcessor` has supplied `anidb_id` since the HAMA GUID support landed).
- The field is documented in the endpoint's `@extend_schema` request body.

The field is optional and is **not** sufficient on its own: `_scrobble_request_error` still requires one of tmdb/imdb/tvdb, so nothing about the existing contract changes and payloads that omit `anidb` behave exactly as before. When the AniDB mapping misses, `_process_tv` already falls through to normal TMDB resolution.

Motivation: I maintain a Stremio-style desktop client (Nuvio) that scrobbles to Floppy. It resolves AniDB/MAL/Kitsu/AniList ids from the bundled Fribb mapping at playback time and already sends `anidb` in the payload — it is simply discarded server-side today.

### One thing worth a maintainer's eye

The AniDB branch in `_process_tv` runs *before* `prefers_grouped_anime` and `find_existing_anime_home`, so an anidb id routes to a flat MAL row regardless of the user's Anime Provider. That precedence is pre-existing (`test_anime_episode_anidb_guid_mark_played` covers it for Plex) and this PR does not change it — but it does widen the set of clients that can reach it, and it reads to me as being in tension with the sticky-routing rule in `docs/grouped_anime.md`. I deliberately left it alone rather than bundle a behaviour change into this PR. Happy to open a separate one gating that branch on `not prefers_grouped_anime(user)` if you agree it should be gated.

## AI Assistance

- Model: `claude-opus-5` (via Claude Code).
- Workflow: manual code reading of `fork_views_scrobble.py`, `generic_scrobble.py` and `webhooks/base.py` to trace the id path; targeted tests written first and confirmed red against unpatched `_extract_external_ids`; no UI work, no automated browser QA.

## How It Was Tested

- `scripts/test.sh integrations.tests.test_generic_scrobble_processor --exclude-tag network` -> Passed (11 tests). The two new tests were verified to fail before the `generic_scrobble.py` change.
- `scripts/test.sh integrations api --exclude-tag network --exclude-tag slow` -> 1662 tests, same 6 pre-existing errors as the unpatched baseline (1660 tests, 6 errors). All six are `python-crontab`/MAL-import failures specific to my Windows dev box, unrelated to this change.
- `scripts/test.sh users.tests.views.test_about app.tests.test_api_contracts app.tests.test_domain_vocabulary api.tests.test_fork_scrobble integrations.tests.test_webhooks_plex --exclude-tag network --exclude-tag slow` -> Passed (151 tests).
- `uv run --no-sync ruff check src` -> All checks passed.
- `python -m app.domain_vocabulary --check` -> Passed.
- `manage.py spectacular --custom-settings api.schema_contract.STATIC_SPECTACULAR_SETTINGS --fail-on-warn --validate --file src/api/contracts/openapi.yaml` -> regenerated with **no diff**. `/api/v1/scrobble/` is not in `VERIFIED_OPERATIONS`, so the pinned artifact does not cover it; the `@extend_schema` update surfaces through the live `/api/schema/`. No contract artifact churn is included here.

Note for anyone reproducing on Windows: the committed contract artifacts must be checked out with LF. With `core.autocrlf=true` four `app.tests.test_api_contracts` tests fail on line endings alone, before any code change. The repo has no `.gitattributes`; adding one is out of scope here but might be worth a separate PR.

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified (if API endpoints changed)
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [ ] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing) — no UI surface in this change

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- None known.
