### PR TITLE
Update Jellyfin API authentication to use Authorization header

### DIFF
--- a/src/integrations/jellyfin_client.py
+++ b/src/integrations/jellyfin_client.py
@@ -29,7 +29,7 @@ class JellyfinClient:
 
     def _headers(self) -> dict[str, str]:
         return {
-            "X-Emby-Token": self.api_key,
+            "Authorization": f'MediaBrowser Token="{self.api_key}"',
             "Accept": "application/json",
         }
 

--- a/src/integrations/tests/test_jellyfin_client.py
+++ b/src/integrations/tests/test_jellyfin_client.py
@@ -30,8 +30,8 @@ class JellyfinClientTests(SimpleTestCase):
         called_url = mock_request.call_args.args[1]
         self.assertTrue(called_url.endswith("/System/Info"))
         self.assertEqual(
-            mock_request.call_args.kwargs["headers"]["X-Emby-Token"],
-            "api-key",
+            mock_request.call_args.kwargs["headers"]["Authorization"],
+            'MediaBrowser Token="api-key"',
         )
 
     @patch("integrations.jellyfin_client.requests.request")


### PR DESCRIPTION
## Summary
Updated the Jellyfin client to use the standard `Authorization` header with `MediaBrowser` scheme instead of the deprecated `X-Emby-Token` header for API authentication. This aligns with Jellyfin's current authentication standards and improves compatibility with the API.

**Changes:**
- Modified `_headers()` method in `jellyfin_client.py` to use `Authorization: MediaBrowser Token="<api-key>"` format
- Updated corresponding test assertions to verify the new header format

## How It Was Tested
- Existing unit test `test_healthcheck_returns_json` updated and passing to verify the new Authorization header format is correctly set

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Database & Migration Safety
- [x] Not applicable (no database changes)

https://claude.ai/code/session_01Kh7gRgVs1fjCVFi3qMxQN5