### PR TITLE
Drop colliding NULL-season provider links when merging items

### DIFF
--- a/src/app/services/item_merge.py
+++ b/src/app/services/item_merge.py
@@ -104,6 +104,26 @@ def _rehome_season(season: Season, surviving_tv: TV) -> None:
     season.delete()
 
 
+def _keeper_has_equivalent(related, field_name: str) -> bool:
+    """Return whether a unique constraint already holds this row's twin on the keeper.
+
+    The IntegrityError fallback below misses constraints over nullable
+    columns: databases treat NULLs as distinct, so e.g. two show-level
+    ItemProviderLink rows (season_number=NULL) never collide and the merge
+    would leave a duplicate. Django's `field=None` lookup is `IS NULL`, so
+    checking explicitly catches those too.
+    """
+    model = type(related)
+    for constraint in model._meta.constraints:
+        fields = getattr(constraint, "fields", ())
+        if field_name not in fields or getattr(constraint, "condition", None):
+            continue
+        lookup = {name: getattr(related, name) for name in fields}
+        if model._base_manager.filter(**lookup).exclude(pk=related.pk).exists():
+            return True
+    return False
+
+
 def _repoint(loser: Item, keeper: Item) -> None:
     """Move everything referencing loser onto keeper."""
     for relation in Item._meta.related_objects:
@@ -129,6 +149,9 @@ def _repoint(loser: Item, keeper: Item) -> None:
         # rows.
         for related in list(related_manager.filter(**{field.name: loser})):
             setattr(related, field.name, keeper)
+            if _keeper_has_equivalent(related, field.name):
+                related.delete()
+                continue
             try:
                 # A savepoint keeps a collision from poisoning the
                 # surrounding transaction, so the rest of the merge can

--- a/src/app/tests/test_item_merge.py
+++ b/src/app/tests/test_item_merge.py
@@ -10,6 +10,7 @@ from app.models import (
     CollectionEntry,
     Episode,
     Item,
+    ItemProviderLink,
     ItemTag,
     MediaTypes,
     PlaybackProgress,
@@ -204,6 +205,48 @@ class MergeItemTests(TestCase):
         self.assertTrue(CollectionEntry.objects.filter(item=keeper, user=self.user).exists())
         loser_progress.refresh_from_db()
         self.assertEqual(loser_progress.item_id, keeper.pk)
+
+    def test_show_provider_link_collision_is_dropped_not_duplicated(self):
+        """Merging two shows that both carry a show-level provider link keeps one.
+
+        Show-level links have season_number=NULL. Postgres treats NULLs as
+        distinct, so the unique constraint never raised and the loser's link
+        was repointed as a second copy. The next detail render then crashed
+        in update_or_create with MultipleObjectsReturned.
+        """
+        loser = Item.objects.create(
+            media_id="97546",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Ted Lasso",
+            image="",
+        )
+        keeper = Item.objects.create(
+            media_id="383203",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Ted Lasso",
+            image="",
+        )
+        for item in (loser, keeper):
+            ItemProviderLink.objects.create(
+                item=item,
+                provider=Sources.TVDB.value,
+                provider_media_type=MediaTypes.TV.value,
+                provider_media_id="383203" if item is keeper else "383203-loser",
+                season_number=None,
+            )
+
+        item_merge.merge_item(loser, keeper)
+
+        links = ItemProviderLink.objects.filter(
+            item=keeper,
+            provider=Sources.TVDB.value,
+            provider_media_type=MediaTypes.TV.value,
+            season_number=None,
+        )
+        self.assertEqual(links.count(), 1)
+        self.assertEqual(links.get().provider_media_id, "383203")
 
     def test_playback_progress_collision_keeps_keepers_row(self):
         loser = Item.objects.create(


### PR DESCRIPTION
## Summary
- `item_merge._repoint` moves every relation from the loser Item onto the keeper and relies on an `IntegrityError` to detect rows the keeper already has. Show-level `ItemProviderLink` rows have `season_number=NULL`, and databases treat NULLs as distinct in unique constraints, so `app_itemproviderlink_unique_item_provider_type` never raises. The keeper ends up with **two** links per provider.
- Every detail render then calls `upsert_provider_links` → `update_or_create(item=…, provider=…, provider_media_type=…, season_number=None)`, which raises `ItemProviderLink.MultipleObjectsReturned` and 500s the show page's secondary fragment.
- Fix: before saving a repointed row, check the model's unconditional unique constraints with a NULL-aware lookup (`field=None` is `IS NULL`), and drop the loser's row when the keeper already holds its twin. The existing `IntegrityError` fallback stays for everything else.

### How it was hit
Seen on a production instance whose TV default is TVDB:
1. A user ran Fix match on three TVDB shows, moving them to TMDB (which also left them half-moved; that part is #1168).
2. The nightly "Migrate TV shows to preferred metadata provider" task (03:45) found the TMDB shows alongside their existing TVDB items and went through `_merge_into_existing_tvdb_show` → `merge_item`.
3. Both items already had show-level `tmdb` and `tvdb` provider links from earlier detail renders, so each TVDB item ended up with 4 links instead of 2. All three show pages returned 500 from then on.

Fix match isn't needed to reach this: any show tracked under both a TMDB and a TVDB item (e.g. after a Trakt import, #620) whose detail pages have both been rendered produces the same duplicates when the migration merges them.

### Existing data
This prevents new duplicates; it doesn't clean up rows already duplicated. Affected instances can be repaired with (keeps the oldest row per group):

```sql
DELETE FROM app_itemproviderlink l
WHERE l.season_number IS NULL
  AND l.id > (
    SELECT min(k.id) FROM app_itemproviderlink k
    WHERE k.item_id = l.item_id
      AND k.provider = l.provider
      AND k.provider_media_type = l.provider_media_type
      AND k.season_number IS NULL
  );
```

Happy to turn that into a data migration if you'd rather ship it.

## AI Assistance
`claude-opus-5`

## How It Was Tested
- New regression test `test_show_provider_link_collision_is_dropped_not_duplicated`: red before the change (`2 != 1`), green after.
- `pytest app/tests/test_item_merge.py app/tests/test_tv_provider_migration.py` -> 25 passed.
- `ruff check` on changed files -> clean.
- Manual: on a restored copy of the affected production dump, all three show pages' `?fragment=secondary` returned 500 on unmodified `latest`; after removing the duplicate links they return 200.

## Public API & Documentation Handoff
- [x] Not applicable (no API or vocabulary changes)

## Human Review & Quality Assurance
- [ ] Code review completed
- [x] Visual or manual QA verified (HTTP against a restored production dump)

## Database & Migration Safety (Only if modifying models)
- [x] Not applicable (no database changes)

## Related Issues
- See also #1168 (Fix match leaving seasons on the old provider, step 1 above) and #1165 (TVDB season page 500)
- Refs #620, #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyF2y3UHzemYazVJvAXks6
