### PR TITLE
Allow slashes in Stremio addon extras segments

### DIFF
--- a/src/integrations/tests/test_webhooks_stremio.py
+++ b/src/integrations/tests/test_webhooks_stremio.py
@@ -444,6 +444,22 @@ class StremioAddonViewTests(TestCase):
             "series:tt0108778:1:1",
         )
 
+    @patch("integrations.views.stremio_queue.reserve_pending", return_value="accepted")
+    @patch("integrations.views.tasks.process_stremio_webhook.delay")
+    def test_subtitles_with_slash_in_extra_path(self, mock_delay, _mock_reserve):
+        """A release filename containing a slash still resolves and scrobbles."""
+        response = self.client.get(
+            "/stremio-addon/test-token/subtitles/movie/"
+            "tt1872181/filename=Novyy Chelovek-pauk / The Amazing Spider-Man 2"
+            " [2014].mp4&videoSize=60913373676.json",
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_delay.assert_called_once_with(
+            {"id": "tt1872181", "type": "movie"},
+            self.user.id,
+            "movie:tt1872181",
+        )
+
     @patch("integrations.views.stremio_queue.reserve_pending", return_value="limited")
     @patch("integrations.views.tasks.process_stremio_webhook.delay")
     def test_subtitles_limit_returns_empty_response_without_dispatch(

--- a/src/integrations/urls.py
+++ b/src/integrations/urls.py
@@ -234,13 +234,13 @@ urlpatterns = [
     re_path(
         r"^stremio-addon/(?P<token>[^/]+)/catalog/"
         r"(?P<media_type>movie|series)/"
-        r"(?P<catalog_id>[^/]+?)(?:/(?P<extra>[^/]*))?\.json$",
+        r"(?P<catalog_id>[^/]+?)(?:/(?P<extra>.*))?\.json$",
         views.stremio_addon_catalog,
         name="stremio_addon_catalog",
     ),
     re_path(
         r"^stremio-addon/(?P<token>[^/]+)/subtitles/"
-        r"(?P<media_type>movie|series)/(?P<media_id>[^/]+?)(?:/[^/]*)?\.json$",
+        r"(?P<media_type>movie|series)/(?P<media_id>[^/]+?)(?:/.*)?\.json$",
         views.stremio_addon_subtitles,
         name="stremio_addon_subtitles",
     ),


### PR DESCRIPTION
## Summary
- Stremio appends the release filename to subtitles and catalog requests. The
  extras group in the addon routes only matched a segment containing no
  slashes, so any release whose name has a slash in it returned 404 before the
  view ran. The scrobble was silently lost with no error shown to the user.
- Widens the extras group in both addon routes. `media_id` and `catalog_id`
  keep `[^/]+?`, so they still cannot span a slash, and the view's existing
  `STREMIO_MEDIA_ID_PATTERN` check is unchanged.

## Bug Fix Explanation
Root cause: `(?:/[^/]*)?` assumed the extras segment never contains a slash.
Stremio puts the raw release filename there. Dual-titled releases commonly
include one, for example
`Новый Человек-паук: Высокое напряжение / The Amazing Spider-Man 2`.

Percent-encoding does not help, because WSGI decodes PATH_INFO before URL
resolution, so an encoded slash arrives decoded.

Because the failure happens at URL resolution, no addon code runs and nothing
is logged beyond a 404. The play disappears with no user-visible signal.

`test_subtitles_with_extra_path` already covered the extras segment, but only
with a slash-free filename, which is why this survived. The new test covers
the case that broke.

## AI Assistance
- Model: `claude-opus-5`
- Workflows: diagnosis from live server logs, fix and regression test written
  through conversation, verified manually against a running instance.

## How It Was Tested
- New test `test_subtitles_with_slash_in_extra_path` on unfixed `latest`
  -> `AssertionError: 404 != 200` (reproduces the bug)
- Same test with the fix -> `Ran 1 test, OK`
- `scripts/test.sh integrations.tests.test_webhooks_stremio` -> 29 tests,
  2 failures and 2 errors, all in `StremioWebhookProcessorTests`. These need
  TMDB metadata resolution (`Movie.DoesNotExist` on id 603) and fail
  identically on clean `latest` with this change stashed. Pre-existing and
  unrelated.
- `uv run --no-sync ruff check src` -> All checks passed
- Live instance: a release that previously 404'd now returns 200 and produces
  `stremio_queue status=queued`, followed by the webhook task succeeding.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (manual playback testing on a live instance)

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Fixes #1108
- Refs #678