### PR TITLE
Floppy -> Jellyfin integration, stop using legacy auth

### DIFF
--- a/src/integrations/jellyfin_client.py
+++ b/src/integrations/jellyfin_client.py
@@ -28,8 +28,12 @@ class JellyfinClient:
         self.user_id = user_id
 
     def _headers(self) -> dict[str, str]:
+        # See the following for the exact schema:
+        # https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f#the-jellyfin-authorization-scheme
         return {
-            "X-Emby-Token": self.api_key,
+            "Authorization": (
+                f'MediaBrowser Token="{self.api_key}", Client="Floppy"'
+            ),
             "Accept": "application/json",
         }
 

--- a/src/integrations/tests/test_jellyfin_client.py
+++ b/src/integrations/tests/test_jellyfin_client.py
@@ -29,10 +29,9 @@ class JellyfinClientTests(SimpleTestCase):
         self.assertEqual(result, {"Version": "10.9"})
         called_url = mock_request.call_args.args[1]
         self.assertTrue(called_url.endswith("/System/Info"))
-        self.assertEqual(
-            mock_request.call_args.kwargs["headers"]["X-Emby-Token"],
-            "api-key",
-        )
+        auth = mock_request.call_args.kwargs["headers"]["Authorization"]
+        self.assertIn('Token="api-key"', auth)
+        self.assertTrue(auth.startswith("MediaBrowser "))
 
     @patch("integrations.jellyfin_client.requests.request")
     def test_unauthorized_raises_auth_error(self, mock_request):


### PR DESCRIPTION
## Summary
- Changed the auth header schema to no longer use the format that has been deprecated in Jellyfin >12.0
- Instead, moved to new(er) schema, as defined [here](https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f#the-jellyfin-authorization-scheme) (this has been supported for years, so should not cause backwards compatibility issues)

## How It Was Tested
- Set up the integration with my JF instance, watched the playback-reporting sync complete successfully

## Public API & Documentation Handoff
- [ ] Domain terminology is up to date (`python -m app.domain_vocabulary --check`)
- [ ] OpenAPI schema contracts verified (if API endpoints changed)
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [x] Code review completed
- [x] Visual or manual QA verified (e.g. `/gstack-qa` or browser testing)

## Database & Migration Safety (Only if modifying models)
- [ ] No existing or shared migrations were altered or renumbered
- [ ] Migration hygiene passed (`uv run --no-sync python src/manage.py check_migration_hygiene --strict`)
- [x] Not applicable (no database changes)

## Related Issues
- #1135