### PR TITLE
let the API answer for TVDB

### DIFF
--- a/src/api/fork_helpers.py
+++ b/src/api/fork_helpers.py
@@ -25,6 +25,22 @@ FORK_VALID_SOURCES = {
     MediaTypes.COMIC_ISSUE.value: [Sources.COMICVINE.value, Sources.MANUAL.value],
 }
 
+# FORK: sources the fork resolves for a media type upstream *already* lists.
+# Kept apart from FORK_VALID_SOURCES because that dict is applied with
+# `setdefault`, which can introduce a media type but never extend one. Every
+# entry here has a matching branch in `services.get_media_metadata` — keep the
+# two in step, or the API will accept a source it cannot then resolve.
+FORK_EXTRA_SOURCES = {
+    # TVDB series, season and episode metadata. Also the source Plex writes
+    # for sports and anything else TMDB does not carry.
+    MediaTypes.TV.value: [Sources.TVDB.value],
+    MediaTypes.SEASON.value: [Sources.TVDB.value],
+    MediaTypes.EPISODE.value: [Sources.TVDB.value],
+    # Anime resolves from all three: MAL natively, TMDB and TVDB through the
+    # grouped-anime route.
+    MediaTypes.ANIME.value: [Sources.TMDB.value, Sources.TVDB.value],
+}
+
 _MODIFIABLE_FIELDS = {"score", "status", "progress", "start_date", "end_date", "notes"}
 
 
@@ -110,6 +126,12 @@ def install_fork_media_types():
         helpers.MEDIA_MODIFIABLE_FIELDS.setdefault(media_type, set(_MODIFIABLE_FIELDS))
     for media_type, sources in FORK_VALID_SOURCES.items():
         helpers.VALID_SOURCES.setdefault(media_type, list(sources))
+    # Extend the entries upstream already owns, rather than defaulting them.
+    # The lists are mutated in place for the same reason MEDIA_TYPE_VALID_LIST
+    # is: they are module-level objects other modules hold references to.
+    for media_type, extra in FORK_EXTRA_SOURCES.items():
+        valid = helpers.VALID_SOURCES.setdefault(media_type, [])
+        valid.extend(source for source in extra if source not in valid)
     # Episodes support the shared tracker fields plus the legacy dropped flag.
     helpers.MEDIA_MODIFIABLE_FIELDS[MediaTypes.EPISODE.value] |= _MODIFIABLE_FIELDS | {
         "dropped"

--- a/src/api/tests/test_fork_valid_sources.py
+++ b/src/api/tests/test_fork_valid_sources.py
@@ -1,0 +1,133 @@
+# FORK: the API's source allowlist has to cover the screen sources the
+# fork's metadata layer resolves. `VALID_SOURCES` lives in upstream's
+# api/helpers.py and never grew TVDB, so a tracked row from it was listable
+# through GET /media/ — which does not consult the table — and 400'd on
+# every keyed route. Plex writes these for sports.
+from http import HTTPStatus as HTTP  # noqa: N814
+from unittest.mock import patch
+
+from api.fork_helpers import FORK_EXTRA_SOURCES, install_fork_media_types
+from api.helpers import VALID_SOURCES, check_source_type
+from app.models import TV, Item, MediaTypes, Sources, Status
+
+from .base import FloppyApiTestCase
+
+
+class ForkExtraSourcesTests(FloppyApiTestCase):
+    """Every source the fork can resolve is a source the API will answer for."""
+
+    def test_tvdb_is_valid_for_the_screen_types(self):
+        """TVDB resolves tv, season and episode metadata, so all three take it."""
+        for media_type in (
+            MediaTypes.TV.value,
+            MediaTypes.SEASON.value,
+            MediaTypes.EPISODE.value,
+        ):
+            with self.subTest(media_type=media_type):
+                self.assertTrue(check_source_type(media_type, Sources.TVDB.value))
+
+    def test_anime_takes_all_three_of_its_providers(self):
+        """MAL natively, TMDB and TVDB through the grouped-anime route."""
+        for source in (
+            Sources.MAL.value,
+            Sources.TMDB.value,
+            Sources.TVDB.value,
+        ):
+            with self.subTest(source=source):
+                self.assertTrue(check_source_type(MediaTypes.ANIME.value, source))
+
+    def test_upstream_sources_survive_the_extension(self):
+        """Extending a list must not displace what upstream put in it."""
+        self.assertIn(Sources.TMDB.value, VALID_SOURCES[MediaTypes.TV.value])
+        self.assertIn(Sources.MANUAL.value, VALID_SOURCES[MediaTypes.TV.value])
+        self.assertIn(Sources.MAL.value, VALID_SOURCES[MediaTypes.ANIME.value])
+        # Books are deliberately untouched: `_storyteller_book` and friends
+        # resolve, but nothing on this deployment tracks one, so widening that
+        # entry would close a hole no client can reach.
+        self.assertNotIn(Sources.STORYTELLER.value, VALID_SOURCES[MediaTypes.BOOK.value])
+
+    def test_an_unroutable_source_is_still_refused(self):
+        """The gate still gates — this widens the table, it does not open it."""
+        self.assertFalse(check_source_type(MediaTypes.TV.value, Sources.IGDB.value))
+        self.assertFalse(check_source_type(MediaTypes.MOVIE.value, Sources.TVDB.value))
+        self.assertFalse(check_source_type(MediaTypes.BOOK.value, "not-a-provider"))
+
+    def test_installing_twice_does_not_duplicate(self):
+        """`ready()` can run more than once; the overlay stays idempotent."""
+        install_fork_media_types()
+        install_fork_media_types()
+        for media_type, extra in FORK_EXTRA_SOURCES.items():
+            for source in extra:
+                with self.subTest(media_type=media_type, source=source):
+                    self.assertEqual(VALID_SOURCES[media_type].count(source), 1)
+
+
+class ForkExtraSourcesEndpointTests(FloppyApiTestCase):
+    """The 400 this fixes was raised before any provider was consulted."""
+
+    def setUp(self):
+        """Track a TVDB show, the way Plex writes one for a sports fixture."""
+        super().setUp()
+        self.tvdb_item, _ = Item.objects.get_or_create(
+            media_id="399081",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            defaults={
+                "title": "Premier League",
+                "image": "https://artworks.thetvdb.com/banners/v4/series/399081/p.jpg",
+            },
+        )
+        self.tvdb_tv = TV.objects.create(
+            user=self.user1,
+            item=self.tvdb_item,
+            status=Status.IN_PROGRESS.value,
+        )
+
+    @staticmethod
+    def _metadata(item, media_type):
+        """The shape CompleteMediaSerializer needs, with nothing provider-specific."""
+        return {
+            "media_id": item.media_id,
+            "source": item.source,
+            "source_url": "",
+            "media_type": media_type,
+            "title": item.title,
+            "max_progress": None,
+            "image": item.image,
+            "synopsis": "",
+            "genres": [],
+            "score": None,
+            "score_count": None,
+            "details": {},
+            "related": {"seasons": [], "recommendations": []},
+        }
+
+    @patch("api.views.services.get_media_metadata")
+    def test_tvdb_show_detail_is_reachable(self, mock_metadata):
+        """The route that 400'd for every TVDB row Plex had written."""
+        mock_metadata.return_value = self._metadata(
+            self.tvdb_item,
+            MediaTypes.TV.value,
+        )
+
+        response = self.call_api(
+            "get",
+            "api_media_detail",
+            args=(MediaTypes.TV.value, Sources.TVDB.value, self.tvdb_item.media_id),
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        self.assertEqual(response.json()["media_id"], self.tvdb_item.media_id)
+
+    def test_a_source_the_type_cannot_resolve_still_400s(self):
+        """The error message this replaces is still raised where it belongs."""
+        response = self.call_api(
+            "get",
+            "api_media_detail",
+            args=(MediaTypes.MOVIE.value, Sources.TVDB.value, "550"),
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, HTTP.BAD_REQUEST)
+        self.assertIn("Cannot query", response.json()["detail"])


### PR DESCRIPTION
## Summary

`api/helpers.py::VALID_SOURCES` maps each media type to the sources it may be addressed by, and `check_source_type` gates **38 handlers in `api/views.py`** and **3 in `api/fork_views_tracking.py`** against it. That table still reads `tv/season/episode -> ["tmdb", "manual"]`, so TVDB was never added to it.

The rest of the codebase supports TVDB. `services.get_media_metadata` routes tv/season/episode to `tvdb.tv` / `tvdb.tv_with_seasons` / `tvdb.episode`, and anime to `mal` | `tmdb.tv` | `tvdb`. The web detail page renders a TVDB show, its season grid and its episodes. `SearchProviderView` accepts `?source=tvdb` and returns TVDB results, so a TVDB item can be found and tracked. Only the API's detail routes refuse it.

That leaves the API internally inconsistent: the list route does not consult `VALID_SOURCES` (`MediaTypeListView` has no `check_source_type` call), so a TVDB item is returned by one endpoint and rejected by every endpoint that addresses it individually.

```
GET /media/?media_type=tv&search=399081   200
GET /media/tv/tvdb/399081/                400  Cannot query `tvdb` for `tv` media type
GET /media/tv/tvdb/399081/seasons/        400
GET /media/tv/tvdb/399081/1/              400
GET /media/tv/tvdb/399081/history/        400
```

This is reachable without a user ever choosing TVDB: integrations write TVDB items for content TMDB does not carry (sports, in the case that surfaced this), so an item can enter a library with `source="tvdb"` and then be unusable through the API while remaining fully usable on the web.

`FORK_VALID_SOURCES` cannot express the fix — it is applied with `setdefault`, so it can introduce a media type upstream lacks but never extend one it already has. This adds `FORK_EXTRA_SOURCES` and a second pass that extends the existing lists in place, leaving upstream's entries intact.

Scope is TVDB for tv/season/episode, plus TMDB for anime, which the grouped-anime route resolves and the table also omits. No UI or visual change; this only affects which `(media_type, source)` pairs the existing API routes accept.

## AI Assistance

`claude-opus-5` (Claude Code)

## How It Was Tested

| Command | Outcome |
|---|---|
| `python src/manage.py test api.tests.test_fork_valid_sources --buffer` | **Passed** — 7 tests |
| `python src/manage.py test api --parallel --buffer` | **605 tests, 2 failures** — both pre-existing, see below |
| `python -m app.domain_vocabulary --check` | **Passed** (exit 0) |
| `python src/manage.py check_migration_hygiene --strict` | **Passed** (exit 0) |
| `python src/manage.py spectacular`, diffed with and without the change | **Byte-identical** |

The two failures are `test_fork_scrobble.ScrobbleStopTests.test_stop_completed_marks_movie_completed` and `test_stop_episode_dedup_within_five_seconds`, both `404 != 200`. They are not caused by this change: verified by backing the change out and re-running (still 2 failures), and again in a clean worktree at the base commit `f2d10d9c` with nothing local applied (still 2 failures). They were already failing on the base commit and are unrelated to this area.

New tests in `api/tests/test_fork_valid_sources.py`:

- TVDB is valid for tv, season and episode
- anime accepts MAL, TMDB and TVDB
- upstream's own entries survive the extension (`tmdb`, `manual`, `mal` still present)
- `install_fork_media_types()` is idempotent — running it twice leaves one copy of each source
- end to end: a tracked TVDB show's detail route returns 200 where it returned 400, and a source the type cannot resolve still returns 400 with the same message

## Public API & Documentation Handoff

- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] OpenAPI schema contracts verified (if API endpoints changed)
- [ ] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance

- [ ] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)

- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed
- [x] Not applicable (no database changes)

## Related Issues

N/A