### PR TITLE
Never render an episode list as an episode count

### DIFF
--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -734,6 +734,13 @@ def get_tv_show_collection_stats(user, tv_item, metadata_episode_count=None):
     )
 
     # Use metadata episode count if provided (matches Details pane), otherwise count from Items
+    # Guard against providers handing back an episode list instead of a count:
+    # a non-numeric value would be rendered verbatim by the Collection panel.
+    if isinstance(metadata_episode_count, bool) or not isinstance(
+        metadata_episode_count,
+        int,
+    ):
+        metadata_episode_count = None
     if metadata_episode_count is not None:
         total_episodes = metadata_episode_count
     else:

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -117,6 +117,41 @@ def _enrich_comic_issues(issues, user):
     return enriched
 
 
+def _metadata_episode_count(media_metadata):
+    """Return a numeric episode count from metadata, or None when unavailable.
+
+    Providers disagree on the shape of their episode payloads: TVDB and MAL
+    expose ``details["episodes"]`` as a count, while the anime detail preview
+    stores a list of episode rows under the top-level ``episodes`` key. Falling
+    back to the raw value rendered the list itself into the Collection panel
+    (see the "0/[{'media_id': ...}]" report), so collapse any sequence to its
+    length and reject anything that is not a usable count.
+    """
+    candidates = (
+        (media_metadata.get("details") or {}).get("episodes"),
+        media_metadata.get("episodes"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, bool) or candidate is None:
+            continue
+        if isinstance(candidate, int):
+            if candidate > 0:
+                return candidate
+            continue
+        if isinstance(candidate, str):
+            try:
+                parsed = int(candidate.strip())
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                return parsed
+            continue
+        if isinstance(candidate, (list, tuple, set, frozenset, dict)):
+            if len(candidate) > 0:
+                return len(candidate)
+    return None
+
+
 def _get_tv_runtime_display_fallback(detail_item, media_metadata):
     """Return a best-effort runtime string for TV details when provider runtime is missing."""
     if not detail_item or detail_item.media_type != MediaTypes.TV.value:
@@ -1633,9 +1668,7 @@ def media_details(
             # For TV shows, also get collection statistics (episodes/seasons)
             if media_type in (MediaTypes.TV.value, MediaTypes.ANIME.value):
                 # Use episode count from metadata if available to match Details pane
-                metadata_episode_count = media_metadata.get("details", {}).get(
-                    "episodes"
-                ) or media_metadata.get("episodes")
+                metadata_episode_count = _metadata_episode_count(media_metadata)
                 collection_stats = get_tv_show_collection_stats(
                     request.user, item, metadata_episode_count=metadata_episode_count
                 )

--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -146,9 +146,10 @@ def _metadata_episode_count(media_metadata):
             if parsed > 0:
                 return parsed
             continue
-        if isinstance(candidate, (list, tuple, set, frozenset, dict)):
-            if len(candidate) > 0:
-                return len(candidate)
+        if isinstance(candidate, (list, tuple, set, frozenset, dict)) and len(
+            candidate,
+        ):
+            return len(candidate)
     return None
 
 

--- a/src/app/providers/tvdb.py
+++ b/src/app/providers/tvdb.py
@@ -159,6 +159,26 @@ def _coerce_list(value) -> list:
     return [value]
 
 
+def _coerce_episode_count(series_data) -> int | None:
+    """Return the series episode count as a number, never as an episode list.
+
+    TVDB omits `numberOfEpisodes` on some series (e.g. long-running anime) while
+    the extended payload carries `episodes` as a list of rows. Returning that
+    list left downstream consumers rendering it verbatim, so fall back to its
+    length instead.
+    """
+    count = series_data.get("numberOfEpisodes")
+    if isinstance(count, int) and not isinstance(count, bool) and count > 0:
+        return count
+
+    episodes = series_data.get("episodes")
+    if isinstance(episodes, list):
+        return len(episodes) or None
+    if isinstance(episodes, int) and not isinstance(episodes, bool) and episodes > 0:
+        return episodes
+    return None
+
+
 def _normalize_text_value(value) -> str | None:
     """Collapse provider text payloads into a displayable string."""
     if value in (None, ""):
@@ -1000,9 +1020,7 @@ def _build_series_metadata(series_data: dict, *, media_type: str, language: str 
         if isinstance(series_data.get("status"), dict)
         else series_data.get("status"),
         "seasons": len(seasons),
-        "episodes": series_data.get("numberOfEpisodes")
-        or series_data.get("episodes")
-        or None,
+        "episodes": _coerce_episode_count(series_data),
         "runtime": tmdb.get_readable_duration(episode_runtime),
         "studios": _get_company_names(series_data),
         "country": None,

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -10046,6 +10046,69 @@ class MediaDetailsViewTests(TestCase):
         self.assertContains(response, "2/3")
 
     @patch("app.providers.services.get_media_metadata")
+    def test_anime_media_details_collection_stats_ignore_episode_list_payload(
+        self,
+        mock_get_metadata,
+    ):
+        """A missing episode count must not leak the episode list into the stats."""
+        Item.objects.create(
+            media_id="anime-episode-list-count",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Long Running Anime",
+            image="http://example.com/anime.jpg",
+        )
+
+        mock_get_metadata.return_value = {
+            "media_id": "anime-episode-list-count",
+            "title": "Long Running Anime",
+            "media_type": MediaTypes.ANIME.value,
+            "source": Sources.MAL.value,
+            "source_url": "https://myanimelist.net/anime/anime-episode-list-count",
+            "image": "http://example.com/anime.jpg",
+            "synopsis": "Test synopsis",
+            # Providers omit the episode count for some long-running shows.
+            "details": {"format": "TV", "runtime": "25m", "episodes": None},
+            # The detail page stores the episode preview under this key.
+            "episodes": [
+                {
+                    "media_id": "anime-episode-list-count",
+                    "media_type": MediaTypes.EPISODE.value,
+                    "source": Sources.TVDB.value,
+                    "season_number": 1,
+                    "episode_number": episode_number,
+                }
+                for episode_number in (1, 2, 3)
+            ],
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+            "providers": {},
+            "external_links": {},
+        }
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.MAL.value,
+                    "media_type": MediaTypes.ANIME.value,
+                    "media_id": "anime-episode-list-count",
+                    "title": "long-running-anime",
+                },
+            ),
+            # Collection stats are computed for the secondary fragment.
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["collection_stats"]["total_episodes"], 3)
+        self.assertContains(response, "COLLECTED EPISODES")
+        self.assertContains(response, "0/3")
+        self.assertNotContains(response, "&#x27;media_id&#x27;")
+
+    @patch("app.providers.services.get_media_metadata")
     def test_tv_media_details_play_stats_skip_placeholder_episode_runtimes(
         self,
         mock_get_metadata,


### PR DESCRIPTION
## What was wrong

The Collection panel on a show's detail page rendered a raw Python list repr where the episode total belongs:

```
COLLECTED SEASONS
0/0

COLLECTED EPISODES
0/[{'media_id': '76703', 'media_type': 'episode', 'source': 'tvdb', 'season_number': 18, ...
```

## How it surfaced

It showed up on **anime** detail pages while **MyAnimeList was unreachable** (every MAL call returning `401 invalid_client`, so `services.get_media_metadata(..., "mal")` raised `ProviderAPIError`). With MAL failing, the anime page fell back to **TVDB** — and TVDB omits `numberOfEpisodes` for some long-running series. For *Pokémon the Series: Sun & Moon* (`tvdb/76703`), probed against the live provider:

```
details.episodes = None
details.seasons  = 21
max_progress     = None
```

`media_details` then did:

```python
metadata_episode_count = media_metadata.get("details", {}).get("episodes") or media_metadata.get("episodes")
```

With `details["episodes"]` falsy, the `or` fell through to the top-level `episodes` key — which on an anime detail page holds the **flat episode preview list**, not a count. That list became `total_episodes`, so the template printed its repr, and `{% if collection_stats.total_episodes > 0 %}` silently evaluated false, dropping the percentage too.

The MAL outage was only the trigger. Any provider payload that leaves the episode count empty while carrying an episode list reproduces this.

## The fix

Guarded at all three layers the bad value travelled through:

- **`_metadata_episode_count()`** (`media_details_views.py`) — only ever returns a positive `int`, collapsing a sequence payload to its length so the preview list still yields a usable total instead of being discarded.
- **`_coerce_episode_count()`** (`providers/tvdb.py`) — keeps `details["episodes"]` numeric. The old `series_data.get("numberOfEpisodes") or series_data.get("episodes")` could itself return the extended payload's episode list (1452 rows for this series), so the same repr could reach any consumer of the provider, not just this panel.
- **`get_tv_show_collection_stats()`** (`helpers.py`) — rejects a non-int `metadata_episode_count` rather than handing it to the template.

## Verification

- New regression test `test_anime_media_details_collection_stats_ignore_episode_list_payload`: asserts `total_episodes == 3` from a 3-row preview list with `details["episodes"] = None`, that the page shows `0/3`, and that no `'media_id'` repr reaches the HTML.
- It fails without the view fix (`AssertionError: 0 != 3`) and passes with it.
- `95 passed` across tvdb-selected tests; `55 passed` across `test_collection_helpers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
