### PR TITLE
fix: tolerate rows without title_main in _scrollable_row (#1139)

### DIFF
--- a/src/app/tests/test_horizontal_scroll.py
+++ b/src/app/tests/test_horizontal_scroll.py
@@ -17,7 +17,11 @@ class HorizontalScrollContractTests(SimpleTestCase):
         self.assertIn('data-horizontal-drag="true"', row)
         self.assertIn('tabindex="0"', row)
         self.assertIn('role="region"', row)
-        self.assertIn('aria-label="{{ row.title|default:row.title_main }}"', row)
+        self.assertIn('aria-label="{% firstof row.title row.title_main %}"', row)
+        # Filter arguments raise VariableDoesNotExist when the key is missing,
+        # so the label must not resolve row.title_main as a `default` argument:
+        # rows built outside the home screen only carry `title`. See #1139.
+        self.assertNotIn("default:row.title_main", row)
 
     def test_base_loads_the_horizontal_drag_controller_once(self):
         base = self.read("templates/base.html")

--- a/src/templates/app/components/_scrollable_row.html
+++ b/src/templates/app/components/_scrollable_row.html
@@ -139,7 +139,7 @@
        data-horizontal-drag="true"
        tabindex="0"
        role="region"
-       aria-label="{{ row.title|default:row.title_main }}"
+       aria-label="{% firstof row.title row.title_main %}"
        data-loaded-count="{{ row.loaded_count }}"
        data-loading="false"
        data-row-id="{{ row.row_id }}"


### PR DESCRIPTION
# PR title

fix: tolerate rows without `title_main` in `_scrollable_row` (#1139)

# PR body

Fixes #1139.

## Cause

`src/templates/app/components/_scrollable_row.html` labels the scroll region with:

```django
aria-label="{{ row.title|default:row.title_main }}"
```

`row.title_main` sits in an **argument** position. Django treats that differently from a variable in an output slot: a missing variable falls back to `string_if_invalid`, but `FilterExpression.resolve()` calls `arg.resolve(context)` directly for filter arguments and lets `VariableDoesNotExist` propagate. So any caller whose row dict has no `title_main` key gets a 500 instead of an empty label.

Only the home screen builds its rows through `_build_row_section()`, which sets `title_main` / `title_detail` via `home_row_header_title_parts()`. The statistics fragments (`statistics_views.py`) and the person media strips on media detail pages assemble their row dicts inline and carry `title` only — see the failing context in the issue:

```
{'row_id': 'person-media-strip', 'title': "Aaron Moten's Titles", 'summary': '1 title · sorted by plays', ...}
```

Result: every request to `/statistics/fragments/*` and to a detail page with a cast strip returns 500.

Introduced in 30f10c0 (#1134); reproduces on `latest` at 8e61de8.

## Fix

Use `{% firstof %}`, which resolves its arguments with `ignore_failures=True` and therefore tolerates either key being absent:

```django
aria-label="{% firstof row.title row.title_main %}"
```

Note that the mirrored form `{{ row.title_main|default:row.title }}` would only move the crash: it breaks on home-screen rows, which have no `title` key. Minimal check against Django 5.2.16:

| expression | context `{'title': 'X'}` | context `{'title_main': 'X'}` |
| --- | --- | --- |
| `{{ row.title\|default:row.title_main }}` | `VariableDoesNotExist` | `X` |
| `{{ row.title_main\|default:row.title }}` | `X` | `VariableDoesNotExist` |
| `{% firstof row.title row.title_main %}` | `X` | `X` |

The heading block above already guards its own `title_main` / `title_detail` usage with `{% if %}`, so it is unaffected.

## Tests

`test_horizontal_scroll.py` asserted the exact broken string, so the contract test is updated to the new expression plus a negative assertion against reintroducing `default:row.title_main`.

Happy to add a view-level regression test (rendering `statistics_talent_fragment` and asserting 200) if you'd prefer coverage closer to the actual failure — kept this minimal on purpose.
