### PR TITLE
Fix pickling of recently-played music album entries

### DIFF
--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -1595,6 +1595,24 @@ class _ArtistHomeAdapter(_MusicTrackerAdapter):
         self.card_subtitle_date = getattr(tracker, "created_at", None)
 
 
+class _RecentAlbumAdapter:
+    """Media-like wrapper around an Album for the recently-played music row."""
+
+    def __init__(self, album, play_count, last_played_at, primary_track):
+        self.album = album
+        self.id = album.id
+        self.play_count = play_count
+        self.last_played_at = last_played_at
+        self.created_at = last_played_at
+        self.status = None
+        self.end_date = last_played_at
+        self.next_event = None
+        self.score = None
+        self.title = album.title
+        self.item = _music_shell_item(f"album_{album.id}", album.title, album.image)
+        self.primary_track = primary_track
+
+
 def _apply_music_tracker_rating_filter(trackers, rating_filter: str):
     if rating_filter == "rated":
         return trackers.filter(score__isnull=False)
@@ -1713,21 +1731,6 @@ def _build_recent_music_album_entries(media_items: list[object]) -> list[HomeRow
             album_last_played[album_id] = last_played
             album_primary_track[album_id] = track
 
-    class AlbumAdapter:
-        def __init__(self, album, play_count, last_played_at, primary_track):
-            self.album = album
-            self.id = album.id
-            self.play_count = play_count
-            self.last_played_at = last_played_at
-            self.created_at = last_played_at
-            self.status = None
-            self.end_date = last_played_at
-            self.next_event = None
-            self.score = None
-            self.title = album.title
-            self.item = _music_shell_item(f"album_{album.id}", album.title, album.image)
-            self.primary_track = primary_track
-
     entries = [
         HomeRowEntry(
             item=adapter.item,
@@ -1735,7 +1738,7 @@ def _build_recent_music_album_entries(media_items: list[object]) -> list[HomeRow
             show_progress_controls=False,
         )
         for adapter in [
-            AlbumAdapter(
+            _RecentAlbumAdapter(
                 albums_by_id[album_id],
                 album_play_counts[album_id],
                 album_last_played[album_id],

--- a/src/users/tests/views/test_home_music_subview.py
+++ b/src/users/tests/views/test_home_music_subview.py
@@ -1,6 +1,9 @@
 """Smoke tests for music subview Home rows (albums/artists/tracks)."""
 
 import json
+import pickle
+from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -14,6 +17,16 @@ from users.models import (
     HomeScreenRowTypeChoices,
     MediaStatusChoices,
 )
+
+
+@dataclass
+class _FakeTrack:
+    """Minimal stand-in for a Track: only the attributes the row builder reads."""
+
+    album: object
+    repeats: int
+    last_played_at: object
+    created_at: object
 
 
 class MusicSubviewHomeTests(TestCase):
@@ -117,6 +130,24 @@ class MusicSubviewHomeTests(TestCase):
         self.assertContains(response, "A Night at the Opera")
         # Album cards carry the artist as the hover subtitle (mirrors the library).
         self.assertContains(response, "Queen")
+
+    def test_recent_music_album_entries_are_picklable(self):
+        # Regression test for #1122: the "Recently Played Music" row is cached
+        # via django_redis, which pickles cache values. A locally-scoped
+        # adapter class previously broke this with an unpicklable-object error.
+        now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        track = _FakeTrack(
+            album=self.album,
+            repeats=3,
+            last_played_at=now,
+            created_at=now,
+        )
+        entries = home_screen._build_recent_music_album_entries([track])
+        self.assertEqual(len(entries), 1)
+
+        roundtripped = pickle.loads(pickle.dumps(entries))
+        self.assertEqual(roundtripped[0].media.title, "A Night at the Opera")
+        self.assertEqual(roundtripped[0].media.play_count, 3)
 
     def test_home_page_renders_artist_card(self):
         self._add_music_row("artists", Status.IN_PROGRESS.value)

--- a/src/users/tests/views/test_home_music_subview.py
+++ b/src/users/tests/views/test_home_music_subview.py
@@ -3,7 +3,7 @@
 import json
 import pickle
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -135,7 +135,7 @@ class MusicSubviewHomeTests(TestCase):
         # Regression test for #1122: the "Recently Played Music" row is cached
         # via django_redis, which pickles cache values. A locally-scoped
         # adapter class previously broke this with an unpicklable-object error.
-        now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        now = datetime(2024, 1, 1, tzinfo=UTC)
         track = _FakeTrack(
             album=self.album,
             repeats=3,


### PR DESCRIPTION
## Summary

Fixed a regression where the "Recently Played Music" home row could not be cached due to an unpicklable locally-scoped adapter class. The `AlbumAdapter` class was moved to module scope as `_RecentAlbumAdapter` so it can be properly pickled by django_redis's cache backend.

This resolves issue #1122 where caching the recently-played music row would fail with an unpicklable object error.

## How It Was Tested

- Added regression test `test_recent_music_album_entries_are_picklable` that verifies the album entries can be pickled and unpickled while preserving data integrity
- Test confirms that after round-tripping through pickle, the media object retains its title and play_count attributes

## Public API & Documentation Handoff

- [x] Not applicable (no API or vocabulary changes)

## Database & Migration Safety

- [x] Not applicable (no database changes)

## Related Issues

- Fixes #1122

https://claude.ai/code/session_01P2hTex31exEumPAmfaXzcN