### PR TITLE
Support Stremio series catalogs from TV-season smart lists

### DIFF
--- a/src/integrations/stremio_catalog.py
+++ b/src/integrations/stremio_catalog.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qsl, unquote
 
 from django.db.models import F, Max
 
-from app.models import TV, MediaTypes, Movie, Sources, Status
+from app.models import TV, MediaTypes, Movie, Season, Sources, Status
 from lists.models import CustomList, CustomListItem
 
 PAGE_SIZE = 100
@@ -230,13 +230,7 @@ def local_imdb_id(item):
 
 
 def catalog_readiness(user):
-    """Return per-catalog publishable/unresolved counts for the settings page.
-
-    project_catalog() already counts the items it has to drop for want of an
-    IMDb ID, but only logs it. Surfacing the same number tells users whether a
-    thin catalog is a Floppy problem they need to wait out or a list they need
-    to fill (issue #1066).
-    """
+    """Return per-catalog publishable/unresolved counts for the settings page."""
     readiness = []
     for spec in CATALOG_SPECS:
         if spec.statuses:
@@ -303,8 +297,44 @@ def list_source_items(user, spec):
         .select_related("item")
         .order_by("-date_added", "-id")
     )
+
+    seen_item_ids = set()
     for membership in memberships.iterator():
+        seen_item_ids.add(membership.item.pk)
         yield membership.item
+
+    if source_list.is_smart and spec.media_type == MediaTypes.TV.value:
+        for parent_item in smart_season_parent_items(user, source_list):
+            if parent_item.pk in seen_item_ids:
+                continue
+            seen_item_ids.add(parent_item.pk)
+            yield parent_item
+
+
+def smart_season_parent_items(user, source_list):
+    """Yield parent TV items for smart-list seasons, newest season release first."""
+    seen_item_ids = set()
+    seasons = (
+        Season.objects.filter(
+            user=user,
+            item__customlistitem__custom_list=source_list,
+            item__media_type=MediaTypes.SEASON.value,
+        )
+        .select_related("item", "related_tv__item")
+        .order_by(
+            F("item__release_datetime").desc(nulls_last=True),
+            "related_tv__item__title",
+            "related_tv__item_id",
+            "-item__customlistitem__id",
+        )
+    )
+    for season in seasons.iterator():
+        parent_item = season.related_tv.item
+        parent_item_id = parent_item.pk
+        if parent_item_id in seen_item_ids:
+            continue
+        seen_item_ids.add(parent_item_id)
+        yield parent_item
 
 
 def last_watched_queryset(model, media_type, user, statuses):

--- a/src/integrations/tests/test_webhooks_stremio.py
+++ b/src/integrations/tests/test_webhooks_stremio.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from unittest.mock import patch
 
@@ -68,6 +69,48 @@ class StremioAddonViewTests(TestCase):
         )
         CustomListItem.objects.create(custom_list=custom_list, item=item)
         return item
+
+    def _add_series_with_season(
+        self,
+        custom_list,
+        index,
+        *,
+        show_media_id=None,
+        show_source=Sources.IMDB.value,
+        show_external_ids=None,
+        season_release_date=None,
+        season_number=1,
+    ):
+        show_item = Item.objects.create(
+            title=f"Show {index}",
+            media_id=show_media_id or f"tt{index + 1:07d}",
+            media_type=MediaTypes.TV.value,
+            source=show_source,
+            provider_external_ids=show_external_ids or {},
+            image=f"https://example.com/show{index}.jpg",
+        )
+        tv = TV.objects.create(
+            item=show_item,
+            user=self.user,
+            status=Status.PLANNING.value,
+        )
+        season_item = Item.objects.create(
+            title=f"Show {index} Season {season_number}",
+            media_id=str(1000 + index),
+            media_type=MediaTypes.SEASON.value,
+            source=Sources.TMDB.value,
+            season_number=season_number,
+            release_datetime=season_release_date,
+            image=f"https://example.com/season{index}.jpg",
+        )
+        Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.PLANNING.value,
+        )
+        CustomListItem.objects.get_or_create(custom_list=custom_list, item=season_item)
+        return show_item, season_item
 
     def _response_metas(self, response):
         return json.loads(response.content)["metas"]
@@ -388,6 +431,173 @@ class StremioAddonViewTests(TestCase):
             [meta["id"] for meta in self._response_metas(response)],
             [tv_item.media_id],
         )
+
+    def test_series_catalog_projects_smart_seasons_as_parent_shows(self):
+        """Season-only smart catalogs publish parent shows for Stremio."""
+        series = CustomList.objects.create(
+            name="Series",
+            owner=self.user,
+            is_smart=True,
+            smart_media_types=[MediaTypes.SEASON.value],
+        )
+        older_show, _ = self._add_series_with_season(
+            series,
+            1,
+            season_release_date=datetime.datetime(2026, 1, 20, tzinfo=datetime.UTC),
+        )
+        newer_show, _ = self._add_series_with_season(
+            series,
+            2,
+            season_release_date=datetime.datetime(2026, 8, 20, tzinfo=datetime.UTC),
+        )
+
+        response = self.client.get(
+            self._catalog_url(
+                media_type="series",
+                catalog_id="floppy-watchlist-series",
+            )
+        )
+
+        self.assertEqual(
+            [meta["id"] for meta in self._response_metas(response)],
+            [newer_show.media_id, older_show.media_id],
+        )
+        self.assertEqual(
+            [meta["name"] for meta in self._response_metas(response)],
+            [newer_show.title, older_show.title],
+        )
+
+    def test_series_catalog_merges_smart_seasons_with_direct_tv_rows(self):
+        """A mixed [tv, season] smart list keeps shows matched only directly.
+
+        A show can match a smart list's rules through a direct TV row with no
+        season in the list at all; dropping it there was issue #1101's bug.
+        """
+        series = CustomList.objects.create(
+            name="Series",
+            owner=self.user,
+            is_smart=True,
+            smart_media_types=[MediaTypes.TV.value, MediaTypes.SEASON.value],
+        )
+        season_show, _ = self._add_series_with_season(
+            series,
+            1,
+            season_release_date=datetime.datetime(2026, 8, 20, tzinfo=datetime.UTC),
+        )
+        direct_tv = self._add_catalog_item(
+            series,
+            2,
+            media_type=MediaTypes.TV.value,
+            media_id="tt9999999",
+        )
+
+        response = self.client.get(
+            self._catalog_url(
+                media_type="series",
+                catalog_id="floppy-watchlist-series",
+            )
+        )
+
+        self.assertEqual(
+            {meta["id"] for meta in self._response_metas(response)},
+            {season_show.media_id, direct_tv.media_id},
+        )
+
+    def test_series_catalog_deduplicates_shows_by_newest_matching_season(self):
+        """Multiple matching seasons produce one show at the newest season date."""
+        series = CustomList.objects.create(
+            name="Series",
+            owner=self.user,
+            is_smart=True,
+            smart_media_types=[MediaTypes.SEASON.value],
+        )
+        other_show, _ = self._add_series_with_season(
+            series,
+            1,
+            season_release_date=datetime.datetime(2026, 4, 1, tzinfo=datetime.UTC),
+        )
+        duplicate_show, _ = self._add_series_with_season(
+            series,
+            2,
+            season_release_date=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+            season_number=1,
+        )
+        duplicate_tv = TV.objects.get(item=duplicate_show, user=self.user)
+        newest_duplicate_season = Item.objects.create(
+            title="Show 2 Season 2",
+            media_id="2002",
+            media_type=MediaTypes.SEASON.value,
+            source=Sources.TMDB.value,
+            season_number=2,
+            release_datetime=datetime.datetime(2026, 9, 1, tzinfo=datetime.UTC),
+        )
+        Season.objects.create(
+            item=newest_duplicate_season,
+            user=self.user,
+            related_tv=duplicate_tv,
+            status=Status.PLANNING.value,
+        )
+        CustomListItem.objects.get_or_create(
+            custom_list=series,
+            item=newest_duplicate_season,
+        )
+
+        response = self.client.get(
+            self._catalog_url(
+                media_type="series",
+                catalog_id="floppy-watchlist-series",
+            )
+        )
+
+        self.assertEqual(
+            [meta["id"] for meta in self._response_metas(response)],
+            [duplicate_show.media_id, other_show.media_id],
+        )
+
+    def test_series_catalog_filters_unresolved_parent_shows_after_skip(self):
+        """Unresolved season-derived parent shows do not consume skip slots."""
+        series = CustomList.objects.create(
+            name="Series",
+            owner=self.user,
+            is_smart=True,
+            smart_media_types=[MediaTypes.SEASON.value],
+        )
+        resolved_show, _ = self._add_series_with_season(
+            series,
+            1,
+            season_release_date=datetime.datetime(2026, 8, 20, tzinfo=datetime.UTC),
+        )
+        self._add_series_with_season(
+            series,
+            2,
+            show_media_id="3002",
+            show_source=Sources.TMDB.value,
+            season_release_date=datetime.datetime(2026, 9, 1, tzinfo=datetime.UTC),
+        )
+
+        first_page = self._response_metas(
+            self.client.get(
+                self._catalog_url(
+                    media_type="series",
+                    catalog_id="floppy-watchlist-series",
+                )
+            )
+        )
+        second_page = self._response_metas(
+            self.client.get(
+                self._catalog_url(
+                    media_type="series",
+                    catalog_id="floppy-watchlist-series",
+                    extra="skip=1",
+                )
+            )
+        )
+
+        self.assertEqual(
+            [meta["id"] for meta in first_page],
+            [resolved_show.media_id],
+        )
+        self.assertEqual(second_page, [])
 
     def test_catalog_validates_token_and_catalog_with_json_cors_responses(self):
         """Token, catalog id, CORS, and JSON content type remain stable."""


### PR DESCRIPTION
## Summary

Allows lists that are Season based to show in Stremio catalogs.

Great if you want to make a calendar like smart list: 

Configure the List to be Season filtered and order by recency.
You will now get shows popping up when their seasons begin.


## AI Assistance
Clause Sonnet 5

## How It Was Tested
- Run on my self hosted setup for a few days. I wanted a calendar like catalog
- Unit tests have been added

## Public API & Documentation Handoff
- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [] Code review completed
- [] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [x] No existing or shared migrations were altered or renumbered
- [x] Not applicable (no database changes)


