### PR TITLE
Keep episode navigation visible with long titles

### DIFF
--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db.utils import OperationalError
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import override
@@ -10479,7 +10479,7 @@ class AnimeNextEpisodeRedirectTests(TestCase):
         self.assertRedirects(response, self.detail_url, fetch_redirect_response=False)
 
 
-class EpisodePickerTemplateContractTests(TestCase):
+class EpisodePickerTemplateContractTests(SimpleTestCase):
     def test_long_title_is_constrained_inside_episode_picker(self):
         template = Path(
             settings.BASE_DIR, "templates", "app", "episode_details.html"

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -1,6 +1,7 @@
 import re
 from datetime import UTC, datetime, timedelta
 from html import unescape
+from pathlib import Path
 from unittest.mock import patch
 from urllib.parse import urlparse
 
@@ -10476,3 +10477,16 @@ class AnimeNextEpisodeRedirectTests(TestCase):
         response = self.client.get(self.url)
 
         self.assertRedirects(response, self.detail_url, fetch_redirect_response=False)
+
+
+class EpisodePickerTemplateContractTests(TestCase):
+    def test_long_title_is_constrained_inside_episode_picker(self):
+        template = Path(
+            settings.BASE_DIR, "templates", "app", "episode_details.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('class="relative min-w-0 flex-1 md:max-w-xs"', template)
+        self.assertIn(
+            'class="block min-w-0 flex-1 truncate text-sm font-medium"',
+            template,
+        )

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -108,6 +108,43 @@
                 </span>
               {% endif %}
 
+            <div class="relative min-w-0 flex-1 md:max-w-xs"
+                 x-data="{ open: false }"
+                 @click.away="open = false"
+                 @keydown.escape.window="open = false">
+              <button @click="open = !open"
+                      class="flex h-11 w-full min-w-0 items-center justify-center gap-2 px-4 border border-[var(--color-surface-border)] bg-[var(--color-surface)] text-[var(--color-text)] shadow-sm hover:bg-[var(--color-surface-muted)] rounded-xl transition-colors duration-200 cursor-pointer md:justify-start">
+                <span class="block min-w-0 flex-1 truncate text-sm font-medium">{{ episode.display_episode_number|default:episode_number }}. {{ episode_title }}</span>
+                <div class="h-4 w-4 shrink-0" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" with classes="w-full h-full" %}</div>
+              </button>
+              <div x-show="open"
+                   x-transition:enter="transition ease-out duration-200"
+                   x-transition:enter-start="opacity-0 transform scale-95"
+                   x-transition:enter-end="opacity-100 transform scale-100"
+                   x-transition:leave="transition ease-in duration-150"
+                   x-transition:leave-start="opacity-100 transform scale-100"
+                   x-transition:leave-end="opacity-0 transform scale-95"
+                   class="absolute right-1/2 md:right-0 translate-x-1/2 md:translate-x-0 mt-2 w-64 bg-[var(--color-surface)] rounded-md shadow-lg overflow-hidden z-10">
+                <div class="max-h-[300px] overflow-y-auto">
+                  {% for ep in episodes %}
+                    <a href="{% if parent_media_type == MediaTypes.ANIME.value %}{% url 'anime_episode_details' source=source media_id=media_id title=show_title|slug season_number=season_number episode_number=ep.episode_number %}{% else %}{% url 'episode_details' source=source media_id=media_id title=show_title|slug season_number=season_number episode_number=ep.episode_number %}{% endif %}"
+                       hx-boost="true"
+                       class="w-full px-4 py-3 flex items-center space-x-3 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] transition-colors duration-200 cursor-pointer {% if ep.episode_number == episode_number %}bg-[var(--color-surface-muted)]{% endif %}">
+                      <div class="w-8 h-8 rounded-full flex items-center justify-center bg-indigo-600 text-white shrink-0">
+                        {{ ep.display_episode_number|default:ep.episode_number }}
+                      </div>
+                      <div class="flex-1 text-left min-w-0">
+                        <div class="text-sm font-medium line-clamp-1">{{ ep.title }}</div>
+                        <div class="text-xs text-[var(--color-text-muted)]">
+                          {{ ep.air_date|user_date_format:user|default_if_none:"Unknown date" }}
+                        </div>
+                      </div>
+                    </a>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+
               {% if next_episode_number %}
                 <a href="{% if parent_media_type == MediaTypes.ANIME.value %}{% url 'anime_episode_details' source=source media_id=media_id title=show_title|slug season_number=season_number episode_number=next_episode_number %}{% else %}{% url 'episode_details' source=source media_id=media_id title=show_title|slug season_number=season_number episode_number=next_episode_number %}{% endif %}"
                    hx-boost="true"


### PR DESCRIPTION
## Summary

Long episode titles could push the previous and next controls outside the available width. This constrains the picker, truncates its label when needed, and leaves the full title unchanged in the episode content.

## Screenshot

At 390 px with an intentionally long title:

<img width="390" height="124" alt="Episode picker with a long title at 390 px" src="https://github.com/user-attachments/assets/03526c01-84f9-4874-9dc3-d0544714c9b7" />

## AI Assistance

Codex (GPT-5) and gemini-3.8-flash-high assisted with the implementation review and PR split.

## How It Was Tested

`python src/manage.py test app.tests.views.test_media_details.EpisodePickerTemplateContractTests --keepdb`
Passed: 1 test.

`python -m ruff check src/app/tests/views/test_media_details.py`
Passed.

`git diff --check`
Passed.

## Public API & Documentation Handoff

- [x] Not applicable. No API or vocabulary changes.

## Human Review & Quality Assurance

- [ ] Code review completed.
- [x] Verified visually at 390 px with an intentionally long title.

## Database & Migration Safety

- [x] Not applicable. No database changes.

## Related Issues

This is the first focused replacement for #993.