### PR TITLE
Add watch providers to MAL anime

### DIFF
--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -1635,7 +1635,16 @@ def media_details(
                 # Use episode count from metadata if available to match Details pane
                 metadata_episode_count = media_metadata.get("details", {}).get(
                     "episodes"
-                ) or media_metadata.get("episodes")
+                )
+                if (
+                    not isinstance(metadata_episode_count, int)
+                    or metadata_episode_count <= 0
+                ):
+                    metadata_episodes = media_metadata.get("episodes")
+                    if isinstance(metadata_episodes, list):
+                        metadata_episode_count = len(metadata_episodes)
+                    elif isinstance(metadata_episodes, int):
+                        metadata_episode_count = metadata_episodes
                 collection_stats = get_tv_show_collection_stats(
                     request.user, item, metadata_episode_count=metadata_episode_count
                 )
@@ -1682,7 +1691,36 @@ def media_details(
         MediaTypes.ANIME.value,
     ]:
         watch_provider_payload = media_metadata.get("providers")
+        tmdb_media_id = None
+        tmdb_media_type = media_type
         if (
+            render_secondary_only
+            and media_type == MediaTypes.ANIME.value
+            and source == Sources.MAL.value
+            and not watch_provider_payload
+        ):
+            try:
+                identity = metadata_resolution.resolve_mal_tmdb_identity(media_id)
+            except (services.ProviderAPIError, TypeError, ValueError) as error:
+                logger.warning(
+                    "Skipping watch providers for MAL anime media_id=%s: "
+                    "mapping resolution failed: %s",
+                    media_id,
+                    exception_summary(error),
+                )
+                identity = None
+            if identity:
+                tmdb_media_id = identity.media_id
+                tmdb_media_type = identity.media_type
+                if detail_item:
+                    metadata_resolution.persist_mal_tmdb_identity(
+                        detail_item,
+                        identity,
+                        persistence_mode="best_effort",
+                        retry_max_retries=detail_db_max_retries,
+                        on_deferred=_mark_detail_persistence_deferred,
+                    )
+        elif (
             render_secondary_only
             and detail_item
             and media_type in (MediaTypes.TV.value, MediaTypes.ANIME.value)
@@ -1696,29 +1734,30 @@ def media_details(
                 retry_max_retries=detail_db_max_retries,
                 on_deferred=_mark_detail_persistence_deferred,
             )
-            if tmdb_media_id:
-                try:
-                    tmdb_metadata = services.get_media_metadata(
-                        media_type,
-                        tmdb_media_id,
-                        Sources.TMDB.value,
-                        language=metadata_resolution.metadata_language_default(
-                            request.user, detail_item
-                        ),
-                    )
-                except services.ProviderAPIError:
-                    # Watch providers are TMDB-only enrichment. A dead TMDB
-                    # mapping must not take down a page the tracking provider
-                    # can render on its own.
-                    logger.warning(
-                        "Skipping watch providers for %s media_id=%s: mapped TMDB "
-                        "ID %s could not be fetched",
-                        source,
-                        media_id,
-                        tmdb_media_id,
-                    )
-                else:
-                    watch_provider_payload = tmdb_metadata.get("providers")
+
+        if tmdb_media_id:
+            try:
+                tmdb_metadata = services.get_media_metadata(
+                    tmdb_media_type,
+                    tmdb_media_id,
+                    Sources.TMDB.value,
+                    language=metadata_resolution.metadata_language_default(
+                        request.user, detail_item
+                    ),
+                )
+            except services.ProviderAPIError:
+                # Watch providers are TMDB-only enrichment. A dead TMDB
+                # mapping must not take down a page the tracking provider
+                # can render on its own.
+                logger.warning(
+                    "Skipping watch providers for %s media_id=%s: mapped TMDB "
+                    "ID %s could not be fetched",
+                    source,
+                    media_id,
+                    tmdb_media_id,
+                )
+            else:
+                watch_provider_payload = tmdb_metadata.get("providers")
 
         if (
             detail_item

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -1635,16 +1635,7 @@ def media_details(
                 # Use episode count from metadata if available to match Details pane
                 metadata_episode_count = media_metadata.get("details", {}).get(
                     "episodes"
-                )
-                if (
-                    not isinstance(metadata_episode_count, int)
-                    or metadata_episode_count <= 0
-                ):
-                    metadata_episodes = media_metadata.get("episodes")
-                    if isinstance(metadata_episodes, list):
-                        metadata_episode_count = len(metadata_episodes)
-                    elif isinstance(metadata_episodes, int):
-                        metadata_episode_count = metadata_episodes
+                ) or media_metadata.get("episodes")
                 collection_stats = get_tv_show_collection_stats(
                     request.user, item, metadata_episode_count=metadata_episode_count
                 )
@@ -1690,6 +1681,11 @@ def media_details(
         MediaTypes.MOVIE.value,
         MediaTypes.ANIME.value,
     ]:
+        watch_provider_region = (
+            request.user.watch_provider_region
+            if request.user.is_authenticated
+            else None
+        )
         watch_provider_payload = media_metadata.get("providers")
         tmdb_media_id = None
         tmdb_media_type = media_type
@@ -1698,6 +1694,7 @@ def media_details(
             and media_type == MediaTypes.ANIME.value
             and source == Sources.MAL.value
             and not watch_provider_payload
+            and watch_provider_region != "UNSET"
         ):
             try:
                 identity = metadata_resolution.resolve_mal_tmdb_identity(media_id)
@@ -1775,9 +1772,7 @@ def media_details(
         watch_providers = (
             tmdb.filter_providers(
                 watch_provider_payload,
-                request.user.watch_provider_region
-                if request.user.is_authenticated
-                else None,
+                watch_provider_region,
             )
             if watch_provider_payload is not None
             else None

--- a/src/app/services/metadata_resolution.py
+++ b/src/app/services/metadata_resolution.py
@@ -798,6 +798,32 @@ def _reconcile_competing_seasons(canonical_season, stray_season) -> None:
     canonical_season.save(update_fields=["status", "score", "notes"])
 
 
+def _tmdb_series_id_from_tvdb_id(tvdb_id: str) -> str | None:
+    """Return one exact TMDB TV result for a TVDB series ID."""
+    from app.providers import tmdb
+
+    try:
+        find_response = tmdb.find(tvdb_id, "tvdb_id")
+    except services.ProviderAPIError:
+        logger.warning(
+            "Skipping TMDB resolution for TVDB ID %s: provider request failed",
+            tvdb_id,
+        )
+        return None
+
+    tv_results = (
+        find_response.get("tv_results", [])
+        if isinstance(find_response, dict)
+        else []
+    )
+    tmdb_ids = {
+        str(result["id"])
+        for result in tv_results
+        if isinstance(result, dict) and result.get("id") not in (None, "")
+    }
+    return tmdb_ids.pop() if len(tmdb_ids) == 1 else None
+
+
 def resolve_provider_media_id(
     item: Item | None,
     provider: str,
@@ -852,7 +878,35 @@ def resolve_provider_media_id(
             item.media_id,
             provider,
         )
+        mapped_tvdb_id = None
+        if not mapped_series_id and provider == Sources.TMDB.value:
+            mapped_tvdb_id = anime_mapping.resolve_provider_series_id(
+                item.media_id,
+                Sources.TVDB.value,
+            )
+            if mapped_tvdb_id:
+                mapped_series_id = _tmdb_series_id_from_tvdb_id(mapped_tvdb_id)
+
         if mapped_series_id:
+            if mapped_tvdb_id:
+                upsert_provider_links(
+                    item,
+                    {
+                        "media_id": str(mapped_series_id),
+                        "provider_external_ids": {
+                            "tmdb_id": str(mapped_series_id),
+                            "tvdb_id": str(mapped_tvdb_id),
+                        },
+                    },
+                    provider=Sources.TMDB.value,
+                    provider_media_type=provider_media_type,
+                    season_number=season_number,
+                    persistence_mode=persistence_mode,
+                    retry_max_retries=retry_max_retries,
+                    on_deferred=on_deferred,
+                )
+                return str(mapped_series_id)
+
             run_retryable_db_operation(
                 lambda: update_or_create_race_safe(
                     ItemProviderLink.objects,

--- a/src/app/services/metadata_resolution.py
+++ b/src/app/services/metadata_resolution.py
@@ -63,6 +63,16 @@ class MetadataProviderOption:
     label: str
 
 
+@dataclass(frozen=True, slots=True)
+class AnimeTMDBIdentity:
+    """One exact TMDB identity resolved from a MAL title."""
+
+    media_id: str
+    media_type: str
+    tvdb_id: str | None = None
+    imdb_id: str | None = None
+
+
 def provider_is_enabled(provider: str, user=None) -> bool:
     """Return whether a provider is configured for live use.
 
@@ -798,30 +808,125 @@ def _reconcile_competing_seasons(canonical_season, stray_season) -> None:
     canonical_season.save(update_fields=["status", "score", "notes"])
 
 
-def _tmdb_series_id_from_tvdb_id(tvdb_id: str) -> str | None:
-    """Return one exact TMDB TV result for a TVDB series ID."""
+def _tmdb_identity_from_external_id(
+    external_id: str,
+    external_source: str,
+    *,
+    allowed_media_types: tuple[str, ...],
+) -> AnimeTMDBIdentity | None:
+    """Return one exact TMDB result for an external provider ID."""
     from app.providers import tmdb
 
     try:
-        find_response = tmdb.find(tvdb_id, "tvdb_id")
+        find_response = tmdb.find(external_id, external_source)
     except services.ProviderAPIError:
         logger.warning(
-            "Skipping TMDB resolution for TVDB ID %s: provider request failed",
-            tvdb_id,
+            "Skipping TMDB resolution for %s=%s: provider request failed",
+            external_source,
+            external_id,
         )
         return None
 
-    tv_results = (
-        find_response.get("tv_results", [])
-        if isinstance(find_response, dict)
-        else []
-    )
-    tmdb_ids = {
-        str(result["id"])
-        for result in tv_results
+    if not isinstance(find_response, dict):
+        return None
+
+    result_keys = {
+        MediaTypes.TV.value: "tv_results",
+        MediaTypes.MOVIE.value: "movie_results",
+    }
+    identities = {
+        (str(result["id"]), media_type)
+        for media_type in allowed_media_types
+        for result in find_response.get(result_keys[media_type], [])
         if isinstance(result, dict) and result.get("id") not in (None, "")
     }
-    return tmdb_ids.pop() if len(tmdb_ids) == 1 else None
+    if len(identities) != 1:
+        return None
+
+    media_id, media_type = identities.pop()
+    return AnimeTMDBIdentity(media_id=media_id, media_type=media_type)
+
+
+def resolve_mal_tmdb_identity(mal_id: str | int) -> AnimeTMDBIdentity | None:
+    """Resolve one exact TMDB movie or TV identity for a MAL title."""
+    direct_tv_id = anime_mapping.resolve_provider_id(
+        mal_id,
+        Sources.TMDB.value,
+        media_type=MediaTypes.TV.value,
+    )
+    direct_movie_id = anime_mapping.resolve_provider_id(
+        mal_id,
+        Sources.TMDB.value,
+        media_type=MediaTypes.MOVIE.value,
+    )
+    direct_identities = {
+        (direct_tv_id, MediaTypes.TV.value) if direct_tv_id else None,
+        (direct_movie_id, MediaTypes.MOVIE.value) if direct_movie_id else None,
+    } - {None}
+    if len(direct_identities) == 1:
+        media_id, media_type = direct_identities.pop()
+        return AnimeTMDBIdentity(media_id=media_id, media_type=media_type)
+    if len(direct_identities) > 1:
+        return None
+
+    tvdb_id = anime_mapping.resolve_provider_id(mal_id, Sources.TVDB.value)
+    if tvdb_id:
+        identity = _tmdb_identity_from_external_id(
+            tvdb_id,
+            "tvdb_id",
+            allowed_media_types=(MediaTypes.TV.value,),
+        )
+        if identity:
+            return AnimeTMDBIdentity(
+                media_id=identity.media_id,
+                media_type=identity.media_type,
+                tvdb_id=tvdb_id,
+            )
+
+    imdb_id = anime_mapping.resolve_provider_id(mal_id, Sources.IMDB.value)
+    if not imdb_id:
+        return None
+    identity = _tmdb_identity_from_external_id(
+        imdb_id,
+        "imdb_id",
+        allowed_media_types=(MediaTypes.TV.value, MediaTypes.MOVIE.value),
+    )
+    if not identity:
+        return None
+    return AnimeTMDBIdentity(
+        media_id=identity.media_id,
+        media_type=identity.media_type,
+        tvdb_id=tvdb_id,
+        imdb_id=imdb_id,
+    )
+
+
+def persist_mal_tmdb_identity(
+    item: Item,
+    identity: AnimeTMDBIdentity,
+    *,
+    persistence_mode: str = "required",
+    retry_max_retries: int | None = None,
+    on_deferred: Callable[[Exception], None] | None = None,
+) -> None:
+    """Persist an exact MAL-to-TMDB identity through existing provider links."""
+    external_ids = {"tmdb_id": identity.media_id}
+    if identity.tvdb_id:
+        external_ids["tvdb_id"] = identity.tvdb_id
+    if identity.imdb_id:
+        external_ids["imdb_id"] = identity.imdb_id
+    upsert_provider_links(
+        item,
+        {
+            "media_id": identity.media_id,
+            "provider_external_ids": external_ids,
+        },
+        provider=Sources.TMDB.value,
+        provider_media_type=identity.media_type,
+        persistence_mode=persistence_mode,
+        retry_max_retries=retry_max_retries,
+        on_deferred=on_deferred,
+    )
 
 
 def resolve_provider_media_id(
@@ -864,7 +969,17 @@ def resolve_provider_media_id(
         return provider_link.provider_media_id
 
     external_key = PROVIDER_EXTERNAL_ID_KEYS.get(provider)
-    if external_key:
+    tmdb_id_is_known_movie = (
+        item.source == Sources.MAL.value
+        and route_media_type == MediaTypes.ANIME.value
+        and provider == Sources.TMDB.value
+        and ItemProviderLink.objects.filter(
+            item=item,
+            provider=Sources.TMDB.value,
+            provider_media_type=MediaTypes.MOVIE.value,
+        ).exists()
+    )
+    if external_key and not tmdb_id_is_known_movie:
         external_ids = item.provider_external_ids or {}
         if external_ids.get(external_key):
             return str(external_ids[external_key])
@@ -874,39 +989,25 @@ def resolve_provider_media_id(
         and route_media_type == MediaTypes.ANIME.value
         and provider in GROUPED_ANIME_PROVIDERS
     ):
+        if provider == Sources.TMDB.value:
+            identity = resolve_mal_tmdb_identity(item.media_id)
+            if not identity or identity.media_type != MediaTypes.TV.value:
+                return None
+            persist_mal_tmdb_identity(
+                item,
+                identity,
+                persistence_mode=persistence_mode,
+                retry_max_retries=retry_max_retries,
+                on_deferred=on_deferred,
+            )
+            return identity.media_id
+
         mapped_series_id = anime_mapping.resolve_provider_series_id(
             item.media_id,
             provider,
         )
-        mapped_tvdb_id = None
-        if not mapped_series_id and provider == Sources.TMDB.value:
-            mapped_tvdb_id = anime_mapping.resolve_provider_series_id(
-                item.media_id,
-                Sources.TVDB.value,
-            )
-            if mapped_tvdb_id:
-                mapped_series_id = _tmdb_series_id_from_tvdb_id(mapped_tvdb_id)
 
         if mapped_series_id:
-            if mapped_tvdb_id:
-                upsert_provider_links(
-                    item,
-                    {
-                        "media_id": str(mapped_series_id),
-                        "provider_external_ids": {
-                            "tmdb_id": str(mapped_series_id),
-                            "tvdb_id": str(mapped_tvdb_id),
-                        },
-                    },
-                    provider=Sources.TMDB.value,
-                    provider_media_type=provider_media_type,
-                    season_number=season_number,
-                    persistence_mode=persistence_mode,
-                    retry_max_retries=retry_max_retries,
-                    on_deferred=on_deferred,
-                )
-                return str(mapped_series_id)
-
             run_retryable_db_operation(
                 lambda: update_or_create_race_safe(
                     ItemProviderLink.objects,

--- a/src/app/services/metadata_resolution.py
+++ b/src/app/services/metadata_resolution.py
@@ -817,15 +817,7 @@ def _tmdb_identity_from_external_id(
     """Return one exact TMDB result for an external provider ID."""
     from app.providers import tmdb
 
-    try:
-        find_response = tmdb.find(external_id, external_source)
-    except services.ProviderAPIError:
-        logger.warning(
-            "Skipping TMDB resolution for %s=%s: provider request failed",
-            external_source,
-            external_id,
-        )
-        return None
+    find_response = tmdb.find(external_id, external_source)
 
     if not isinstance(find_response, dict):
         return None
@@ -990,7 +982,15 @@ def resolve_provider_media_id(
         and provider in GROUPED_ANIME_PROVIDERS
     ):
         if provider == Sources.TMDB.value:
-            identity = resolve_mal_tmdb_identity(item.media_id)
+            try:
+                identity = resolve_mal_tmdb_identity(item.media_id)
+            except services.ProviderAPIError:
+                logger.warning(
+                    "Skipping TMDB resolution for MAL anime media_id=%s: "
+                    "provider request failed",
+                    item.media_id,
+                )
+                return None
             if not identity or identity.media_type != MediaTypes.TV.value:
                 return None
             persist_mal_tmdb_identity(

--- a/src/app/tasks_backfill_state.py
+++ b/src/app/tasks_backfill_state.py
@@ -28,8 +28,8 @@ METADATA_BACKFILL_BASE_DELAY_SECONDS = 60 * 60  # 1 hour
 METADATA_BACKFILL_MAX_DELAY_SECONDS = 60 * 60 * 24  # 1 day
 METADATA_BACKFILL_MAX_ATTEMPTS = 6
 GENRE_BACKFILL_VERSION = 4
-# Bumped when empty TMDB payloads stopped counting as a completed backfill.
-WATCH_PROVIDERS_BACKFILL_VERSION = 2
+# Bumped when MAL anime became eligible for TMDB watch-provider enrichment.
+WATCH_PROVIDERS_BACKFILL_VERSION = 3
 EXTERNAL_IDS_BACKFILL_VERSION = 1
 
 

--- a/src/app/tasks_providers.py
+++ b/src/app/tasks_providers.py
@@ -103,13 +103,9 @@ def _populate_providers_for_items(items):
                 item.source == Sources.MAL.value
                 and item.media_type == MediaTypes.ANIME.value
             ):
-                provider_media_id = metadata_resolution.resolve_provider_media_id(
-                    item,
-                    Sources.TMDB.value,
-                    route_media_type=MediaTypes.ANIME.value,
-                )
+                identity = metadata_resolution.resolve_mal_tmdb_identity(item.media_id)
                 provider_source = Sources.TMDB.value
-                if not provider_media_id:
+                if not identity:
                     _record_backfill_pending(
                         item,
                         MetadataBackfillField.WATCH_PROVIDERS,
@@ -117,9 +113,14 @@ def _populate_providers_for_items(items):
                         strategy_version=WATCH_PROVIDERS_BACKFILL_VERSION,
                     )
                     continue
+                metadata_resolution.persist_mal_tmdb_identity(item, identity)
+                provider_media_id = identity.media_id
+                provider_media_type = identity.media_type
+            else:
+                provider_media_type = item.media_type.lower()
 
             metadata = services.get_media_metadata(
-                item.media_type.lower(),
+                provider_media_type,
                 provider_media_id,
                 provider_source,
             )

--- a/src/app/tasks_providers.py
+++ b/src/app/tasks_providers.py
@@ -17,6 +17,7 @@ from app.interactive_requests import interactive_request_active
 from app.log_safety import exception_summary
 from app.models import Item, MediaTypes, MetadataBackfillField, Sources
 from app.providers import services
+from app.services import metadata_resolution
 from app.task_cooperation import CooperativeRun
 from app.tasks_backfill_state import (
     WATCH_PROVIDERS_BACKFILL_VERSION,
@@ -51,14 +52,25 @@ RECONCILE_KEY = "watch_providers"
 RECONCILE_MAX_CHUNKS_PER_RUN = settings.RECONCILE_MAX_CHUNKS_PER_RUN
 
 
+def _provider_item_scope(prefix: str = ""):
+    """Return items whose watch providers can be supplied by TMDB."""
+    return Q(
+        **{
+            f"{prefix}source": Sources.TMDB.value,
+            f"{prefix}media_type__in": PROVIDER_MEDIA_TYPES,
+        },
+    ) | Q(
+        **{
+            f"{prefix}source": Sources.MAL.value,
+            f"{prefix}media_type": MediaTypes.ANIME.value,
+        },
+    )
+
+
 def _provider_items_queryset(*, for_reconcile: bool = False):
     from app.models import MetadataBackfillState
 
-    queryset = Item.objects.filter(
-        media_type__in=PROVIDER_MEDIA_TYPES,
-        source=Sources.TMDB.value,
-        watch_providers={},
-    )
+    queryset = Item.objects.filter(_provider_item_scope(), watch_providers={})
     queryset = _apply_backfill_state_filters(
         queryset,
         MetadataBackfillField.WATCH_PROVIDERS,
@@ -85,10 +97,31 @@ def _populate_providers_for_items(items):
     run = CooperativeRun("watch_providers_backfill")
     for item in run.iter(items):
         try:
+            provider_media_id = item.media_id
+            provider_source = item.source
+            if (
+                item.source == Sources.MAL.value
+                and item.media_type == MediaTypes.ANIME.value
+            ):
+                provider_media_id = metadata_resolution.resolve_provider_media_id(
+                    item,
+                    Sources.TMDB.value,
+                    route_media_type=MediaTypes.ANIME.value,
+                )
+                provider_source = Sources.TMDB.value
+                if not provider_media_id:
+                    _record_backfill_pending(
+                        item,
+                        MetadataBackfillField.WATCH_PROVIDERS,
+                        "no TMDB mapping",
+                        strategy_version=WATCH_PROVIDERS_BACKFILL_VERSION,
+                    )
+                    continue
+
             metadata = services.get_media_metadata(
                 item.media_type.lower(),
-                item.media_id,
-                item.source,
+                provider_media_id,
+                provider_source,
             )
             if not isinstance(metadata, dict):
                 error_count += 1
@@ -227,10 +260,9 @@ def enqueue_due_provider_backfill_retries(
             field=MetadataBackfillField.WATCH_PROVIDERS,
             give_up=False,
             last_success_at__isnull=True,
-            item__media_type__in=PROVIDER_MEDIA_TYPES,
-            item__source=Sources.TMDB.value,
             item__watch_providers={},
         )
+        .filter(_provider_item_scope("item__"))
         .filter(Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=now))
         .order_by("next_retry_at", "item_id")
         .values_list("item_id", flat=True)[:batch_size]

--- a/src/app/tasks_providers.py
+++ b/src/app/tasks_providers.py
@@ -106,10 +106,12 @@ def _populate_providers_for_items(items):
                 identity = metadata_resolution.resolve_mal_tmdb_identity(item.media_id)
                 provider_source = Sources.TMDB.value
                 if not identity:
-                    _record_backfill_pending(
+                    # No exact mapping is a completed result for this pinned
+                    # mapping strategy. A later strategy-version bump will
+                    # reconsider the item without retrying it every day now.
+                    _record_backfill_success(
                         item,
                         MetadataBackfillField.WATCH_PROVIDERS,
-                        "no TMDB mapping",
                         strategy_version=WATCH_PROVIDERS_BACKFILL_VERSION,
                     )
                     continue

--- a/src/app/tests/test_metadata_resolution.py
+++ b/src/app/tests/test_metadata_resolution.py
@@ -515,10 +515,10 @@ class MetadataResolutionTests(TestCase):
         )
 
     @patch("app.providers.tmdb.find")
-    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_series_id")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_id")
     def test_resolve_provider_media_id_maps_mal_to_tmdb_via_tvdb(
         self,
-        mock_resolve_provider_series_id,
+        mock_resolve_provider_id,
         mock_tmdb_find,
     ):
         """MAL anime should reuse exact TVDB IDs for TMDB resolution."""
@@ -528,7 +528,7 @@ class MetadataResolutionTests(TestCase):
             media_type=MediaTypes.ANIME.value,
             title="Frieren",
         )
-        mock_resolve_provider_series_id.side_effect = lambda _mal_id, provider: (
+        mock_resolve_provider_id.side_effect = lambda _mal_id, provider, **_kwargs: (
             "407407" if provider == Sources.TVDB.value else None
         )
         mock_tmdb_find.return_value = {"tv_results": [{"id": 209867}]}
@@ -554,10 +554,10 @@ class MetadataResolutionTests(TestCase):
         )
 
     @patch("app.providers.tmdb.find")
-    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_series_id")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_id")
     def test_resolve_provider_media_id_rejects_ambiguous_tvdb_lookup(
         self,
-        mock_resolve_provider_series_id,
+        mock_resolve_provider_id,
         mock_tmdb_find,
     ):
         """An ambiguous external-ID response must not persist a guessed TMDB ID."""
@@ -567,7 +567,7 @@ class MetadataResolutionTests(TestCase):
             media_type=MediaTypes.ANIME.value,
             title="Frieren",
         )
-        mock_resolve_provider_series_id.side_effect = lambda _mal_id, provider: (
+        mock_resolve_provider_id.side_effect = lambda _mal_id, provider, **_kwargs: (
             "407407" if provider == Sources.TVDB.value else None
         )
         mock_tmdb_find.return_value = {"tv_results": [{"id": 1}, {"id": 2}]}
@@ -587,10 +587,10 @@ class MetadataResolutionTests(TestCase):
         )
 
     @patch("app.providers.tmdb.find")
-    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_series_id")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_id")
     def test_resolve_provider_media_id_tolerates_tmdb_lookup_failure(
         self,
-        mock_resolve_provider_series_id,
+        mock_resolve_provider_id,
         mock_tmdb_find,
     ):
         """Provider enrichment must not make a MAL detail page unavailable."""
@@ -600,7 +600,7 @@ class MetadataResolutionTests(TestCase):
             media_type=MediaTypes.ANIME.value,
             title="Frieren",
         )
-        mock_resolve_provider_series_id.side_effect = lambda _mal_id, provider: (
+        mock_resolve_provider_id.side_effect = lambda _mal_id, provider, **_kwargs: (
             "407407" if provider == Sources.TVDB.value else None
         )
         mock_tmdb_find.side_effect = metadata_resolution.services.ProviderAPIError(
@@ -615,6 +615,53 @@ class MetadataResolutionTests(TestCase):
         )
 
         self.assertIsNone(provider_media_id)
+
+    @patch("app.providers.tmdb.find")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_id")
+    def test_resolve_mal_tmdb_identity_maps_movie_via_imdb(
+        self,
+        mock_resolve_provider_id,
+        mock_tmdb_find,
+    ):
+        mock_resolve_provider_id.side_effect = lambda _mal_id, provider, **_kwargs: (
+            "tt0245429" if provider == Sources.IMDB.value else None
+        )
+        mock_tmdb_find.return_value = {"movie_results": [{"id": 129}]}
+
+        identity = metadata_resolution.resolve_mal_tmdb_identity("199")
+
+        self.assertEqual(
+            identity,
+            metadata_resolution.AnimeTMDBIdentity(
+                media_id="129",
+                media_type=MediaTypes.MOVIE.value,
+                imdb_id="tt0245429",
+            ),
+        )
+        mock_tmdb_find.assert_called_once_with("tt0245429", "imdb_id")
+
+        item = Item.objects.create(
+            media_id="199",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Spirited Away",
+        )
+        metadata_resolution.persist_mal_tmdb_identity(item, identity)
+        self.assertIsNone(
+            metadata_resolution.resolve_provider_media_id(
+                item,
+                Sources.TMDB.value,
+                route_media_type=MediaTypes.ANIME.value,
+            ),
+        )
+        self.assertTrue(
+            ItemProviderLink.objects.filter(
+                item=item,
+                provider=Sources.TMDB.value,
+                provider_media_id="129",
+                provider_media_type=MediaTypes.MOVIE.value,
+            ).exists(),
+        )
 
     @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.services.metadata_resolution.services.get_media_metadata")

--- a/src/app/tests/test_metadata_resolution.py
+++ b/src/app/tests/test_metadata_resolution.py
@@ -514,6 +514,108 @@ class MetadataResolutionTests(TestCase):
             ).exists(),
         )
 
+    @patch("app.providers.tmdb.find")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_series_id")
+    def test_resolve_provider_media_id_maps_mal_to_tmdb_via_tvdb(
+        self,
+        mock_resolve_provider_series_id,
+        mock_tmdb_find,
+    ):
+        """MAL anime should reuse exact TVDB IDs for TMDB resolution."""
+        item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+        )
+        mock_resolve_provider_series_id.side_effect = lambda _mal_id, provider: (
+            "407407" if provider == Sources.TVDB.value else None
+        )
+        mock_tmdb_find.return_value = {"tv_results": [{"id": 209867}]}
+
+        provider_media_id = metadata_resolution.resolve_provider_media_id(
+            item,
+            Sources.TMDB.value,
+            route_media_type=MediaTypes.ANIME.value,
+        )
+
+        self.assertEqual(provider_media_id, "209867")
+        mock_tmdb_find.assert_called_once_with("407407", "tvdb_id")
+        item.refresh_from_db()
+        self.assertEqual(item.provider_external_ids["tvdb_id"], "407407")
+        self.assertEqual(item.provider_external_ids["tmdb_id"], "209867")
+        self.assertTrue(
+            ItemProviderLink.objects.filter(
+                item=item,
+                provider=Sources.TMDB.value,
+                provider_media_id="209867",
+                provider_media_type=MediaTypes.TV.value,
+            ).exists(),
+        )
+
+    @patch("app.providers.tmdb.find")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_series_id")
+    def test_resolve_provider_media_id_rejects_ambiguous_tvdb_lookup(
+        self,
+        mock_resolve_provider_series_id,
+        mock_tmdb_find,
+    ):
+        """An ambiguous external-ID response must not persist a guessed TMDB ID."""
+        item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+        )
+        mock_resolve_provider_series_id.side_effect = lambda _mal_id, provider: (
+            "407407" if provider == Sources.TVDB.value else None
+        )
+        mock_tmdb_find.return_value = {"tv_results": [{"id": 1}, {"id": 2}]}
+
+        provider_media_id = metadata_resolution.resolve_provider_media_id(
+            item,
+            Sources.TMDB.value,
+            route_media_type=MediaTypes.ANIME.value,
+        )
+
+        self.assertIsNone(provider_media_id)
+        self.assertFalse(
+            ItemProviderLink.objects.filter(
+                item=item,
+                provider=Sources.TMDB.value,
+            ).exists(),
+        )
+
+    @patch("app.providers.tmdb.find")
+    @patch("app.services.metadata_resolution.anime_mapping.resolve_provider_series_id")
+    def test_resolve_provider_media_id_tolerates_tmdb_lookup_failure(
+        self,
+        mock_resolve_provider_series_id,
+        mock_tmdb_find,
+    ):
+        """Provider enrichment must not make a MAL detail page unavailable."""
+        item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+        )
+        mock_resolve_provider_series_id.side_effect = lambda _mal_id, provider: (
+            "407407" if provider == Sources.TVDB.value else None
+        )
+        mock_tmdb_find.side_effect = metadata_resolution.services.ProviderAPIError(
+            Sources.TMDB.value,
+            RuntimeError("offline"),
+        )
+
+        provider_media_id = metadata_resolution.resolve_provider_media_id(
+            item,
+            Sources.TMDB.value,
+            route_media_type=MediaTypes.ANIME.value,
+        )
+
+        self.assertIsNone(provider_media_id)
+
     @override_settings(TVDB_API_KEY="test-tvdb-key")
     @patch("app.services.metadata_resolution.services.get_media_metadata")
     def test_resolve_detail_metadata_adds_grouped_preview_target_for_flat_mal_anime(

--- a/src/app/tests/test_tasks_providers.py
+++ b/src/app/tests/test_tasks_providers.py
@@ -25,7 +25,7 @@ class ProviderBackfillTaskTests(TestCase):
             tasks_providers.WATCH_PROVIDERS_BACKFILL_ITEMS_SCHEDULED_KEY,
         )
 
-    def test_provider_items_queryset_scopes_to_tmdb_movie_tv_anime_missing_data(self):
+    def test_provider_items_queryset_includes_tmdb_media_and_mal_anime(self):
         needs_backfill = Item.objects.create(
             media_id="2001",
             source=Sources.TMDB.value,
@@ -51,15 +51,97 @@ class ProviderBackfillTaskTests(TestCase):
             media_type=MediaTypes.BOOK.value,
             title="Not a supported provider type",
         )
+        mal_anime = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+        )
+        mal_manga = Item.objects.create(
+            media_id="2",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.MANGA.value,
+            title="Berserk",
+        )
 
         queryset_ids = set(
             tasks_providers._provider_items_queryset().values_list("id", flat=True)
         )
 
         self.assertIn(needs_backfill.id, queryset_ids)
+        self.assertIn(mal_anime.id, queryset_ids)
         self.assertNotIn(already_has_data.id, queryset_ids)
         self.assertNotIn(non_tmdb_item.id, queryset_ids)
         self.assertNotIn(unsupported_media_type.id, queryset_ids)
+        self.assertNotIn(mal_manga.id, queryset_ids)
+
+    @patch("app.tasks_providers.services.get_media_metadata")
+    @patch("app.tasks_providers.metadata_resolution.resolve_provider_media_id")
+    def test_populate_providers_for_mal_anime_uses_mapped_tmdb_series(
+        self,
+        mock_resolve_provider_media_id,
+        mock_get_metadata,
+    ):
+        item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+        )
+        mock_resolve_provider_media_id.return_value = "209867"
+        mock_get_metadata.return_value = {
+            "providers": {
+                "DE": {
+                    "flatrate": [
+                        {"provider_id": 283, "provider_name": "Crunchyroll"},
+                    ],
+                },
+            },
+        }
+
+        updated_count, error_count = tasks_providers._populate_providers_for_items(
+            [item]
+        )
+
+        self.assertEqual((updated_count, error_count), (1, 0))
+        mock_get_metadata.assert_called_once_with(
+            MediaTypes.ANIME.value,
+            "209867",
+            Sources.TMDB.value,
+        )
+        item.refresh_from_db()
+        self.assertEqual(
+            item.watch_providers["DE"]["flatrate"][0]["provider_name"],
+            "Crunchyroll",
+        )
+
+    @patch("app.tasks_providers.services.get_media_metadata")
+    @patch("app.tasks_providers.metadata_resolution.resolve_provider_media_id")
+    def test_populate_providers_for_unmapped_mal_anime_retries_later(
+        self,
+        mock_resolve_provider_media_id,
+        mock_get_metadata,
+    ):
+        item = Item.objects.create(
+            media_id="62811",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Unmapped Anime",
+        )
+        mock_resolve_provider_media_id.return_value = None
+
+        updated_count, error_count = tasks_providers._populate_providers_for_items(
+            [item]
+        )
+
+        self.assertEqual((updated_count, error_count), (0, 0))
+        mock_get_metadata.assert_not_called()
+        state = MetadataBackfillState.objects.get(
+            item=item,
+            field=MetadataBackfillField.WATCH_PROVIDERS,
+        )
+        self.assertEqual(state.last_error, "no TMDB mapping")
+        self.assertIsNotNone(state.next_retry_at)
 
     @patch("app.tasks_providers.services.get_media_metadata")
     def test_populate_providers_for_items_persists_watch_providers(

--- a/src/app/tests/test_tasks_providers.py
+++ b/src/app/tests/test_tasks_providers.py
@@ -8,11 +8,13 @@ from app import backfill_queue, tasks_providers
 from app.models import (
     BackfillReconcileState,
     Item,
+    ItemProviderLink,
     MediaTypes,
     MetadataBackfillField,
     MetadataBackfillState,
     Sources,
 )
+from app.services import metadata_resolution
 from app.tasks_backfill_state import METADATA_BACKFILL_MAX_ATTEMPTS
 from app.tasks_providers import RECONCILE_KEY
 
@@ -76,10 +78,10 @@ class ProviderBackfillTaskTests(TestCase):
         self.assertNotIn(mal_manga.id, queryset_ids)
 
     @patch("app.tasks_providers.services.get_media_metadata")
-    @patch("app.tasks_providers.metadata_resolution.resolve_provider_media_id")
+    @patch("app.tasks_providers.metadata_resolution.resolve_mal_tmdb_identity")
     def test_populate_providers_for_mal_anime_uses_mapped_tmdb_series(
         self,
-        mock_resolve_provider_media_id,
+        mock_resolve_mal_tmdb_identity,
         mock_get_metadata,
     ):
         item = Item.objects.create(
@@ -88,7 +90,13 @@ class ProviderBackfillTaskTests(TestCase):
             media_type=MediaTypes.ANIME.value,
             title="Frieren",
         )
-        mock_resolve_provider_media_id.return_value = "209867"
+        mock_resolve_mal_tmdb_identity.return_value = (
+            metadata_resolution.AnimeTMDBIdentity(
+                media_id="209867",
+                media_type=MediaTypes.TV.value,
+                tvdb_id="407407",
+            )
+        )
         mock_get_metadata.return_value = {
             "providers": {
                 "DE": {
@@ -105,7 +113,7 @@ class ProviderBackfillTaskTests(TestCase):
 
         self.assertEqual((updated_count, error_count), (1, 0))
         mock_get_metadata.assert_called_once_with(
-            MediaTypes.ANIME.value,
+            MediaTypes.TV.value,
             "209867",
             Sources.TMDB.value,
         )
@@ -116,10 +124,59 @@ class ProviderBackfillTaskTests(TestCase):
         )
 
     @patch("app.tasks_providers.services.get_media_metadata")
-    @patch("app.tasks_providers.metadata_resolution.resolve_provider_media_id")
+    @patch("app.tasks_providers.metadata_resolution.resolve_mal_tmdb_identity")
+    def test_populate_providers_for_mal_anime_movie_uses_tmdb_movie(
+        self,
+        mock_resolve_mal_tmdb_identity,
+        mock_get_metadata,
+    ):
+        item = Item.objects.create(
+            media_id="199",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Spirited Away",
+        )
+        mock_resolve_mal_tmdb_identity.return_value = (
+            metadata_resolution.AnimeTMDBIdentity(
+                media_id="129",
+                media_type=MediaTypes.MOVIE.value,
+                imdb_id="tt0245429",
+            )
+        )
+        mock_get_metadata.return_value = {
+            "providers": {
+                "DE": {
+                    "flatrate": [
+                        {"provider_id": 8, "provider_name": "Netflix"},
+                    ],
+                },
+            },
+        }
+
+        updated_count, error_count = tasks_providers._populate_providers_for_items(
+            [item]
+        )
+
+        self.assertEqual((updated_count, error_count), (1, 0))
+        mock_get_metadata.assert_called_once_with(
+            MediaTypes.MOVIE.value,
+            "129",
+            Sources.TMDB.value,
+        )
+        self.assertTrue(
+            ItemProviderLink.objects.filter(
+                item=item,
+                provider=Sources.TMDB.value,
+                provider_media_id="129",
+                provider_media_type=MediaTypes.MOVIE.value,
+            ).exists(),
+        )
+
+    @patch("app.tasks_providers.services.get_media_metadata")
+    @patch("app.tasks_providers.metadata_resolution.resolve_mal_tmdb_identity")
     def test_populate_providers_for_unmapped_mal_anime_retries_later(
         self,
-        mock_resolve_provider_media_id,
+        mock_resolve_mal_tmdb_identity,
         mock_get_metadata,
     ):
         item = Item.objects.create(
@@ -128,7 +185,7 @@ class ProviderBackfillTaskTests(TestCase):
             media_type=MediaTypes.ANIME.value,
             title="Unmapped Anime",
         )
-        mock_resolve_provider_media_id.return_value = None
+        mock_resolve_mal_tmdb_identity.return_value = None
 
         updated_count, error_count = tasks_providers._populate_providers_for_items(
             [item]

--- a/src/app/tests/test_tasks_providers.py
+++ b/src/app/tests/test_tasks_providers.py
@@ -14,6 +14,7 @@ from app.models import (
     MetadataBackfillState,
     Sources,
 )
+from app.providers import services
 from app.services import metadata_resolution
 from app.tasks_backfill_state import METADATA_BACKFILL_MAX_ATTEMPTS
 from app.tasks_providers import RECONCILE_KEY
@@ -174,7 +175,7 @@ class ProviderBackfillTaskTests(TestCase):
 
     @patch("app.tasks_providers.services.get_media_metadata")
     @patch("app.tasks_providers.metadata_resolution.resolve_mal_tmdb_identity")
-    def test_populate_providers_for_unmapped_mal_anime_retries_later(
+    def test_populate_providers_for_unmapped_mal_anime_completes_strategy(
         self,
         mock_resolve_mal_tmdb_identity,
         mock_get_metadata,
@@ -197,7 +198,43 @@ class ProviderBackfillTaskTests(TestCase):
             item=item,
             field=MetadataBackfillField.WATCH_PROVIDERS,
         )
-        self.assertEqual(state.last_error, "no TMDB mapping")
+        self.assertEqual(
+            state.strategy_version,
+            tasks_providers.WATCH_PROVIDERS_BACKFILL_VERSION,
+        )
+        self.assertIsNotNone(state.last_success_at)
+        self.assertIsNone(state.next_retry_at)
+
+    @patch("app.tasks_providers.services.get_media_metadata")
+    @patch("app.tasks_providers.metadata_resolution.resolve_mal_tmdb_identity")
+    def test_populate_providers_for_mal_mapping_failure_retries_later(
+        self,
+        mock_resolve_mal_tmdb_identity,
+        mock_get_metadata,
+    ):
+        item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+        )
+        mock_resolve_mal_tmdb_identity.side_effect = services.ProviderAPIError(
+            Sources.TMDB.value,
+            RuntimeError("offline"),
+        )
+
+        updated_count, error_count = tasks_providers._populate_providers_for_items(
+            [item]
+        )
+
+        self.assertEqual((updated_count, error_count), (0, 1))
+        mock_get_metadata.assert_not_called()
+        state = MetadataBackfillState.objects.get(
+            item=item,
+            field=MetadataBackfillField.WATCH_PROVIDERS,
+        )
+        self.assertEqual(state.fail_count, 1)
+        self.assertIsNone(state.last_success_at)
         self.assertIsNotNone(state.next_retry_at)
 
     @patch("app.tasks_providers.services.get_media_metadata")

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -57,7 +57,7 @@ from app.models import (
 )
 from app.providers import services, tmdb
 from app.services import game_lengths as game_length_services
-from app.services.metadata_resolution import MetadataResolutionResult
+from app.services.metadata_resolution import AnimeTMDBIdentity, MetadataResolutionResult
 from integrations.models import PlexAccount
 from lists.models import CustomList, CustomListItem
 from users.models import DateFormatChoices, RatingScaleChoices, TimeFormatChoices
@@ -2796,12 +2796,12 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.context["watch_providers"])
 
-    @patch("app.views.metadata_resolution.resolve_provider_media_id")
+    @patch("app.views.metadata_resolution.resolve_mal_tmdb_identity")
     @patch("app.providers.services.get_media_metadata")
     def test_media_details_enriches_mal_anime_with_tmdb_watch_providers(
         self,
         mock_get_metadata,
-        mock_resolve_provider_media_id,
+        mock_resolve_mal_tmdb_identity,
     ):
         """A tracked MAL anime should use its mapped TMDB provider payload."""
         self.user.watch_provider_region = "DE"
@@ -2849,7 +2849,11 @@ class MediaDetailsViewTests(TestCase):
         mock_get_metadata.side_effect = lambda *args, **_kwargs: (
             tmdb_metadata if args[2] == Sources.TMDB.value else mal_metadata
         )
-        mock_resolve_provider_media_id.return_value = "209867"
+        mock_resolve_mal_tmdb_identity.return_value = AnimeTMDBIdentity(
+            media_id="209867",
+            media_type=MediaTypes.TV.value,
+            tvdb_id="407407",
+        )
 
         response = self.client.get(
             reverse(
@@ -2865,12 +2869,219 @@ class MediaDetailsViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["watch_providers"][0]["provider_name"], "Crunchyroll")
+        self.assertEqual(
+            response.context["watch_providers"][0]["provider_name"], "Crunchyroll"
+        )
         item.refresh_from_db()
         self.assertEqual(
             item.watch_providers["DE"]["flatrate"][0]["provider_name"],
             "Crunchyroll",
         )
+
+    @patch("app.views.metadata_resolution.resolve_mal_tmdb_identity")
+    @patch("app.providers.services.get_media_metadata")
+    def test_untracked_mal_anime_details_show_series_and_movie_providers(
+        self,
+        mock_get_metadata,
+        mock_resolve_mal_tmdb_identity,
+    ):
+        """Search results should show providers before an anime is tracked."""
+        self.user.watch_provider_region = "DE"
+        self.user.save(update_fields=["watch_provider_region"])
+        cases = (
+            (
+                "52991",
+                "Frieren",
+                AnimeTMDBIdentity(
+                    media_id="209867",
+                    media_type=MediaTypes.TV.value,
+                    tvdb_id="407407",
+                ),
+                "Crunchyroll",
+            ),
+            (
+                "199",
+                "Spirited Away",
+                AnimeTMDBIdentity(
+                    media_id="129",
+                    media_type=MediaTypes.MOVIE.value,
+                    imdb_id="tt0245429",
+                ),
+                "Netflix",
+            ),
+        )
+
+        for mal_id, title, identity, provider_name in cases:
+            with self.subTest(title=title):
+                mock_get_metadata.reset_mock()
+                mock_resolve_mal_tmdb_identity.reset_mock()
+                mock_resolve_mal_tmdb_identity.return_value = identity
+
+                def metadata_side_effect(
+                    media_type,
+                    media_id,
+                    source,
+                    expected_identity=identity,
+                    expected_mal_id=mal_id,
+                    expected_title=title,
+                    expected_provider_name=provider_name,
+                    **_kwargs,
+                ):
+                    if source == Sources.TMDB.value:
+                        self.assertEqual(media_type, expected_identity.media_type)
+                        self.assertEqual(media_id, expected_identity.media_id)
+                        return {
+                            "providers": {
+                                "DE": {
+                                    "flatrate": [
+                                        {
+                                            "provider_id": 8,
+                                            "provider_name": expected_provider_name,
+                                            "logo_path": "/provider.jpg",
+                                        },
+                                    ],
+                                },
+                            },
+                        }
+                    return {
+                        "media_id": expected_mal_id,
+                        "title": expected_title,
+                        "media_type": MediaTypes.ANIME.value,
+                        "source": Sources.MAL.value,
+                        "image": "https://example.com/anime.jpg",
+                        "details": {},
+                        "related": {},
+                        "cast": [],
+                        "crew": [],
+                        "studios_full": [],
+                    }
+
+                mock_get_metadata.side_effect = metadata_side_effect
+                response = self.client.get(
+                    reverse(
+                        "media_details",
+                        kwargs={
+                            "source": Sources.MAL.value,
+                            "media_type": MediaTypes.ANIME.value,
+                            "media_id": mal_id,
+                            "title": title.lower().replace(" ", "-"),
+                        },
+                    ),
+                    {"fragment": "secondary"},
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.context["watch_providers"][0]["provider_name"],
+                    provider_name,
+                )
+                self.assertFalse(
+                    Item.objects.filter(
+                        media_id=mal_id,
+                        source=Sources.MAL.value,
+                        media_type=MediaTypes.ANIME.value,
+                    ).exists(),
+                )
+
+    @patch("app.views.metadata_resolution.resolve_mal_tmdb_identity")
+    @patch("app.providers.services.get_media_metadata")
+    def test_untracked_mal_anime_details_tolerate_mapping_failure(
+        self,
+        mock_get_metadata,
+        mock_resolve_mal_tmdb_identity,
+    ):
+        """Optional provider enrichment must not make MAL details unavailable."""
+        mock_get_metadata.return_value = {
+            "media_id": "4081",
+            "title": "Natsume's Book of Friends",
+            "media_type": MediaTypes.ANIME.value,
+            "source": Sources.MAL.value,
+            "image": "https://example.com/natsume.jpg",
+            "details": {"episodes": 13},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        mock_resolve_mal_tmdb_identity.side_effect = services.ProviderAPIError(
+            "ANIME_MAPPING",
+            RuntimeError("offline"),
+        )
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.MAL.value,
+                    "media_type": MediaTypes.ANIME.value,
+                    "media_id": "4081",
+                    "title": "natsume-yuujinchou",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["watch_providers"])
+
+    @patch("app.views.metadata_resolution.resolve_mal_tmdb_identity", return_value=None)
+    @patch("app.media_details_views._build_flat_anime_episode_preview")
+    @patch("app.providers.services.get_media_metadata")
+    def test_mal_anime_collection_stats_count_flat_episode_preview(
+        self,
+        mock_get_metadata,
+        mock_build_flat_anime_episode_preview,
+        _mock_resolve_mal_tmdb_identity,
+    ):
+        """A flat episode preview must be counted, not rendered as the total."""
+        Item.objects.create(
+            media_id="4081",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Natsume's Book of Friends",
+            image="https://example.com/natsume.jpg",
+        )
+        mock_get_metadata.return_value = {
+            "media_id": "4081",
+            "title": "Natsume's Book of Friends",
+            "media_type": MediaTypes.ANIME.value,
+            "source": Sources.MAL.value,
+            "image": "https://example.com/natsume.jpg",
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+            "providers": {},
+        }
+        mock_build_flat_anime_episode_preview.return_value = [
+            {
+                "media_id": "4081",
+                "media_type": MediaTypes.EPISODE.value,
+                "source": Sources.MAL.value,
+                "season_number": 1,
+                "episode_number": episode_number,
+                "title": f"Episode {episode_number}",
+            }
+            for episode_number in range(1, 4)
+        ]
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.MAL.value,
+                    "media_type": MediaTypes.ANIME.value,
+                    "media_id": "4081",
+                    "title": "natsume-yuujinchou",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["collection_stats"]["total_episodes"], 3)
+        self.assertContains(response, "0/3")
 
     @patch("app.providers.services.get_media_metadata")
     def test_media_details_persists_movie_recommendation_metadata(

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -2796,6 +2796,82 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.context["watch_providers"])
 
+    @patch("app.views.metadata_resolution.resolve_provider_media_id")
+    @patch("app.providers.services.get_media_metadata")
+    def test_media_details_enriches_mal_anime_with_tmdb_watch_providers(
+        self,
+        mock_get_metadata,
+        mock_resolve_provider_media_id,
+    ):
+        """A tracked MAL anime should use its mapped TMDB provider payload."""
+        self.user.watch_provider_region = "DE"
+        self.user.save(update_fields=["watch_provider_region"])
+        item = Item.objects.create(
+            media_id="52991",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Frieren",
+            image="https://example.com/frieren.jpg",
+        )
+        Anime.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.PLANNING.value,
+        )
+        mal_metadata = {
+            "media_id": "52991",
+            "title": "Frieren",
+            "media_type": MediaTypes.ANIME.value,
+            "source": Sources.MAL.value,
+            "image": "https://example.com/frieren.jpg",
+            "details": {"episodes": 28},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        tmdb_metadata = {
+            **mal_metadata,
+            "media_id": "209867",
+            "source": Sources.TMDB.value,
+            "providers": {
+                "DE": {
+                    "flatrate": [
+                        {
+                            "provider_id": 283,
+                            "provider_name": "Crunchyroll",
+                            "logo_path": "/crunchyroll.jpg",
+                        },
+                    ],
+                },
+            },
+        }
+        mock_get_metadata.side_effect = lambda *args, **_kwargs: (
+            tmdb_metadata if args[2] == Sources.TMDB.value else mal_metadata
+        )
+        mock_resolve_provider_media_id.return_value = "209867"
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.MAL.value,
+                    "media_type": MediaTypes.ANIME.value,
+                    "media_id": "52991",
+                    "title": "frieren",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["watch_providers"][0]["provider_name"], "Crunchyroll")
+        item.refresh_from_db()
+        self.assertEqual(
+            item.watch_providers["DE"]["flatrate"][0]["provider_name"],
+            "Crunchyroll",
+        )
+
     @patch("app.providers.services.get_media_metadata")
     def test_media_details_persists_movie_recommendation_metadata(
         self, mock_get_metadata

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -2869,6 +2869,14 @@ class MediaDetailsViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'data-watch-providers-placement="desktop"',
+        )
+        self.assertContains(
+            response,
+            'data-watch-providers-placement="mobile"',
+        )
         self.assertEqual(
             response.context["watch_providers"][0]["provider_name"], "Crunchyroll"
         )

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -2999,6 +2999,8 @@ class MediaDetailsViewTests(TestCase):
         mock_resolve_mal_tmdb_identity,
     ):
         """Optional provider enrichment must not make MAL details unavailable."""
+        self.user.watch_provider_region = "DE"
+        self.user.save(update_fields=["watch_provider_region"])
         mock_get_metadata.return_value = {
             "media_id": "4081",
             "title": "Natsume's Book of Friends",
@@ -3032,23 +3034,16 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.context["watch_providers"])
 
-    @patch("app.views.metadata_resolution.resolve_mal_tmdb_identity", return_value=None)
-    @patch("app.media_details_views._build_flat_anime_episode_preview")
+    @patch("app.views.metadata_resolution.resolve_mal_tmdb_identity")
     @patch("app.providers.services.get_media_metadata")
-    def test_mal_anime_collection_stats_count_flat_episode_preview(
+    def test_untracked_mal_anime_skips_provider_resolution_when_region_disabled(
         self,
         mock_get_metadata,
-        mock_build_flat_anime_episode_preview,
-        _mock_resolve_mal_tmdb_identity,
+        mock_resolve_mal_tmdb_identity,
     ):
-        """A flat episode preview must be counted, not rendered as the total."""
-        Item.objects.create(
-            media_id="4081",
-            source=Sources.MAL.value,
-            media_type=MediaTypes.ANIME.value,
-            title="Natsume's Book of Friends",
-            image="https://example.com/natsume.jpg",
-        )
+        """A disabled provider region must not trigger MAL-to-TMDB lookups."""
+        self.user.watch_provider_region = "UNSET"
+        self.user.save(update_fields=["watch_provider_region"])
         mock_get_metadata.return_value = {
             "media_id": "4081",
             "title": "Natsume's Book of Friends",
@@ -3060,19 +3055,7 @@ class MediaDetailsViewTests(TestCase):
             "cast": [],
             "crew": [],
             "studios_full": [],
-            "providers": {},
         }
-        mock_build_flat_anime_episode_preview.return_value = [
-            {
-                "media_id": "4081",
-                "media_type": MediaTypes.EPISODE.value,
-                "source": Sources.MAL.value,
-                "season_number": 1,
-                "episode_number": episode_number,
-                "title": f"Episode {episode_number}",
-            }
-            for episode_number in range(1, 4)
-        ]
 
         response = self.client.get(
             reverse(
@@ -3088,8 +3071,8 @@ class MediaDetailsViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["collection_stats"]["total_episodes"], 3)
-        self.assertContains(response, "0/3")
+        self.assertIsNone(response.context["watch_providers"])
+        mock_resolve_mal_tmdb_identity.assert_not_called()
 
     @patch("app.providers.services.get_media_metadata")
     def test_media_details_persists_movie_recommendation_metadata(

--- a/src/integrations/anime_mapping.py
+++ b/src/integrations/anime_mapping.py
@@ -506,23 +506,34 @@ def find_entries_for_mal_id(mal_id: str | int) -> list[dict[str, Any]]:
     return list(load_mapping_snapshot().mal_index.get(normalized, ()))
 
 
+def resolve_provider_id(
+    mal_id: str | int,
+    provider: str,
+    *,
+    media_type: str | None = None,
+) -> str | None:
+    """Resolve one unambiguous provider ID for a MAL title."""
+    fields = {
+        "tvdb": ("tvdb_id",),
+        "imdb": ("imdb_id",),
+        "tmdb": (
+            ("tmdb_movie_id",)
+            if media_type == "movie"
+            else ("tmdb_show_id", "tmdb_id", "tmdb_tv_id")
+        ),
+    }.get(provider)
+    if not fields:
+        return None
+
+    provider_ids = {
+        provider_id
+        for entry in find_entries_for_mal_id(mal_id)
+        for field in fields
+        for provider_id in _normalize_ids(entry.get(field))
+    }
+    return provider_ids.pop() if len(provider_ids) == 1 else None
+
+
 def resolve_provider_series_id(mal_id: str | int, provider: str) -> str | None:
     """Resolve a grouped-provider series ID for a MAL title."""
-    entries = find_entries_for_mal_id(mal_id)
-    if not entries:
-        return None
-
-    if provider == "tvdb":
-        for entry in entries:
-            if entry.get("tvdb_id") not in (None, ""):
-                return str(entry["tvdb_id"])
-        return None
-
-    if provider == "tmdb":
-        for key in ("tmdb_show_id", "tmdb_id", "tmdb_tv_id"):
-            for entry in entries:
-                if entry.get(key) not in (None, ""):
-                    return str(entry[key])
-        return None
-
-    return None
+    return resolve_provider_id(mal_id, provider, media_type="tv")

--- a/src/integrations/tests/test_anime_mapping.py
+++ b/src/integrations/tests/test_anime_mapping.py
@@ -103,6 +103,42 @@ class AnimeMappingSnapshotTests(SimpleTestCase):
 
             self.assertEqual(anime_mapping.find_entries_for_mal_id("missing"), [])
 
+    def test_resolve_provider_id_supports_anime_movies_and_imdb(self):
+        with patch.object(
+            anime_mapping,
+            "find_entries_for_mal_id",
+            return_value=[
+                {
+                    "mal_id": "199",
+                    "tmdb_movie_id": "129",
+                    "imdb_id": "tt0245429",
+                },
+            ],
+        ):
+            self.assertEqual(
+                anime_mapping.resolve_provider_id(
+                    "199",
+                    "tmdb",
+                    media_type="movie",
+                ),
+                "129",
+            )
+            self.assertEqual(
+                anime_mapping.resolve_provider_id("199", "imdb"),
+                "tt0245429",
+            )
+
+    def test_resolve_provider_id_rejects_ambiguous_mapping(self):
+        with patch.object(
+            anime_mapping,
+            "find_entries_for_mal_id",
+            return_value=[
+                {"mal_id": "199", "imdb_id": "tt0000001"},
+                {"mal_id": "199", "imdb_id": "tt0000002"},
+            ],
+        ):
+            self.assertIsNone(anime_mapping.resolve_provider_id("199", "imdb"))
+
     @tag("slow", "benchmark")
     def test_mal_index_lookup_is_bounded_for_large_mapping(self):
         """Regression for #995: the MAL lookup must be O(1), not a full scan.

--- a/src/integrations/tests/test_anime_mapping.py
+++ b/src/integrations/tests/test_anime_mapping.py
@@ -104,16 +104,17 @@ class AnimeMappingSnapshotTests(SimpleTestCase):
             self.assertEqual(anime_mapping.find_entries_for_mal_id("missing"), [])
 
     def test_resolve_provider_id_supports_anime_movies_and_imdb(self):
+        mapping = {
+            "movie": {
+                "mal_id": "199",
+                "tmdb_movie_id": "129",
+                "imdb_id": "tt0245429",
+            }
+        }
         with patch.object(
             anime_mapping,
-            "find_entries_for_mal_id",
-            return_value=[
-                {
-                    "mal_id": "199",
-                    "tmdb_movie_id": "129",
-                    "imdb_id": "tt0245429",
-                },
-            ],
+            "_load_source_data",
+            return_value=(mapping, "revision-a", "digest-a"),
         ):
             self.assertEqual(
                 anime_mapping.resolve_provider_id(

--- a/src/templates/app/components/detail_secondary_content.html
+++ b/src/templates/app/components/detail_secondary_content.html
@@ -135,23 +135,9 @@
 
       {# Media Details #}
       <h2 class="text-xl font-bold mb-4">{% translate "Details" %}</h2>
-      {% if watch_provider_region != "UNSET" and watch_providers is not None %}
-        <div class="bg-[var(--color-surface)] p-4 rounded-lg my-4">
-          <h3 class="text-sm font-semibold text-[var(--color-text-muted)] mb-2">{% translate "STREAMING" %}</h3>
-          <div class="flex flex-wrap items-center gap-2 place-content-evenly">
-            {% if watch_providers %}
-              {% for provider in watch_providers %}
-                <img class="size-10 rounded-md"
-                     src="{{ provider.image|image_url }}"
-                     title="{{ provider.provider_name }}"
-                     alt="{{ provider.provider_name }}" />
-              {% endfor %}
-            {% else %}
-              <p>{% translate "No watch providers" %}</p>
-            {% endif %}
-          </div>
-        </div>
-      {% endif %}
+      <div class="hidden md:block">
+        {% include "app/components/detail_watch_providers.html" with placement="desktop" %}
+      </div>
 
       <div class="bg-[var(--color-surface)] p-4 rounded-lg text-center md:text-start">
         {% if media.details.items %}
@@ -551,6 +537,10 @@
         {% include "app/components/detail_notes_section.html" %}
       </div>
     {% endif %}
+
+    <div class="md:hidden">
+      {% include "app/components/detail_watch_providers.html" with placement="mobile" %}
+    </div>
 
   </div>
 {% if media.episodes or episodes %}

--- a/src/templates/app/components/detail_watch_providers.html
+++ b/src/templates/app/components/detail_watch_providers.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% load app_tags %}
+
+{% if watch_provider_region != "UNSET" and watch_providers is not None %}
+  <div class="bg-[var(--color-surface)] p-4 rounded-lg my-4"
+       data-watch-providers-placement="{{ placement }}">
+    <h3 class="text-sm font-semibold text-[var(--color-text-muted)] mb-2">{% translate "STREAMING" %}</h3>
+    <div class="flex flex-wrap items-center gap-2 place-content-evenly">
+      {% if watch_providers %}
+        {% for provider in watch_providers %}
+          <img class="size-10 rounded-md"
+               src="{{ provider.image|image_url }}"
+               title="{{ provider.provider_name }}"
+               alt="{{ provider.provider_name }}" />
+        {% endfor %}
+      {% else %}
+        <p>{% translate "No watch providers" %}</p>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
## Summary

- Keep MyAnimeList as the metadata and tracking identity for anime while enriching MAL detail pages with TMDB's regional watch-provider data when an exact mapping exists.
- Resolve exact MAL-to-TMDB TV or movie identities through the pinned Anime-IDs mapping, with exact TVDB/IMDb external-ID lookup fallbacks. Missing or ambiguous mappings fail closed; no fuzzy title matching is used.
- Show streaming providers for tracked and untracked MAL anime, including anime movies, using the user's existing Watch Provider Region and Floppy's existing provider display and filtering pipeline.
- Reuse the same streaming component in the existing details column on desktop and place it directly below the synopsis on mobile.
- Persist exact provider links, cache provider payloads for tracked items, and include MAL anime in the existing bounded background backfill and retry flow.
- Skip MAL-to-TMDB provider resolution entirely when the user has disabled the Watch Provider Region setting.
- Treat a missing exact mapping as complete for the pinned mapping strategy, while temporary provider failures keep the existing bounded retry behavior.

## Screenshots

### Desktop

<img width="3804" height="1890" alt="grafik" src="https://github.com/user-attachments/assets/477af5b9-74ac-457e-81ee-d8e25c6caa4b" />

### Mobile

<img width="1080" height="2340" alt="Screenshot_20260910_091241_Firefox" src="https://github.com/user-attachments/assets/3964dfba-0ae2-4e5e-b511-033102f5ba2d" />


## AI Assistance

- OpenAI `gpt-5` (Codex) shaped the implementation, tests, final code review, and PR preparation.
- Workflows used: targeted and full automated test runs, Ruff and domain-vocabulary checks, diff review against `latest`, and manual browser QA on desktop and mobile.

## How It Was Tested

- `SECRET=test-only scripts/test.sh integrations.tests.test_anime_mapping app.tests.test_metadata_resolution app.tests.test_tasks_providers app.tests.views.test_media_details` -> 222 tests passed.
- `SECRET=test-only scripts/test.sh` -> all non-socket tests passed (5,724 passed, 15 sandbox-blocked, 4 skipped); the affected socket module was then rerun without the sandbox restriction.
- `SECRET=test-only scripts/test.sh config.tests.test_sqlite_recovery_server` -> 32 tests passed.
- `uv run --no-sync ruff check src` -> passed.
- `PYTHONPATH=src uv run --no-sync python -m app.domain_vocabulary --check` -> passed.
- Manual QA covered tracked and untracked MAL anime, anime movies, successful and unavailable mappings, regional provider filtering, and desktop/mobile layouts. On mobile, the Streaming section appears directly below the synopsis.

## Public API & Documentation Handoff

- [x] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance

- [x] Code review completed
- [x] Visual or manual QA verified (browser testing)

## Database & Migration Safety (Only if modifying models)

- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues

- No linked issue.
