### PR TITLE
Pin the scrobble Now Playing card to the AniDB-mapped cour

### DIFF
--- a/src/api/fork_views_scrobble.py
+++ b/src/api/fork_views_scrobble.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 import app.providers.tmdb
 from app import live_playback
-from app.models import MediaTypes
+from app.models import MediaTypes, Sources
 from integrations.delivery import get_or_record_receipt
 from integrations.models import IntegrationToken
 from integrations.webhooks.generic_scrobble import GenericScrobbleProcessor, is_played
@@ -363,21 +363,49 @@ class ScrobbleView(drf_views.APIView):
     def _update_live_playback(self, user, action, media_type, ids, data):
         """Update the Now Playing card; failures are logged, never raised."""
         try:
+            source = Sources.TMDB.value
             media_id = _resolve_live_playback_media_id(media_type, ids)
+            season_number = data.get("season_number")
+            episode_number = data.get("episode_number")
+            series_title = data.get("series_title")
+            image = None
+
+            if media_type == MediaTypes.EPISODE.value and ids.get("anidb"):
+                identity = GenericScrobbleProcessor().resolve_anime_live_identity(
+                    user,
+                    {
+                        "tmdb_id": ids.get("tmdb"),
+                        "imdb_id": ids.get("imdb"),
+                        "tvdb_id": ids.get("tvdb"),
+                        "anidb_id": ids.get("anidb"),
+                    },
+                    season_number,
+                    episode_number,
+                )
+                if identity:
+                    source = identity["source"]
+                    media_id = identity["media_id"]
+                    season_number = identity["season_number"]
+                    episode_number = identity["episode_number"]
+                    series_title = identity.get("series_title") or series_title
+                    image = identity.get("image")
+
             live_playback.apply_playback_event(
                 user_id=user.id,
                 event_type=_EVENT_TYPE_MAP[action],
                 playback_media_type=media_type,
                 media_id=media_id,
+                source=source,
                 title=data.get("title"),
-                series_title=data.get("series_title"),
+                series_title=series_title,
                 episode_title=data.get("title")
                 if media_type == MediaTypes.EPISODE.value
                 else None,
-                season_number=data.get("season_number"),
-                episode_number=data.get("episode_number"),
+                season_number=season_number,
+                episode_number=episode_number,
                 view_offset_seconds=data.get("position_seconds"),
                 duration_seconds=data.get("duration_seconds"),
+                image=image,
             )
         except Exception:
             logger.warning("Scrobble live-playback update failed", exc_info=True)

--- a/src/api/tests/test_fork_scrobble.py
+++ b/src/api/tests/test_fork_scrobble.py
@@ -121,6 +121,48 @@ class ScrobbleLivePlaybackTests(FloppyApiTestCase):
             Movie.objects.filter(user=self.user1, item__media_id="603").exists(),
         )
 
+    @patch("app.providers.mal.anime")
+    @patch("integrations.webhooks.anime_mappings.fetch_mapping_data")
+    @patch("api.fork_views_scrobble.live_playback.apply_playback_event")
+    def test_anidb_episode_pins_the_card_to_the_mal_cour(
+        self,
+        mock_apply_event,
+        mock_mapping,
+        mock_mal,
+    ):
+        """An anidb id on a flat-MAL user resolves the Now Playing card cour."""
+        self.user1.anime_enabled = True
+        self.user1.anime_metadata_source_default = "mal"
+        self.user1.save()
+        mock_mapping.return_value = {"anidb:3651:R": {"mal:849": {"1-": "1-"}}}
+        mock_mal.return_value = {
+            "title": "Suzumiya Haruhi no Yuutsu",
+            "image": "https://example.com/haruhi.jpg",
+            "max_progress": 14,
+        }
+
+        response = self.call_api(
+            "post",
+            "api_scrobble",
+            payload={
+                "action": "start",
+                "media_type": "episode",
+                "ids": {"tvdb": "9350138", "anidb": "3651"},
+                "series_title": "Suzumiya Haruhi no Yuutsu",
+                "season_number": 1,
+                "episode_number": 1,
+            },
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, HTTP.OK)
+        _, kwargs = mock_apply_event.call_args
+        self.assertEqual(kwargs["source"], "mal")
+        self.assertEqual(kwargs["media_id"], "849")
+        self.assertEqual(kwargs["episode_number"], 1)
+        self.assertEqual(kwargs["series_title"], "Suzumiya Haruhi no Yuutsu")
+        self.assertEqual(kwargs["image"], "https://example.com/haruhi.jpg")
+
     @patch("api.fork_views_scrobble.live_playback.apply_playback_event")
     def test_live_playback_failure_does_not_fail_request(self, mock_apply_event):
         """A best-effort live-card failure never surfaces as a request error."""

--- a/src/app/live_playback.py
+++ b/src/app/live_playback.py
@@ -287,6 +287,7 @@ def apply_playback_event(
     duration_seconds: int | None = None,
     store_progress: bool = False,
     provider_completed: bool | None = None,
+    image: str | None = None,
 ) -> None:
     """Update live playback cache state from a webhook event.
 
@@ -459,6 +460,12 @@ def apply_playback_event(
         state["image_resolved_at_ts"] = existing_state.get(
             "image_resolved_at_ts",
         )
+    elif image:
+        # The caller already resolved artwork (e.g. a MAL cour that the
+        # source-agnostic episode resolver below cannot look up).
+        state["image"] = image
+        state["image_source"] = "primary"
+        state["image_resolved_at_ts"] = now_ts
     else:
         # Runs in the webhook Celery worker, so provider calls are
         # allowed here; the request path only ever reads the result.
@@ -721,6 +728,9 @@ def _resolve_card_subtitle(state, title):
     episode_code = None
     if season_number is not None and episode_number is not None:
         episode_code = f"S{season_number:02d}E{episode_number:02d}"
+    elif episode_number is not None:
+        # Flat MAL anime cours have no season; show the cour-relative number.
+        episode_code = f"E{episode_number:02d}"
     episode_title = (state.get("episode_title") or "").strip()
     if episode_code and episode_title and episode_title != title:
         return episode_code, f"{episode_code} • {episode_title}"
@@ -965,7 +975,11 @@ def build_home_playback_card(user) -> dict | None:
     ):
         _ep_media_id = state.get("media_id")
         _ep_source = state.get("source") or Sources.TMDB.value
-        if _ep_media_id:
+        if _ep_source == Sources.MAL.value:
+            # A MAL-sourced episode card is a flat anime cour by construction
+            # (see GenericScrobbleProcessor.resolve_anime_live_identity).
+            library_media_type = MediaTypes.ANIME.value
+        elif _ep_media_id:
             tv_item = (
                 Item.objects.filter(
                     media_id=_ep_media_id,

--- a/src/app/tests/test_live_playback.py
+++ b/src/app/tests/test_live_playback.py
@@ -162,6 +162,20 @@ class ApplyPlaybackEventImageTests(TestCase):
         self.assertIsNotNone(state)
         self.assertNotIn("image", state)
 
+    @patch("app.live_playback._resolve_landscape_image")
+    def test_caller_supplied_image_skips_resolution(self, mock_resolve):
+        """A MAL cour card carries artwork the episode resolver cannot look up."""
+        self._apply_play(
+            source=Sources.MAL.value,
+            media_id="849",
+            image="https://example.com/haruhi.jpg",
+        )
+
+        state = live_playback.get_user_playback_state(self.user.id)
+        self.assertEqual(state["image"], "https://example.com/haruhi.jpg")
+        self.assertEqual(state["image_source"], "primary")
+        mock_resolve.assert_not_called()
+
 
 class FetchEpisodeStillCacheTests(TestCase):
     """Episode still lookups are cached, including failures."""
@@ -283,6 +297,52 @@ class RequestPathPurityTests(TestCase):
         live_playback.build_home_playback_card(self.user)
 
         mock_fill.assert_called_once_with(self.user.id)
+
+
+class MalCourCardTests(TestCase):
+    """A MAL-sourced episode card renders as a flat anime cour."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="malcard")
+        self.user.anime_enabled = True
+        self.user.save()
+
+    def tearDown(self):
+        live_playback.clear_user_playback_state(self.user.id)
+        cache.clear()
+        super().tearDown()
+
+    def _seed(self):
+        now_ts = live_playback._now_ts()
+        live_playback.set_user_playback_state(
+            self.user.id,
+            {
+                "event_type": "media.play",
+                "media_type": MediaTypes.EPISODE.value,
+                "media_id": "849",
+                "source": Sources.MAL.value,
+                "series_title": "Suzumiya Haruhi no Yuutsu",
+                "season_number": None,
+                "episode_number": 3,
+                "image": "https://example.com/haruhi.jpg",
+                "image_source": "primary",
+                "view_offset_seconds": 60,
+                "duration_seconds": 1400,
+                "started_at_ts": now_ts,
+                "status": live_playback.PLAYBACK_STATUS_PLAYING,
+                "updated_at_ts": now_ts,
+                "expires_at_ts": now_ts + 3600,
+                "pause_expires_at_ts": None,
+                "scrobble_expires_at_ts": None,
+            },
+        )
+
+    def test_card_links_to_the_anime_details_page(self):
+        self._seed()
+        card = live_playback.build_home_playback_card(self.user)
+        self.assertIn(f"/{Sources.MAL.value}/{MediaTypes.ANIME.value}/849/", card["details_url"])
+        self.assertEqual(card["image"], "https://example.com/haruhi.jpg")
+        self.assertEqual(card["episode_code"], "E03")
 
 
 class ResolveStateImageTaskTests(TestCase):

--- a/src/integrations/tests/test_generic_scrobble_processor.py
+++ b/src/integrations/tests/test_generic_scrobble_processor.py
@@ -18,6 +18,78 @@ from app.services.grouped_anime import GroupedAnimeMatch
 from integrations.webhooks.generic_scrobble import GenericScrobbleProcessor
 
 
+class ResolveAnimeLiveIdentityTests(TestCase):
+    """The live Now Playing card follows the same anidb->MAL cour decision."""
+
+    def setUp(self):
+        """A MAL-provider anime user and the processor under test."""
+        self.processor = GenericScrobbleProcessor()
+        self.user = get_user_model().objects.create_user(username="live-anime")
+        self.user.anime_enabled = True
+        self.user.anime_metadata_source_default = Sources.MAL.value
+        self.user.save()
+        self._ids = {
+            "tmdb_id": "603",
+            "imdb_id": None,
+            "tvdb_id": "9350138",
+            "anidb_id": "3651",
+        }
+
+    def _resolve(self, **overrides):
+        with (
+            patch(
+                "integrations.webhooks.anime_mappings.fetch_mapping_data",
+                return_value={"anidb:3651:R": {"mal:849": {"1-": "1-"}}},
+            ),
+            patch(
+                "app.providers.mal.anime",
+                return_value={
+                    "title": "Suzumiya Haruhi no Yuutsu",
+                    "image": "https://example.com/haruhi.jpg",
+                    "max_progress": 14,
+                },
+            ),
+        ):
+            return self.processor.resolve_anime_live_identity(
+                self.user,
+                overrides.get("ids", self._ids),
+                overrides.get("season_number", 1),
+                overrides.get("episode_number", 1),
+            )
+
+    def test_flat_mal_user_gets_the_mapped_cour(self):
+        """The card is pinned to the MAL entry, not the payload's tmdb show."""
+        identity = self._resolve()
+        self.assertEqual(identity["source"], Sources.MAL.value)
+        self.assertEqual(identity["media_id"], "849")
+        self.assertEqual(identity["episode_number"], 1)
+        self.assertIsNone(identity["season_number"])
+        self.assertEqual(identity["series_title"], "Suzumiya Haruhi no Yuutsu")
+        self.assertEqual(identity["image"], "https://example.com/haruhi.jpg")
+
+    def test_no_anidb_id_leaves_default_resolution(self):
+        """Without an anidb id the default tmdb resolution is untouched."""
+        self.assertIsNone(
+            self._resolve(ids={**self._ids, "anidb_id": None}),
+        )
+
+    def test_grouped_provider_defers_to_the_normal_decision(self):
+        """A TMDB Anime Provider keeps the grouped path; no MAL override."""
+        self.user.anime_metadata_source_default = Sources.TMDB.value
+        self.user.save(update_fields=["anime_metadata_source_default"])
+        self.assertIsNone(self._resolve())
+
+    def test_episode_past_the_cour_end_is_not_pinned(self):
+        """An episode the MAL entry would refuse falls back to default routing."""
+        self.assertIsNone(self._resolve(episode_number=99))
+
+    def test_anime_disabled_user_is_ignored(self):
+        """The override only applies when the anime library is enabled."""
+        self.user.anime_enabled = False
+        self.user.save(update_fields=["anime_enabled"])
+        self.assertIsNone(self._resolve())
+
+
 class GenericScrobbleHeuristicTests(TestCase):
     """Unit tests for GenericScrobbleProcessor's hook methods."""
 

--- a/src/integrations/webhooks/generic_scrobble.py
+++ b/src/integrations/webhooks/generic_scrobble.py
@@ -6,13 +6,19 @@ this processor only needs to bridge that normalized shape into the shared
 TMDB-resolution and DB-write logic in ``BaseWebhookProcessor``.
 """
 
+import logging
+
+import app.providers.mal
 from app.live_playback import (
     PLAYBACK_SCROBBLE_BUFFER_SECONDS,
     PLAYBACK_SCROBBLE_FALLBACK_SECONDS,
 )
-from app.models import MediaTypes
+from app.models import MediaTypes, Sources
 
+from . import anime_mappings
 from .base import BaseWebhookProcessor
+
+logger = logging.getLogger(__name__)
 
 # The API speaks "movie"/"episode" (matching apply_playback_event's
 # playback_media_type vocabulary); the base processor routes on TV/MOVIE.
@@ -86,3 +92,91 @@ class GenericScrobbleProcessor(BaseWebhookProcessor):
 
     def _get_played_at(self, payload):
         return payload.get("played_at")
+
+    def resolve_anime_live_identity(self, user, ids, season_number, episode_number):
+        """Pin the live Now Playing card to the anime an AniDB id names.
+
+        The durable stop path already routes an ``anidb`` id to its exact
+        MyAnimeList cour when the user's Anime library stores flat MAL rows
+        (see ``BaseWebhookProcessor._process_tv``). The live card never did:
+        it resolved the payload's tmdb/tvdb id straight through, so a
+        start/pause event showed the umbrella series - the "unresolved"
+        anime - while the same client's stop marked the right cour as
+        played.
+
+        This is a read-only mirror of that decision. It returns ``None`` -
+        leaving the default resolution untouched - unless a flat MAL cour is
+        the shape this show resolves to. The grouped-anime case already
+        renders from the payload's franchise id and is deliberately left
+        alone.
+        """
+        from app.services import metadata_resolution
+
+        anidb_id = ids.get("anidb_id")
+        if not (getattr(user, "anime_enabled", False) and anidb_id and episode_number):
+            return None
+
+        try:
+            mapping_data = anime_mappings.fetch_mapping_data()
+            mal_id, mal_episode_number = anime_mappings.get_mal_id_from_anidb(
+                mapping_data,
+                anidb_id,
+                episode_number,
+            )
+        except Exception:
+            logger.warning("Live card AniDB resolution failed", exc_info=True)
+            return None
+        if not mal_id:
+            return None
+
+        tmdb_id = ids.get("tmdb_id")
+        tvdb_id = ids.get("tvdb_id")
+        if not (tmdb_id or tvdb_id):
+            entry = next(
+                (
+                    e
+                    for e in anime_mappings.find_entries_for_mal_id(mapping_data, mal_id)
+                    if e.get("tvdb_id") or e.get("tmdb_id")
+                ),
+                None,
+            )
+            if entry:
+                tmdb_id = entry.get("tmdb_id")
+                tvdb_id = entry.get("tvdb_id")
+
+        home = metadata_resolution.find_existing_anime_home(
+            user,
+            tmdb_id=tmdb_id,
+            tvdb_id=tvdb_id,
+        )
+        home_kind = home[0] if home else None
+        defer_to_grouped = home_kind == "grouped" or (
+            home_kind is None and metadata_resolution.prefers_grouped_anime(user)
+        )
+        if defer_to_grouped:
+            return None
+
+        try:
+            anime_metadata = app.providers.mal.anime(mal_id)
+        except Exception:
+            logger.warning("Live card MAL lookup failed for %s", mal_id, exc_info=True)
+            return None
+
+        max_progress = anime_metadata.get("max_progress")
+        if (
+            isinstance(max_progress, int)
+            and max_progress > 0
+            and mal_episode_number > max_progress
+        ):
+            # Past this cour's end - the stop path refuses it too, so do not
+            # pin the card to an entry that will not accept the scrobble.
+            return None
+
+        return {
+            "source": Sources.MAL.value,
+            "media_id": str(mal_id),
+            "season_number": None,
+            "episode_number": mal_episode_number,
+            "series_title": anime_metadata.get("title"),
+            "image": anime_metadata.get("image"),
+        }


### PR DESCRIPTION
## Summary
- When a third-party client scrobbles an anime episode with an `anidb` id, the durable **stop** already resolves it to the exact MyAnimeList cour (PR #1082). The live **Now Playing** card did not: `start`/`pause`/`stop` resolved the payload's `tmdb`/`tvdb` id straight through as a TMDB show, so the card showed the umbrella series — the "unresolved" anime — while the same client's stop correctly marked the mapped cour as played.
- This teaches the live card the same `anidb` → MAL cour resolution, so what the card shows matches what gets marked played.
- No API surface change: the `anidb` request field was already documented on `/api/v1/scrobble/`; OpenAPI contract tests still pass.

### What changed
- **`GenericScrobbleProcessor.resolve_anime_live_identity`** — a read-only mirror of the `_process_tv` routing decision. It returns `None` (leaving the existing resolution untouched) unless the show resolves to a **flat MAL** row, honouring the "an AniDB id names the cour, not the library shape" rule from `4870907e`: grouped anime already renders from the franchise id and is deliberately left alone. It also declines when the episode is past the cour's `max_progress`, the same case the stop path refuses.
- **`fork_views_scrobble._update_live_playback`** — for episodes carrying an `anidb` id, threads the resolved `source` / `media_id` / `episode_number` plus the MAL title and artwork into `apply_playback_event`.
- **`live_playback`** — `apply_playback_event` accepts an optional pre-resolved `image` (the TMDB-only episode image resolver cannot look a MAL cour up); `build_home_playback_card` treats a MAL-sourced episode as anime so the details link points at the anime page, and `_resolve_card_subtitle` renders `E03` when there is no season (flat cours have none).

## AI Assistance
- `claude-sonnet-5` (Claude Code) generated and shaped this change under human direction and review.

## How It Was Tested
- `manage.py test integrations.tests.test_generic_scrobble_processor` — Passed (new `ResolveAnimeLiveIdentityTests`: flat-MAL pin, no-anidb passthrough, grouped-provider defer, past-cour-end decline, anime-disabled ignore). Pre-existing network-tagged errors unchanged vs. `latest`.
- `manage.py test app.tests.test_live_playback` — Passed (new `MalCourCardTests` for details URL + `E03` subtitle; `apply_playback_event` caller-supplied-image path).
- `manage.py test api.tests.test_fork_scrobble` — Passed (new end-to-end `test_anidb_episode_pins_the_card_to_the_mal_cour`). Pre-existing network-tagged failures unchanged vs. `latest`.
- `manage.py test app.tests.test_api_contracts app.tests.test_domain_vocabulary users.tests.views.test_about` — Passed (69/69); confirms no OpenAPI drift.
- `ruff check src` — Passed.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes — the `anidb` scrobble field and its docs already shipped in #1082; contract tests green)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs #1082
