### PR TITLE
Fix match: move season items with the show, stop persisting search results

### DIFF
--- a/src/integrations/match_corrections.py
+++ b/src/integrations/match_corrections.py
@@ -432,6 +432,12 @@ def _move_tv(user, source_item, destination_item, mapping, decisions):
     source = TV.objects.filter(user=user, item=source_item).first()
     if not source:
         raise InvalidMatchCorrectionError("The source TV show is not tracked by this user.")
+    # Read the source's seasons before the show can be repointed below: with no
+    # destination row the source row becomes the destination, and these seasons
+    # would then look like they already belong to it.
+    source_seasons = list(
+        Season.objects.filter(user=user, related_tv=source).select_related("item"),
+    )
     destination = TV.objects.filter(user=user, item=destination_item).first()
     if destination:
         _merge_scalars(source, destination, decisions)
@@ -441,13 +447,11 @@ def _move_tv(user, source_item, destination_item, mapping, decisions):
 
     destination_seasons = {
         season.item.season_number: season
-        for season in Season.objects.filter(user=user, related_tv=destination).select_related(
-            "item"
-        )
+        for season in Season.objects.filter(user=user, related_tv=destination)
+        .exclude(pk__in=[season.pk for season in source_seasons])
+        .select_related("item")
     }
-    for season in list(
-        Season.objects.filter(user=user, related_tv=source).select_related("item"),
-    ):
+    for season in source_seasons:
         source_season = season.item.season_number
         destination_season_number = source_season
         if source_season is not None:

--- a/src/integrations/tests/test_matching_and_corrections.py
+++ b/src/integrations/tests/test_matching_and_corrections.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
 from app.models import (
     TV,
@@ -316,6 +317,95 @@ class MatchCorrectionTests(TestCase):
         self.assertEqual(episode.item.media_id, "502")
         self.assertEqual(episode.item.source, Sources.TMDB.value)
         self.assertEqual(episode.related_season_id, source_season.pk)
+
+    @patch("integrations.views.services.search")
+    def test_match_fix_search_does_not_persist_candidate_items(self, mock_search):
+        """Listing search results must not write an Item per candidate.
+
+        The destination radio used to carry an Item pk, so rendering the
+        result list materialized one Item per hit. A single search wrote
+        rows for every unrelated show it returned, and the metadata
+        backfill then fanned each one out into season, episode, person and
+        calendar rows.
+        """
+        source = Item.objects.create(
+            media_id="601",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Tracked Show",
+        )
+        TV.objects.create(
+            user=self.user,
+            item=source,
+            status=Status.IN_PROGRESS.value,
+        )
+        mock_search.return_value = {
+            "results": [
+                {"media_id": "900", "title": "Right Show", "year": 2020},
+                {"media_id": "901", "title": "Unrelated Show", "year": 2011},
+            ],
+        }
+        self.client.force_login(self.user)
+
+        before = set(Item.objects.values_list("pk", flat=True))
+        response = self.client.get(
+            reverse("match_fix", args=[source.pk]),
+            {"q": "show"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Right Show")
+        self.assertContains(response, "Unrelated Show")
+        self.assertEqual(set(Item.objects.values_list("pk", flat=True)), before)
+        self.assertFalse(
+            Item.objects.filter(
+                media_id__in=("900", "901"),
+                source=Sources.TMDB.value,
+            ).exists(),
+        )
+
+    @patch("integrations.views.services.search")
+    def test_match_fix_preview_materializes_only_the_chosen_destination(
+        self,
+        mock_search,
+    ):
+        """Previewing one candidate creates that destination Item and no other."""
+        source = Item.objects.create(
+            media_id="602",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Tracked Show",
+        )
+        TV.objects.create(
+            user=self.user,
+            item=source,
+            status=Status.IN_PROGRESS.value,
+        )
+        mock_search.return_value = {
+            "results": [
+                {"media_id": "910", "title": "Right Show", "year": 2020},
+                {"media_id": "911", "title": "Unrelated Show", "year": 2011},
+            ],
+        }
+        self.client.force_login(self.user)
+
+        with patch("app.models.Item.fetch_releases"):
+            response = self.client.post(
+                reverse("match_fix", args=[source.pk]) + "?q=show",
+                {"action": "preview", "destination_media_id": "910"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            Item.objects.filter(
+                media_id="910",
+                source=Sources.TMDB.value,
+                media_type=MediaTypes.TV.value,
+            ).exists(),
+        )
+        self.assertFalse(
+            Item.objects.filter(media_id="911", source=Sources.TMDB.value).exists(),
+        )
 
     def test_reference_lookup_is_user_scoped(self):
         ExternalReference.objects.create(

--- a/src/integrations/tests/test_matching_and_corrections.py
+++ b/src/integrations/tests/test_matching_and_corrections.py
@@ -247,6 +247,76 @@ class MatchCorrectionTests(TestCase):
         self.assertEqual(episode.item.episode_number, 3)
         self.assertTrue(Season.objects.filter(related_tv=destination_tv).exists())
 
+    def test_tv_move_to_untracked_destination_repoints_season_items(self):
+        """Seasons must follow the show when the destination is not tracked yet.
+
+        With no destination TV row the correction repoints the source row
+        itself, so source and destination became the same row; the
+        already-seen season map was then pre-filled with the source's own
+        seasons and every season matched itself, leaving app_season.item on
+        the old provider's season Item while the show and its episodes moved.
+        Season lookups key off that Item, so the user's watches went
+        invisible under the corrected identity.
+        """
+        source = Item.objects.create(
+            media_id="501",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Wrong Show",
+        )
+        destination = self._item("502", MediaTypes.TV.value, "Right Show")
+        source_tv = TV.objects.create(
+            user=self.user,
+            item=source,
+            status=Status.IN_PROGRESS.value,
+        )
+        source_season_item = Item.objects.create(
+            media_id="501",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Season 1",
+            season_number=1,
+        )
+        source_season = Season.objects.create(
+            user=self.user,
+            item=source_season_item,
+            related_tv=source_tv,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode_item = Item.objects.create(
+            media_id="501",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Pilot",
+            season_number=1,
+            episode_number=1,
+        )
+        episode = Episode.objects.create(
+            item=episode_item,
+            related_season=source_season,
+            end_date="2024-01-01T00:00:00Z",
+        )
+
+        preview = preview_match_correction(self.user, source, destination)
+        with patch("app.models.Item.fetch_releases"):
+            apply_match_correction(
+                self.user,
+                source.pk,
+                destination.pk,
+                preview["token"],
+            )
+
+        source_tv.refresh_from_db()
+        source_season.refresh_from_db()
+        episode.refresh_from_db()
+        self.assertEqual(source_tv.item_id, destination.pk)
+        self.assertEqual(source_season.item.media_id, "502")
+        self.assertEqual(source_season.item.source, Sources.TMDB.value)
+        self.assertEqual(source_season.item.season_number, 1)
+        self.assertEqual(episode.item.media_id, "502")
+        self.assertEqual(episode.item.source, Sources.TMDB.value)
+        self.assertEqual(episode.related_season_id, source_season.pk)
+
     def test_reference_lookup_is_user_scoped(self):
         ExternalReference.objects.create(
             user=self.user,

--- a/src/integrations/views.py
+++ b/src/integrations/views.py
@@ -4776,6 +4776,22 @@ def _match_destination_from_result(result, media_type):
     return destination
 
 
+def _match_candidate_rows(results):
+    """Return renderable destination rows without persisting any Item.
+
+    Rendering used to hand the template an Item pk per result, which meant a
+    search wrote one Item (and its later metadata fan-out) for every hit.
+    """
+    rows = []
+    for result in results:
+        media_id = result.get("media_id") or result.get("id")
+        title = result.get("title") or result.get("name")
+        if not media_id or not title:
+            continue
+        rows.append({"media_id": str(media_id), "title": title, "result": result})
+    return rows
+
+
 def _match_reference_ids(user, source_item):
     """Return only this user's source references affected by the correction."""
     item_ids = [source_item.pk]
@@ -4814,15 +4830,25 @@ def match_fix(request, item_id):
         except services.ProviderAPIError as error:
             messages.error(request, f"Could not search TMDB: {error}")
 
+    candidate_rows = _match_candidate_rows(candidates)
+
     preview = None
     if request.method == "POST":
         action = request.POST.get("action")
         if action == "preview":
-            destination = Item.objects.filter(
-                pk=request.POST.get("destination_item_id"),
-                source=Sources.TMDB.value,
-                media_type=source_item.media_type,
-            ).first()
+            chosen = next(
+                (
+                    row
+                    for row in candidate_rows
+                    if row["media_id"] == request.POST.get("destination_media_id")
+                ),
+                None,
+            )
+            destination = (
+                _match_destination_from_result(chosen["result"], source_item.media_type)
+                if chosen
+                else None
+            )
             if destination is None:
                 messages.error(request, "Choose a valid same-type destination.")
             else:
@@ -4889,13 +4915,7 @@ def match_fix(request, item_id):
 
     context = {
         "source_item": source_item,
-        "candidates": [
-            {
-                "result": result,
-                "item": _match_destination_from_result(result, source_item.media_type),
-            }
-            for result in candidates
-        ],
+        "candidates": candidate_rows,
         "preview": preview,
         "preview_mapping_json": (
             json.dumps(preview["episode_mapping"], sort_keys=True)

--- a/src/templates/integrations/match_fix.html
+++ b/src/templates/integrations/match_fix.html
@@ -26,15 +26,15 @@
     {% if candidates %}
       <div class="space-y-2">
         {% for candidate in candidates %}
-          {% if candidate.item %}
+          {% if candidate.media_id %}
             <form method="post"
                   class="flex items-center justify-between gap-3 rounded-lg border border-[var(--color-surface-border)] bg-[var(--color-surface)] p-3">
               {% csrf_token %}
               <input type="hidden" name="action" value="preview">
               <input type="hidden"
-                     name="destination_item_id"
-                     value="{{ candidate.item.id }}">
-              <span class="text-sm text-[var(--color-text)]">{{ candidate.item.title }}
+                     name="destination_media_id"
+                     value="{{ candidate.media_id }}">
+              <span class="text-sm text-[var(--color-text)]">{{ candidate.title }}
                 {% if candidate.result.year %}({{ candidate.result.year }}){% endif %}
               </span>
               <button class="shrink-0 rounded-md border border-indigo-500 px-3 py-1.5 text-sm text-indigo-300 hover:bg-indigo-500/10"


### PR DESCRIPTION
## Summary
Two bugs in the Plex/Trakt match-correction flow added in 7a5864a1, found after running Fix match on three real TVDB shows.

**1. Seasons stay on the old provider when the destination show isn't tracked yet.**
With no TV row on the destination item, `_move_tv` repoints the source row itself, so `source` and `destination` become the same row. The "seasons already at the destination" map is then built from that row's own seasons. Every source season matches itself, and the branch that moves `Season.item` onto a destination-provider season Item never runs.

The show Item and every episode Item move to TMDB, but `app_season.item` stays on TVDB. Season lookups key off that Item (`BasicMedia.filter_media_prefetch` matches `media_id`/`source`/`season_number`), so all of the user's episode watches vanish under the corrected identity while still showing under the old URLs. Fix: read the source's seasons before the repoint and exclude them from the destination map.

**2. Listing search results writes one Item per hit.**
The destination radio carried an Item pk, so rendering the candidate list ran `get_or_create` for every TMDB result. One search for "Angel" wrote 20 unrelated shows, and the metadata backfill fanned them out: three searches in one session produced +1,646 Items, +1,419 calendar events, +1,339 people and +5,715 credits. Fix: the template now posts the result's `media_id`, and the destination Item is materialized only when the user previews that candidate.

The existing TV test only covered the path where the destination is already tracked, which works, so neither bug was exercised.

## AI Assistance
`claude-opus-5`

## How It Was Tested
- New tests, each red before its fix and green after:
  - `test_tv_move_to_untracked_destination_repoints_season_items`
  - `test_match_fix_search_does_not_persist_candidate_items`
  - `test_match_fix_preview_materializes_only_the_chosen_destination`
- `pytest integrations/tests/test_matching_and_corrections.py` -> 9 passed.
- `ruff check` on changed files -> clean.
- Diffed two production dumps taken before and after the corrections, row by row. The damage is confined to exactly these two bugs: 3 `app_tv` rows and 205 `app_episode` rows moved, 0 `app_season` rows moved, plus the 1,646 search-result Items.
- The rest of `integrations/tests/` fails the same on unmodified `latest` in this environment (blocked outbound provider calls); none of those failures touch these files.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [ ] Visual or manual QA verified

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- Refs 7a5864a1 (Add safe Plex and Trakt match corrections)
- See also #1169: the nightly TVDB migration later merged these half-moved shows and duplicated their provider links, 500ing the show pages

Users who already ran a TV correction onto an untracked destination have split data (show/episodes on the new provider, seasons on the old one). A detector for it: TV rows whose Item `(source, media_id)` differs from their seasons' Items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyF2y3UHzemYazVJvAXks6