### PR TITLE
Patch IMDb credits task in sync_metadata IGDB test

### DIFF
--- a/src/app/tests/views/test_sync_metadata.py
+++ b/src/app/tests/views/test_sync_metadata.py
@@ -97,6 +97,7 @@ class SyncMetadataViewTests(TestCase):
 
         self.assertEqual(response.status_code, 302)
 
+    @patch("app.tasks_imdb.refresh_imdb_game_credits_from_datasets.apply_async")
     @patch("app.metadata_sync_views._sync_plex_rating")
     @patch("app.views.Item.fetch_releases")
     @patch("app.views.game_length_services.refresh_game_lengths")
@@ -107,6 +108,7 @@ class SyncMetadataViewTests(TestCase):
         mock_refresh_game_lengths,
         mock_fetch_releases,
         mock_sync_plex_rating,
+        _mock_refresh_imdb_credits,
     ):
         mock_get_media_metadata.return_value = {
             "media_id": "325609",


### PR DESCRIPTION
## Summary
- Since ac90f807, `enrich_synced_item` dispatches `refresh_imdb_game_credits_from_datasets` for IGDB games. Under `CELERY_TASK_ALWAYS_EAGER` (set in `test_settings.py`) the task runs inline and pulls the full `title.principals` dataset inside the test request, so the default suite never finishes.
- Adds `@patch("app.tasks_imdb.refresh_imdb_game_credits_from_datasets.apply_async")` to `test_sync_metadata_refreshes_game_lengths_for_igdb_games`, the only test that reaches that branch. Same pattern already used in `test_app_startup.py`.
- Test-only change; no runtime code touched.

## AI Assistance
- Diagnosis (py-spy trace interpretation, commit bisection): `claude-opus-5`
- Fix and PR text: `claude-fable-5-1`
- Reproduction, process data and test runs are from my own instance.

## How It Was Tested
- `SECRET=test-only .venv/bin/python3 src/manage.py test app.tests.views.test_sync_metadata` -> 11 tests, OK in 4.8s
- Before the patch, the same test ran indefinitely (47+ min CPU) parsing the IMDb dataset — see #1113 for the py-spy dump.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [ ] Visual or manual QA verified — not applicable, test-only change

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Fixes #1113