### PR TITLE
fix: clamp open-file soft limit so celery beat starts promptly

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -324,5 +324,23 @@ else
 fi
 echo "[entrypoint] celery workers background=on(${FLOPPY_CELERY_QUEUES}) interactive=${interactive_topology} discover=${discover_topology}" >&2
 
+# Docker 25+ and recent containerd give a container an effectively unlimited
+# RLIMIT_NOFILE, so SC_OPEN_MAX inside it reads as 2147483584. Celery's
+# embedded beat calls billiard's close_open_fds() during startup, which closes
+# every descriptor up to that number one at a time: the process pins a core for
+# hours before "beat: Starting..." appears, and no scheduled task runs until it
+# does (celery/celery#8306, still open). Lower the soft limit here, once, so
+# every supervised child inherits it. The hard limit is untouched, so an
+# operator who needs more can raise FLOPPY_NOFILE_LIMIT or the soft limit again.
+NOFILE_SOFT=${FLOPPY_NOFILE_LIMIT:-65536}
+current_nofile=$(ulimit -n 2>/dev/null || echo unlimited)
+if [ "$current_nofile" = "unlimited" ] || [ "$current_nofile" -gt "$NOFILE_SOFT" ] 2>/dev/null; then
+    if ulimit -n "$NOFILE_SOFT" 2>/dev/null; then
+        echo "[entrypoint] Open-file soft limit lowered from ${current_nofile} to ${NOFILE_SOFT} (celery/celery#8306)" >&2
+    else
+        echo "[entrypoint] WARNING: open-file soft limit is ${current_nofile} and could not be lowered; celery beat may take hours to start" >&2
+    fi
+fi
+
 echo "[entrypoint] Starting services" >&2
 exec supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
## Summary
- Celery's embedded beat pins a CPU core for hours on container start when the host gives the container a very large `RLIMIT_NOFILE`. No scheduled task runs until it finishes. `entrypoint.sh` now lowers the open-file soft limit once, before `exec supervisord`, so every supervised child inherits a sane value.
- Cause: billiard's `get_fdmax()` reads `os.sysconf('SC_OPEN_MAX')`. Docker 25+ and recent containerd hand containers an effectively unlimited `RLIMIT_NOFILE`, so that reads 2147483584. `celery/beat.py` calls `close_open_fds()` when the embedded beat process starts, and Floppy runs `celery worker --beat` in `supervisord.conf`, so it is on the hot path. It closes every descriptor up to that number, one at a time.
- **Note for #1104:** the report says celery 5.8.0 fixes this. It does not. `5.8.0` is the milestone on the still-open celery/celery#8306, not a release. The newest celery on PyPI is 5.6.3, which `pyproject.toml` already pins. There is no version bump available, so the fix has to live in Floppy.
- Chose the entrypoint over a `ulimits:` block in `docker-compose.yml` so every deployment method is covered — Unraid, Portainer, Kubernetes, plain `docker run` — not only people who use the repo's compose file. `FLOPPY_NOFILE_LIMIT` overrides the 65536 default. The hard limit is untouched, so an operator can still raise it.
- 18 lines, one file, no Python or dependency changes.

## AI Assistance
- `claude-opus-5` helped trace the cause through celery and billiard and drafted the entrypoint change. I reviewed and tested it.

## How It Was Tested
My Docker daemon reports `ulimit -n` of 1024 inside containers, so I could not reproduce the fault natively. I forced the reporter's condition instead.

- `ulimit -Hn` on the host -> `524288`
- `docker run --rm --ulimit nofile=1048576:1048576 alpine sh -c 'ulimit -n'` -> `1048576` (confirms the limit reaches the container)
- `docker build -t floppy:nofile-test .` -> Passed
- `docker run --rm --ulimit nofile=1048576:1048576 -e SECRET=test-only floppy:nofile-test` -> log shows `[entrypoint] Open-file soft limit lowered from 1048576 to 65536 (celery/celery#8306)`, and beat starts immediately instead of hanging
- `sh -n entrypoint.sh` -> Passed
- `SECRET=test-only scripts/test.sh app.tests.test_data_paths` -> Passed (18 tests)

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (container start log inspected under a forced `nofile` limit)

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Fixes #1104
- Refs celery/celery#8306

